### PR TITLE
Empty table

### DIFF
--- a/record/assets/views/record.html
+++ b/record/assets/views/record.html
@@ -114,7 +114,7 @@
                 </accordion-group>
 
                 <!-- EMBEDED TABLES -->
-                <accordion-group ng-repeat="(title, elements) in entity.embedTables | orderBy: title" is-open="embed.open">
+                <accordion-group ng-repeat="(title, elements) in entity.embedTables" is-open="embed.open">
                     <accordion-heading><div ng-class="{'active': embed.open }">{{title | removeUnderScores}}</div></accordion-heading>
                         <ul id="embed">
                             <li ng-repeat="element in elements" class="embed-block">

--- a/record/assets/views/record.html
+++ b/record/assets/views/record.html
@@ -141,7 +141,7 @@
                         <accordion-heading>
                             <div ng-class="{'active': ft.open }" ng-click="foreignTableToggle($index)">
                                 {{ ft.title | removeUnderScores }}
-                                <span ng-if="ft.count > 0">({{ ft.count }})</span>
+                                <span>({{ ft.count }})</span>
                             </div>
 
                         </accordion-heading>
@@ -213,7 +213,7 @@
                         <accordion-heading>
                             <div ng-class="{'active': ft.open }" >
                                 {{ ft.title | removeUnderScores }}
-                                <span ng-if="ft.count > 0">({{ ft.count }})</span>
+                                <span>({{ ft.count }})</span>
                             </div>
 
                         </accordion-heading>


### PR DESCRIPTION
This is a quick fix for issue #325. Indicate (0) in the reference table header if table has no rows.