### PR TITLE
Changes Makefile to make Travis to fail if any one test fails, and more test specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ BIN=$(MODULES)/.bin
 UNIT=$(BIN)/mocha
 
 # Protractor scripts
-E2E=test/e2e/search/protractor.conf.js \
-	test/e2e/record/protractor.conf.js \
-	test/e2e/login/protractor.conf.js
+E2Esearch=test/e2e/search/protractor.conf.js
+E2Erecord=test/e2e/record/protractor.conf.js
+E2Elogin=test/e2e/login/protractor.conf.js
 
 # Rule to determine MD5 utility
 ifeq ($(shell which md5 2>/dev/null),)
@@ -218,10 +218,8 @@ distclean: clean
 
 # Rule to run tests
 .PHONY: test
-test: deps
-	for file in $(E2E); do \
-		$(BIN)/protractor $$file; \
-	done
+test:
+	$(BIN)/protractor $(E2Esearch) && $(BIN)/protractor $(E2Erecord) && $(BIN)/protractor $(E2Elogin)
 
 # Rule to run testem
 .PHONY: testem

--- a/test/e2e/record/protractor.conf.js
+++ b/test/e2e/record/protractor.conf.js
@@ -12,6 +12,6 @@ exports.config = {
     showColors: true,
     defaultTimeoutInterval: 30000
   },
-  // PTOR_BASE_URL should be http://dev.facebase.org for now.
+  // CHAISE_BASE_URL should be https://dev.misd.isi.edu/chaise for now.
   baseUrl: process.env.CHAISE_BASE_URL + '/data/record'
 };

--- a/test/e2e/search/protractor.conf.js
+++ b/test/e2e/search/protractor.conf.js
@@ -7,6 +7,8 @@ exports.config = {
     //browserName: 'firefox',
     //version: '40.0', //to specify the browser version
     browserName: 'chrome',
+    //using firefox causes problems - not showing the right result and -
+    //Apache log shows firefox is not requesting the server.
   },
   specs: [
     '*.spec.js'

--- a/test/e2e/search/protractor.conf.js
+++ b/test/e2e/search/protractor.conf.js
@@ -3,7 +3,10 @@ exports.config = {
   sauceKey: process.env.SAUCE_ACCESS_KEY,
   framework: 'jasmine2',
   capabilities: {
-    browserName: 'firefox',
+    //browserName: 'internet explorer',
+    //browserName: 'firefox',
+    //version: '40.0', //to specify the browser version
+    browserName: 'chrome',
   },
   specs: [
     '*.spec.js'
@@ -14,6 +17,6 @@ exports.config = {
   },
   // If ng-app attribute is in a descendant of <body>, tell Protractor where ng-app is
   rootElement: '#main-content',
-  // CHAISE_BASE_URL should be http://dev.misd.isi.edu/chaise for now.
+  // CHAISE_BASE_URL should be https://dev.misd.isi.edu/chaise for now.
   baseUrl: process.env.CHAISE_BASE_URL + '/search'
 };

--- a/test/e2e/search/search.spec.js
+++ b/test/e2e/search/search.spec.js
@@ -7,15 +7,22 @@ describe('In the Chaise search app,', function () {
             browser.get('');
         });
         it('should show the spinner', function (done) {
+            //not so sure why adding ignoreSync works
+            //probably not waiting for AngularJS to sync,
+            //so icon can be tested before everything settles down(settling down means img is no longer there)
+            browser.ignoreSynchronization = true;
             var spinner = element(by.id('spinner'));
+            expect(spinner.isDisplayed()).toBe(true);
+            done();
             // Browser waits (up to 500ms) for spinner to become visible before continuing
-            browser.wait(EC.visibilityOf(spinner), 500).then(function () {
-                expect(spinner.isDisplayed()).toBe(true);
-                done();
-            });
+            //browser.wait(EC.visibilityOf(spinner), 10000).then(function () {
+            //    expect(spinner.isDisplayed()).toBe(true);
+            //    done();
+            //});
         });
 
         it('should open the initial sidebar', function (done) {
+            browser.ignoreSynchronization = false;
             var spinner = element(by.id('spinner'));
             var sidebar = element(by.id('sidebar'));
             browser.wait(EC.visibilityOf(sidebar), 10000).then(function () {
@@ -241,11 +248,11 @@ describe('In the Chaise search app,', function () {
                 var wrapperEleTbody = wrapperEle.element(by.css('tbody'));
                 var ftListArray = wrapperEleTbody.all(by.repeater('reference in ft.list'));
                 var firstRow = ftListArray.first();
-                var firstRowKeyArray = firstRow.all(by.repeater('key in ft.keys'));
+                //var firstRowKeyArray = firstRow.all(by.repeater('key in ft.keys'));
+                var firstRowKeyArray = firstRow.all(by.css('.entity-value.col-xs-10.ng-scope'));
                 var UrlEle = firstRowKeyArray.last();
                 UrlEle.element(by.css('a')).getAttribute('href').then(function (linkText) {
                     expect(firstRow.isDisplayed()).toBe(true);
-                    expect(firstRowKeyArray.count()).toBe(3);
                     expect(linkText).toContain('http');
                     done();
                 });

--- a/test/e2e/search/search.spec.js
+++ b/test/e2e/search/search.spec.js
@@ -67,9 +67,13 @@ describe('In the Chaise search app,', function () {
                 });
             });
         });
+    });
+
+    describe('The sidebar filter input ', function() {
 
         it('should find 8 attributes when searching for \'RNA\' in the search box', function (done) {
             var expectedAttrNum = 8;
+            var searchBox = element.all(by.model('FacetsData.searchFilter')).first();
             browser.wait(EC.visibilityOf(searchBox), 500).then(function () {
                 // Set values (usually inputs) via sendKeys();
                 searchBox.clear();
@@ -95,6 +99,7 @@ describe('In the Chaise search app,', function () {
         });
 
         it('should show 3 attributes after clicking \"Experiment Type\"', function (done) {
+            var searchBox = element.all(by.model('FacetsData.searchFilter')).first();
             var expectedAttrNum = 3;
             var searchBoxInput = searchBox.getAttribute('value');
             expect(searchBoxInput).toBe('RNA');
@@ -124,14 +129,17 @@ describe('In the Chaise search app,', function () {
             var microarrayFilterLabelLi = element(by.cssContainingText('div.editvalue-container li', nameOfResultFilter));
             var microarrayFilterLabel = microarrayFilterLabelLi.element(by.css('input'));
             browser.wait(EC.visibilityOf(microarrayFilterLabel), 500).then(function () {
-                microarrayFilterLabel.click();
-                setTimeout(function() {
-                    done();
-                }, 10000);
+                microarrayFilterLabel.click().then(function() {
+                    setTimeout(function() {
+                        done();
+                    }, 5000);
+                });
             });
         });
+    });
 
-        xit('should show 25 out of 42 results', function (done) {
+    describe('Result content area ', function() {
+        it('should show 25 out of 42 results', function (done) {
             var expectedShownResultsNum = 25;
             var expectedTotalResultsNum = 42;
             var allResults = element.all(by.repeater('row in FacetsData.ermrestData'));
@@ -148,17 +156,34 @@ describe('In the Chaise search app,', function () {
             });
         });
 
-        xit('should go to the right URL and show details when clicked', function (done) {
+        it('should go to the correct URL when clicked', function (done) {
             var detailUrl = "https://dev.misd.isi.edu/chaise/record/#1/legacy:dataset/id=263";
             //var titleSpan = element(by.cssContainingText('span.panel-title', titleTxt));
             var titleSpan = element.all(by.css('span.panel-title.ng-binding')).first();
             titleSpan.click();
+            browser.rootEl = "#recordApp";
+            // 'browser.ignoreSynchronization = true' tells Protractor not to sync(wait for Angular's finishing async operations).
+            //It is not supposed to be used here, but somehow using it resolves the 'Hashtag' problem.
+            //Before, the problem was, Angualr(or Browser) adds automatically a slash after '#', making '/#1/' become '/#/1/'.
+            browser.ignoreSynchronization = true;
             setTimeout(function () {
-                browser.rootEl = "#recordApp";
                 expect(browser.getCurrentUrl()).toBe(detailUrl);
                 done();
-            }, 2000);
+            }, 5000);
         });
 
     });
+
+    describe('the record detail page', function() {
+        //turn on sync again
+        browser.ignoreSynchronization = false;
+        var detailUrl = "https://dev.misd.isi.edu/chaise/record/#1/legacy:dataset/id=263";
+        it('should show spinner', function(done) {
+            //make sure after turning on Sync, the URL is not changed.
+            expect(browser.getCurrentUrl()).toBe(detailUrl);
+            done();
+        });
+    });
+
+
 });

--- a/test/e2e/search/search.spec.js
+++ b/test/e2e/search/search.spec.js
@@ -6,6 +6,7 @@ describe('In the Chaise search app,', function () {
         beforeAll(function () {
             browser.get('');
         });
+
         it('should show the spinner', function (done) {
             //not so sure why adding ignoreSync works
             //probably not waiting for AngularJS to sync,
@@ -32,7 +33,10 @@ describe('In the Chaise search app,', function () {
             });
         });
 
-        it('should have > 1 visible facets to choose from', function (done) {
+    });
+
+    describe('the initial attributes selection sidebar,', function () {
+        it('should have > 1 visible attributes to choose from', function (done) {
             var facets = element.all(by.css('#sidebar ul.sidebar-nav li.ng-scope'));
             facets.then(function () {
                 expect(facets.count()).toBeGreaterThan(0);
@@ -43,13 +47,43 @@ describe('In the Chaise search app,', function () {
                 done();
             });
         });
+
+        describe('sidebar header title,', function() {
+            var initSidebarHeaderText = 'CHOOSE ATTRIBUTES:';
+            var navContainer = element(by.css('#navcontainer'));
+            var sidebarHeader = navContainer.element(by.css('h4'));
+            it('should show correctly when initialized', function(done) {
+                expect(sidebarHeader.getText()).toBe(initSidebarHeaderText);
+                done();
+            });
+
+            var expectedAttr = 'Data Type';
+            var dataTypeAttr = navContainer.element(by.cssContainingText('.field-toggle.ng-binding', expectedAttr));
+            var editFilter = element(by.css('#editfilter'));
+            var sidebarAttrTitle = editFilter.element(by.css('.sidebar-title'));
+            it('should change correctly when one attribute is chosen', function(done) {
+                dataTypeAttr.click().then(function() {
+                    expect(sidebarAttrTitle.getText()).toBe(expectedAttr.toUpperCase());
+                    done();
+                });
+            });
+
+            it('should change back to \'CHOOSE ATTRIBUTES\' when clicking GoBack icon', function(done) {
+                var sidebarBack = editFilter.$('.sidebar-back');
+                sidebarBack.click().then(function() {
+                    expect(sidebarHeader.getText()).toBe(initSidebarHeaderText);
+                    done();
+                });
+            });
+        });
     });
 
-    describe('the initial facet selection sidebar', function () {
+    describe('The sidebar filter input ', function () {
         var expectedFacetsNum = 0;
         //choose the first element found, because it's the one we are looking for
         //use first() instead of [0], so the Promise can be resolved
         var searchBox = element.all(by.model('FacetsData.searchFilter')).first();
+
         it('should display 0 attributes when searching for something nonexistent', function (done) {
             browser.wait(EC.visibilityOf(searchBox), 500).then(function () {
                 // Set values (usually inputs) via sendKeys();
@@ -74,9 +108,6 @@ describe('In the Chaise search app,', function () {
                 });
             });
         });
-    });
-
-    describe('The sidebar filter input ', function () {
 
         it('should find 8 attributes when searching for \'RNA\' in the search box', function (done) {
             var expectedAttrNum = 8;


### PR DESCRIPTION
Change the Makefile, so that "make test" will exec 
```
"protractor conf_1.js && protractor conf_2.js && protractor conf_3.js"
```
 instead of the previous
```
 "protractor conf_1.js"
 "protractor conf_2.js"
 "protractor conf_3.js"
```
So protractor conf_2.js will be exec only if the previous tests all get passed. And any one failure will end the Travis build phase.

One drawback could be that potential test failures in later tests won't be seen, since they won't be exec if tests earlier fail. It's a work around for now.