### PR TITLE
Create, edit, delete annotations inside Chaise; add anatomy selection

### DIFF
--- a/viewer/app.js
+++ b/viewer/app.js
@@ -97,16 +97,17 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
     };
 
     // TODO: Rewrite this with ermrestjs
-    this.editAnnotation = function editAnnotation(annotation) {
-        var editedComment = [{
-            "id": annotation.comments.id,
-            "roi_id": annotation.id,
+    this.updateAnnotation = function updateAnnotation(annotation) {
+        var editedAnnotation = [{
+            "id": annotation.id,
+            "image_id": this.entityId,
             "author": null,
-            "timestamp": annotation.comments.timestamp,
-            "comment": annotation.comments.comment
+            "context_uri": annotation.context_uri,
+            "coords": annotation.coords,
+            "description": annotation.description
         }];
-        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi_comment';
-        return $http.put(entityPath, editedComment);
+        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi';
+        return $http.put(entityPath, editedAnnotation);
     };
 
     this.getAnnotations = function getAnnotations() {
@@ -196,25 +197,31 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         $scope.highlightedAnnotation = annotationIndex;
     };
 
+    $scope.createAnnotation = function createAnnotation(annotation_data) {
+
+    }
     // Activates the drawing selector tool in Annotorious
     $scope.drawNewAnnotation = function drawNewAnnotation() {
         $scope.creatingANewAnnotation = true;
         $scope.viewer.postMessage({messageType: 'drawNewAnnotation'}, window.location.origin);
     };
 
+    // Sets the selected annotation to edit mode
     $scope.editAnnotation = function editAnnotation(annotation) {
         $scope.editedAnnotation = annotation.id;
         $scope.editMode = true;
     };
 
+    // Updates the annotation in Annotorious and ERMrest
     $scope.saveAnnotation = function saveAnnotation(annotation) {
         $scope.editedAnnotation = null;
         $scope.editMode = false;
         var timestamp = new Date().toISOString();
-        annotation.comments.timestamp = timestamp;
-        annotation.comments.comment = annotation.comments.comment;
-        $scope.viewer.postMessage({messageType: 'saveAnnotation', content: annotation}, window.location.origin);
-        ERMrestService.editAnnotation(annotation);
+        annotation.timestamp = timestamp;
+        // TODO: Jessie: Is the following line redundant? Since the input on the view is hooked up to annotation.description already..
+        annotation.description = annotation.description;
+        $scope.viewer.postMessage({messageType: 'updateAnnotation', content: annotation}, window.location.origin);
+        ERMrestService.updateAnnotation(annotation);
     }
 
     $scope.deleteAnnotation = function deleteAnnotation(annotation) {

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -17,6 +17,9 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
     this.tableName = this.params[1].split(':')[1];
     this.entityId = this.params[2].split('=')[1];
 
+    // The name of the table where the annotations are stored — currently 'roi'
+    this.annotationTableName = 'roi';
+
     var ERMREST_ENDPOINT = window.location.origin + '/ermrest/catalog/';
     if (chaiseConfig['ermrestLocation'] != null) {
         ERMREST_ENDPOINT = chaiseConfig['ermrestLocation'] + '/ermrest/catalog';
@@ -52,7 +55,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
             "context_uri": context,
             "anatomy": null
         }];
-        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi?defaults=id,author';
+        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':' + this.annotationTableName + '?defaults=id,author';
         return $http.post(entityPath, roi);
     };
 
@@ -99,11 +102,12 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
             "id": annotation.id,
             "image_id": this.entityId,
             "author": null,
+            "timestamp": annotation.timestamp,
             "context_uri": annotation.context_uri,
             "coords": annotation.coords,
             "description": annotation.description
         }];
-        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi';
+        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':' + this.annotationTableName;
         return $http.put(entityPath, editedAnnotation);
     };
 

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -107,7 +107,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
         }];
         var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi_comment';
         return $http.put(entityPath, editedComment);
-    }
+    };
 
     this.getAnnotations = function getAnnotations() {
         var annotations = [];
@@ -130,6 +130,16 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
             });
         });
         return annotations;
+    };
+
+    this.deleteAnnotation = function deleteAnnotation(annotation) {
+        // Delete the comment from roi_comment
+        var commentEntityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi_comment/id=' + annotation.comments.id;
+        return $http.delete(commentEntityPath).then(function() {
+            // Delete the roi itself
+            var roiEntityPath = ERMREST_ENDPOINT + self.catalogId + '/entity/' + self.schemaName + ':roi/id=' + annotation.id;
+            return $http.delete(roiEntityPath);
+        });
     };
 }]);
 
@@ -211,6 +221,13 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         $scope.viewer.postMessage({messageType: 'saveAnnotation', content: annotation}, window.location.origin);
         ERMrestService.editAnnotation(annotation);
     }
+
+    $scope.deleteAnnotation = function deleteAnnotation(annotation) {
+        var index = $scope.annotations.indexOf(annotation);
+        $scope.annotations.splice(index, 1);
+        $scope.viewer.postMessage({messageType: 'deleteAnnotation', content: annotation}, window.location.origin);
+        ERMrestService.deleteAnnotation(annotation);
+    };
 
     // $scope.writtenNewAnnotation = function writtenNewAnnotation() {
     //     // 1. Create the new annotation in ERMrest and Annotorious

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -96,6 +96,19 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
         });
     };
 
+    // TODO: Rewrite this with ermrestjs
+    this.editAnnotation = function editAnnotation(annotation) {
+        var editedComment = [{
+            "id": annotation.comments.id,
+            "roi_id": annotation.id,
+            "author": null,
+            "timestamp": annotation.comments.timestamp,
+            "comment": annotation.comments.comment
+        }];
+        var entityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi_comment';
+        return $http.put(entityPath, editedComment);
+    }
+
     this.getAnnotations = function getAnnotations() {
         var annotations = [];
         this.getSchema().then(function(schema) {
@@ -128,6 +141,9 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     $scope.viewerSource = null;
     $scope.highlightedAnnotation = null;
     $scope.creatingANewAnnotation = false;
+    $scope.editMode = false; // True if user is currently editing an annotation
+    $scope.editedAnnotation = null; // Track which one is being edited right now
+    $scope.editedAnnotationText = ''; // The new annotation text to be used when updating an annotation
 
     // Fetch uri from image table to load OpenSeadragon
     ERMrestService.getEntity().then(function(uri) {
@@ -180,12 +196,25 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         $scope.viewer.postMessage({messageType: 'drawNewAnnotation'}, window.location.origin);
     };
 
-    // TODO: Finish this.
-    $scope.writtenNewAnnotation = function writtenNewAnnotation() {
-        // 1. Create the new annotation in ERMrest and Annotorious
-
-        $scope.creatingANewAnnotation = false;
+    $scope.editAnnotation = function editAnnotation(annotation) {
+        $scope.editedAnnotation = annotation.id;
+        $scope.editMode = true;
     };
+
+    $scope.saveAnnotation = function saveAnnotation(annotation) {
+        $scope.editedAnnotation = null;
+        $scope.editMode = false;
+        var timestamp = new Date().toISOString();
+        annotation.comments.timestamp = timestamp;
+        annotation.comments.comment = annotation.comments.comment;
+        ERMrestService.editAnnotation(annotation);
+    }
+
+    // $scope.writtenNewAnnotation = function writtenNewAnnotation() {
+    //     // 1. Create the new annotation in ERMrest and Annotorious
+    //
+    //     $scope.creatingANewAnnotation = false;
+    // };
 }]);
 
 // Trusted: A filter that tells Angular when a url is trusted =========================================================================================================================

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -172,11 +172,11 @@ openSeadragonApp.controller('MainController', ['$scope', '$window', 'ERMrestServ
             var data = event.data;
             var messageType = data.messageType;
             switch (messageType) {
-                case 'myAnnoReady':
+                case 'annotoriousReady':
                     $scope.viewerReady = data.content;
                     if ($scope.viewerReady) {
                         $scope.viewer = window.frames[0];
-                        $scope.viewer.postMessage({messageType: 'annotationsList', content: $scope.annotations}, window.location.origin);
+                        $scope.viewer.postMessage({messageType: 'loadAnnotations', content: $scope.annotations}, window.location.origin);
                     }
                     break;
                 case 'annotationDrawn':
@@ -188,11 +188,6 @@ openSeadragonApp.controller('MainController', ['$scope', '$window', 'ERMrestServ
                         $scope.createMode = true;
                     });
                     break;
-                case 'onAnnotationCreated':
-                    var annotation = JSON.parse(event.data.content);
-                    var coordinates = annotation.data.shapes[0].geometry;
-                    ERMrestService.createAnnotation(coordinates.x, coordinates.y, coordinates.width, coordinates.height, annotation.data.context, annotation.data.text, $scope.pushAnnotationToScope);
-                    break;
                 default:
                     console.log('Invalid message type. No action performed.');
             }
@@ -201,17 +196,12 @@ openSeadragonApp.controller('MainController', ['$scope', '$window', 'ERMrestServ
         }
     });
 
-    // A success callback fn to push new annotations into this controller's scope
-    $scope.pushAnnotationToScope = function pushAnnotationToScope(newAnnotation) {
-        $scope.annotations.push(newAnnotation);
+    $scope.setHighlightedAnnotation = function setHighlightedAnnotation(annotationId) {
+        $scope.highlightedAnnotation = annotationId;
     };
 
     $scope.highlightAnnotation = function highlightAnnotation(annotation) {
         $scope.viewer.postMessage({messageType: 'highlightAnnotation', content: annotation}, window.location.origin);
-    };
-
-    $scope.setHighlightedAnnotation = function setHighlightedAnnotation(annotationIndex) {
-        $scope.highlightedAnnotation = annotationIndex;
     };
 
     // Activates the drawing selector tool in Annotorious
@@ -236,8 +226,6 @@ openSeadragonApp.controller('MainController', ['$scope', '$window', 'ERMrestServ
                 return response;
             }
         });
-
-        // Use constructed annotation to send a message to Annotorious
     }
 
     // Sets the selected annotation to edit mode

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -128,12 +128,12 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
     };
 
     this.deleteAnnotation = function deleteAnnotation(annotation) {
-        // Delete the comment from roi_comment
-        var commentEntityPath = ERMREST_ENDPOINT + this.catalogId + '/entity/' + this.schemaName + ':roi_comment/id=' + annotation.comments.id;
-        return $http.delete(commentEntityPath).then(function() {
-            // Delete the roi itself
-            var roiEntityPath = ERMREST_ENDPOINT + self.catalogId + '/entity/' + self.schemaName + ':roi/id=' + annotation.id;
-            return $http.delete(roiEntityPath);
+        this.getSchema().then(function(schema) {
+            var table = schema.getTable('roi');
+            var filteredTable = table.getFilteredTable(["id=" + annotation.id]);
+            return filteredTable.getRows().then(function(rows) {
+                rows[0].delete();
+            });
         });
     };
 }]);

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -117,12 +117,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
             return filteredRoiTable.getRows().then(function(roiRows) {
                 if (roiRows.length > 0) {
                     return Promise.all(roiRows.map(function(roi) {
-                        return roi.getRelatedTable(self.schemaName, 'roi_comment').getRows().then(function(commentRows) {
-                            return Promise.all(commentRows.map(function(comment) {
-                                roi.data.comments = {id: comment.data.id, roiId: comment.data.roi_id, author: comment.data.author, comment: comment.data.comment, timestamp: comment.data.timestamp};
-                                annotations.push(roi.data);
-                            }));
-                        });
+                        annotations.push(roi.data);
                     }));
                 } else {
                     console.log('No annotations found for this image.')

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -126,6 +126,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     $scope.viewerReady = false;
     $scope.viewerSource = null;
     $scope.highlightedAnnotation = null;
+    $scope.creatingANewAnnotation = false;
 
     // Fetch uri from image table to load OpenSeadragon
     ERMrestService.getEntity().then(function(uri) {
@@ -174,8 +175,16 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     };
 
     $scope.drawNewAnnotation = function drawNewAnnotation() {
+        $scope.creatingANewAnnotation = true;
         $scope.viewer.postMessage({messageType: 'drawNewAnnotation'}, window.location.origin);
-    }
+    };
+
+    // TODO: Finish this.
+    $scope.writtenNewAnnotation = function writtenNewAnnotation() {
+        // 1. Create the new annotation in ERMrest and Annotorious
+
+        $scope.creatingANewAnnotation = false;
+    };
 }]);
 
 // Trusted: A filter that tells Angular when a url is trusted =========================================================================================================================

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -122,6 +122,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
 // MainController: An Angular controller to update the view ===========================================================================================================================
 openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', function($scope, ERMrestService) {
     $scope.annotations = ERMrestService.getAnnotations();
+    $scope.viewer = null;
     $scope.viewerReady = false;
     $scope.viewerSource = null;
     $scope.highlightedAnnotation = null;
@@ -142,7 +143,8 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
                 case 'myAnnoReady':
                     $scope.viewerReady = data.content;
                     if ($scope.viewerReady) {
-                        window.frames[0].postMessage({messageType: 'annotationsList', content: $scope.annotations}, window.location.origin);
+                        $scope.viewer = window.frames[0];
+                        $scope.viewer.postMessage({messageType: 'annotationsList', content: $scope.annotations}, window.location.origin);
                     }
                     break;
                 case 'onAnnotationCreated':
@@ -164,10 +166,10 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     };
 
     $scope.highlightAnnotation = function highlightAnnotation(annotation) {
-        window.frames[0].postMessage({messageType: 'highlightAnnotation', content: annotation}, window.location.origin);
+        $scope.viewer.postMessage({messageType: 'highlightAnnotation', content: annotation}, window.location.origin);
     };
 
-    $scope.setHighlightedAnnotation = function (annotationIndex) {
+    $scope.setHighlightedAnnotation = function setHighlightedAnnotation(annotationIndex) {
         $scope.highlightedAnnotation = annotationIndex;
     };
 }]);

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -3,9 +3,6 @@ var openSeadragonApp = angular.module('openSeadragonApp', ['ERMrest']);
 
 // ERMrestService: A service for operations that deal with the ERMrest db =============================================================================================================
 openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', function(ermrestClientFactory, $http) {
-    var client = ermrestClientFactory.getClient(window.location.origin + '/ermrest', null);
-    var catalog = client.getCatalog(1);
-
     // Get a reference to the ERMrestService service
     var self = this;
 
@@ -24,6 +21,9 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
     if (chaiseConfig['ermrestLocation'] != null) {
         ERMREST_ENDPOINT = chaiseConfig['ermrestLocation'] + '/ermrest/catalog';
     }
+
+    var client = ermrestClientFactory.getClient(window.location.origin + '/ermrest', null);
+    var catalog = client.getCatalog(1);
 
     // Returns a Schema object from ERMrest
     this.getSchema = function getSchema() {
@@ -154,8 +154,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     $scope.newAnnotation = null; // Holds the data for a new annotation as it's being created
 
     $scope.editMode = false; // True if user is currently editing an annotation
-    $scope.editedAnnotation = null; // Track which one is being edited right now
-    $scope.editedAnnotationText = ''; // The new annotation text to be used when updating an annotation
+    $scope.editedAnnotation = null; // Track which one is being edited right now; used to show/hide the right UI elements depending on which one is being edited.
 
     // Fetch uri from image table to load OpenSeadragon
     ERMrestService.getEntity().then(function(uri) {
@@ -244,7 +243,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         $scope.editMode = true;
     };
 
-    // Updates the annotation in Annotorious and ERMrest
+    // Given the updated annotation data, it updates the annotation in Annotorious and ERMrest
     $scope.saveAnnotation = function saveAnnotation(annotation) {
         $scope.editedAnnotation = null;
         $scope.editMode = false;

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -139,7 +139,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     $scope.viewer = null;
     $scope.viewerReady = false;
     $scope.viewerSource = null;
-    $scope.highlightedAnnotation = null;
+    $scope.highlightedAnnotation = null; // Track which one is highlighted/centered right now
     $scope.creatingANewAnnotation = false;
     $scope.editMode = false; // True if user is currently editing an annotation
     $scope.editedAnnotation = null; // Track which one is being edited right now
@@ -191,6 +191,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         $scope.highlightedAnnotation = annotationIndex;
     };
 
+    // Activates the drawing selector tool in Annotorious
     $scope.drawNewAnnotation = function drawNewAnnotation() {
         $scope.creatingANewAnnotation = true;
         $scope.viewer.postMessage({messageType: 'drawNewAnnotation'}, window.location.origin);

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -208,6 +208,7 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
         var timestamp = new Date().toISOString();
         annotation.comments.timestamp = timestamp;
         annotation.comments.comment = annotation.comments.comment;
+        $scope.viewer.postMessage({messageType: 'saveAnnotation', content: annotation}, window.location.origin);
         ERMrestService.editAnnotation(annotation);
     }
 

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -85,7 +85,8 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
             var roiId = data.id;
             self.insertRoiComment(roiId, comment).then(function(response) {
                 if (response.data) {
-                    newAnnotation.comments = response.data[0].comment;
+                    var commentData = response.data[0];
+                    newAnnotation.comments = {id: commentData.id, roiId: commentData.roi_id, author: commentData.author, comment: commentData.comment, timestamp: commentData.timestamp};
                     return response.data[0];
                 } else {
                     return 'Error: Comment could not be created. ' + response.status + ' ' + response.statusText;
@@ -105,7 +106,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
                     return Promise.all(roiRows.map(function(roi) {
                         return roi.getRelatedTable(self.schemaName, 'roi_comment').getRows().then(function(commentRows) {
                             return Promise.all(commentRows.map(function(comment) {
-                                roi.data.comments = comment.data.comment;
+                                roi.data.comments = {id: comment.data.id, roiId: comment.data.roi_id, author: comment.data.author, comment: comment.data.comment, timestamp: comment.data.timestamp};
                                 annotations.push(roi.data);
                             }));
                         });

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -172,6 +172,10 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
     $scope.setHighlightedAnnotation = function setHighlightedAnnotation(annotationIndex) {
         $scope.highlightedAnnotation = annotationIndex;
     };
+
+    $scope.drawNewAnnotation = function drawNewAnnotation() {
+        $scope.viewer.postMessage({messageType: 'drawNewAnnotation'}, window.location.origin);
+    }
 }]);
 
 // Trusted: A filter that tells Angular when a url is trusted =========================================================================================================================

--- a/viewer/app.js
+++ b/viewer/app.js
@@ -141,7 +141,7 @@ openSeadragonApp.service('ERMrestService', ['ermrestClientFactory', '$http', fun
 }]);
 
 // MainController: An Angular controller to update the view ===========================================================================================================================
-openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', function($scope, ERMrestService) {
+openSeadragonApp.controller('MainController', ['$scope', '$window', 'ERMrestService', function($scope, $window, ERMrestService) {
     $scope.annotations = ERMrestService.getAnnotations();
 
     $scope.viewerSource = null; // The source URL of the iframe/viewer
@@ -158,13 +158,16 @@ openSeadragonApp.controller('MainController', ['$scope', 'ERMrestService', funct
 
     // Fetch uri from image table to load OpenSeadragon
     ERMrestService.getEntity().then(function(uri) {
+        // TODO: Remove me after pushing to vm-wide version of OpenSeadragon ///////////////
+        // Splicing in my ~jessie directory in here so it redirects to my own version of OpenSeadragon and not the VM-wide version..
+        uri = uri.substring(0, 34) + '~jessie/' + uri.substring(34);
+        ///////////////////////////////////////////////////////////////////////////////////
         // Initialize OpenSeadragon with the uri
         $scope.viewerSource = uri;
     });
 
     // Listen for events from OpenSeadragon/iframe
-    // TODO: Maybe figure out an Angular way to listen to the postMessage event
-    window.addEventListener('message', function(event) {
+    $window.addEventListener('message', function(event) {
         if (event.origin === window.location.origin) {
             var data = event.data;
             var messageType = data.messageType;

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -60,7 +60,7 @@
                 <p ng-if="annotations.length == 0">No annotations exist yet.</p>
             </div>
             <div ng-if="viewerSource" id="viewer" class="col-md-9">
-                <iframe id="viewer" width="100%" height="90%" ng-src="{{viewerSource | trusted}}" frameBorder="0" style="border: 1px solid #ccc;">
+                <iframe id="viewer" width="74%" height="90%" ng-src="{{viewerSource | trusted}}" frameBorder="0" style="border: 1px solid #ccc;">
                     &lt;p&gt;Your browser does not support iframes.&lt;/p&gt;
                 </iframe>
             </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -12,8 +12,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=10; IE=9; IE=8; IE=7; IE=EDGE" />
     <style>
         #annotations-control {
-            height: 90vh;
+            height: 98vh;
             overflow: auto;
+            border-right: 1px solid #ccc;
         }
 
         #viewer {
@@ -28,39 +29,51 @@
             border: 1px solid #eee;
         }
 
-        .annotation:hover {
-            cursor: pointer;
-        }
-
         .annotation.highlighted {
             border-left: 5px solid #428bca;
         }
 
-        .annotation:hover .comment, .annotation.highlighted .comment {
+        .annotation.highlighted .comment, .comment:hover {
             color: #428bca;
+        }
+
+        .comment:hover {
+            cursor: pointer;
         }
     </style>
 </head>
 <body>
-    <div class="navbar navbar-fixed-top">
-        <div class="navbar-header"><a id="brand" href="/" class="navbar-brand">(Re)Building A Kidney</a></div>
-        <div class="collapse navbar-collapse navbar-inverse" id="fb-navbar-main-collapse"></div>
-    </div>
-
-    <div class="container-fluid" style="margin-top: 65px;">
+    <div class="container-fluid" style="margin-top: 10px;">
         <div ng-controller="MainController" class="row">
             <div id="annotations-control" class="col-md-3">
+                <!-- TODO: Perform form validation (e.g. no empty annotation descriptions) -->
                 <p><input ng-model="query" class="form-control" type="search" placeholder="Type to filter annotation text..."></p>
-                <h2>Annotations</h2>
-                <button ng-click="drawNewAnnotation();" class="btn btn-sm btn-primary" type="button" role="button">Create Annotation</button>
-                <div ng-repeat="annotation in annotations | orderBy:'-timestamp' | filter:query" class="annotation" ng-class="{highlighted: annotation.id === highlightedAnnotation}" ng-click="setHighlightedAnnotation(annotation.id);highlightAnnotation(annotation);">
-                    <span class="comment">{{annotation.comments}}</span><br>
-                    <small>{{annotation.timestamp | date: 'MMM d, y h:mm a'}}</small>
+                <h2>Annotations<button ng-click="drawAnnotation();" class="btn btn-sm btn-success pull-right" type="button" role="button"><span class="glyphicon glyphicon-plus"></span>   New</button></h2>
+                <!-- Annotation Creation Form -->
+                <div ng-if="createMode" class="annotation">
+                    <form>
+                        <p>Create an Annotation:</p>
+                        <textarea ng-model="newAnnotation.description" class="form-control" rows="3">Annotation text goes here</textarea><br>
+                        <button ng-click="createAnnotation(newAnnotation);" role="button" class="btn btn-sm btn-success form-control" type="button">Create</button>
+                    </form>
+                </div>
+                <div ng-repeat="annotation in annotations | orderBy:'-timestamp' | filter:query track by annotation.id" class="annotation" ng-class="{highlighted: annotation.id === highlightedAnnotation}">
+                    <!-- Annotation -->
+                    <small>{{annotation.timestamp | date: 'MMM d, y h:mm a'}}</small><br>
+                    <span ng-if="annotation.id !== editedAnnotation" ng-click="setHighlightedAnnotation(annotation.id);highlightAnnotation(annotation);" class="comment">{{annotation.description}}</span><br>
+                    <!-- Annotation Edit Form -->
+                    <form ng-if="annotation.id === editedAnnotation">
+                        <textarea ng-model="annotation.description" class="form-control" rows="3"></textarea><br>
+                        <button ng-click="saveAnnotation(annotation);" role="button" class="btn btn-sm btn-success form-control" type="button">Save</button>
+                    </form>
+                    <!-- end edit form -->
+                    <button ng-if="annotation.id !== editedAnnotation" ng-click="deleteAnnotation(annotation);" class="btn btn-sm btn-danger" role="button" type="button"><span class="glyphicon glyphicon-trash"></span></button>
+                    <button ng-if="annotation.id !== editedAnnotation" ng-click="editAnnotation(annotation);" class="btn btn-sm btn-primary" role="button" type="button"><span class="glyphicon glyphicon-pencil"></span></button>
                 </div>
                 <p ng-if="annotations.length == 0">No annotations exist yet.</p>
             </div>
             <div ng-if="viewerSource" id="viewer" class="col-md-9">
-                <iframe id="viewer" width="74%" height="90%" ng-src="{{viewerSource | trusted}}" frameBorder="0" style="border: 1px solid #ccc;">
+                <iframe id="viewer" width="74%" height="100%" ng-src="{{viewerSource | trusted}}" frameBorder="0">
                     &lt;p&gt;Your browser does not support iframes.&lt;/p&gt;
                 </iframe>
             </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -52,7 +52,7 @@
             <div id="annotations-control" class="col-md-3">
                 <p><input ng-model="query" class="form-control" type="search" placeholder="Type to filter annotation text..."></p>
                 <h2>Annotations</h2>
-
+                <button ng-click="drawNewAnnotation();" class="btn btn-sm btn-primary" type="button" role="button">Create Annotation</button>
                 <div ng-repeat="annotation in annotations | orderBy:'-timestamp' | filter:query" class="annotation" ng-class="{highlighted: annotation.id === highlightedAnnotation}" ng-click="setHighlightedAnnotation(annotation.id);highlightAnnotation(annotation);">
                     <span class="comment">{{annotation.comments}}</span><br>
                     <small>{{annotation.timestamp | date: 'MMM d, y h:mm a'}}</small>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -11,6 +11,16 @@
     <script src='../chaise-config.js?v=bceb1440a28b0d8b4fd43d8388977e75'></script>
     <meta http-equiv="X-UA-Compatible" content="IE=10; IE=9; IE=8; IE=7; IE=EDGE" />
     <style>
+        #annotations-control {
+            height: 90vh;
+            overflow: auto;
+        }
+
+        #viewer {
+            position: fixed;
+            left: 25%;
+        }
+
         .annotation {
             padding: 10px;
             margin: 20px 0;
@@ -39,16 +49,17 @@
 
     <div class="container-fluid" style="margin-top: 65px;">
         <div ng-controller="MainController" class="row">
-            <div class="col-md-3">
+            <div id="annotations-control" class="col-md-3">
                 <p><input ng-model="query" class="form-control" type="search" placeholder="Type to filter annotation text..."></p>
                 <h2>Annotations</h2>
+
                 <div ng-repeat="annotation in annotations | orderBy:'-timestamp' | filter:query" class="annotation" ng-class="{highlighted: annotation.id === highlightedAnnotation}" ng-click="setHighlightedAnnotation(annotation.id);highlightAnnotation(annotation);">
                     <span class="comment">{{annotation.comments}}</span><br>
                     <small>{{annotation.timestamp | date: 'MMM d, y h:mm a'}}</small>
                 </div>
                 <p ng-if="annotations.length == 0">No annotations exist yet.</p>
             </div>
-            <div ng-if="viewerSource" class="col-md-9">
+            <div ng-if="viewerSource" id="viewer" class="col-md-9">
                 <iframe id="viewer" width="100%" height="90%" ng-src="{{viewerSource | trusted}}" frameBorder="0" style="border: 1px solid #ccc;">
                     &lt;p&gt;Your browser does not support iframes.&lt;/p&gt;
                 </iframe>


### PR DESCRIPTION
This PR will:
- Allow users to create, edit, and delete annotations in Chaise instead of Annotorious
- Allow users to select and edit an anatomy term when creating or editing an annotation
