### PR TITLE
Hide columns in data entry app

### DIFF
--- a/common/interceptors.js
+++ b/common/interceptors.js
@@ -7,7 +7,6 @@
 
         var responseInterceptor = {
             response: function(response) {
-                console.log("Success", response);
                 return response;
             },
             responseError: function(error) {

--- a/data-entry/form.controller.js
+++ b/data-entry/form.controller.js
@@ -30,6 +30,7 @@
         vm.isAutoGen = isAutoGen;
         vm.isForeignKey = isForeignKey;
         vm.matchType = matchType;
+        vm.isHiddenColumn = isHiddenColumn;
 
         function submit() {
             var form = vm.formContainer;
@@ -100,18 +101,16 @@
         }
 
         function getDefaults() {
-            var autogens = [];
+            var defaults = [];
             var columns =  vm.dataEntryModel.table.columns.all();
             var numColumns = columns.length;
-            // Switched from for..in loop to this because for..in somehow loops
-            // over a blank ("") column name every time, causing an error
             for (var i = 0; i < numColumns; i++) {
                 var columnName = columns[i].name;
-                if (vm.isAutoGen(columnName)) {
-                    autogens.push(columnName);
+                if (vm.isAutoGen(columnName) || vm.isHiddenColumn(columns[i])) {
+                    defaults.push(columnName);
                 }
             }
-            return autogens;
+            return defaults;
         }
 
         function getKeyColumns() {
@@ -190,6 +189,17 @@
 
         function closeAlert() {
             vm.alert = null;
+        }
+
+        // Returns true if a column has a 2015:hidden annotation or a 2016:ignore
+        // (with entry context) annotation.
+        function isHiddenColumn(column) {
+            var ignore = column.annotations.get('tag:isrd.isi.edu,2016:ignore');
+            var hidden = column.annotations.get('tag:misd.isi.edu,2015:hidden');
+            if ((ignore && (ignore.content == [] || ignore.content == null || ignore.content.indexOf('entry'))) || hidden) {
+                return true;
+            }
+            return false;
         }
     }]);
 })();

--- a/data-entry/form.controller.js
+++ b/data-entry/form.controller.js
@@ -196,7 +196,7 @@
         function isHiddenColumn(column) {
             var ignore = column.annotations.get('tag:isrd.isi.edu,2016:ignore');
             var hidden = column.annotations.get('tag:misd.isi.edu,2015:hidden');
-            if ((ignore && (ignore.content == [] || ignore.content == null || ignore.content.indexOf('entry'))) || hidden) {
+            if ((ignore && (ignore.content.length === 0 || ignore.content === null || ignore.content.indexOf('entry') !== -1)) || hidden) {
                 return true;
             }
             return false;

--- a/data-entry/index.html.in
+++ b/data-entry/index.html.in
@@ -55,7 +55,7 @@
                             </div>
                         </div>
                         <table ng-form="form.formContainer" class="table">
-                            <tr ng-form="form.formContainer.row[rowIndex]" ng-repeat="column in form.dataEntryModel.table.columns.all();">
+                            <tr ng-form="form.formContainer.row[rowIndex]" ng-repeat="column in form.dataEntryModel.table.columns.all();" ng-if="!form.isHiddenColumn(column);">
                                 <td class="entity-key col-xs-1" ng-class="{'coltooltip': column.comment}">
                                     <span ng-if="!column.nullok" class="text-danger">{{'*'}}</span>
                                     <span ng-class="{'coltooltiplabel': column.comment}">{{::column.name | underscoreToSpace | toTitleCase}}</span>


### PR DESCRIPTION
This pull request fulfills #352. It adds a feature that hides a column and its input controls if the column has either a `tag:misd.isi.edu,2015:hidden` or `tag:isrd.isi.edu,2016:ignore` annotation. If a column has the `2016:ignore` annotation and the annotation is an empty array, `null`, or has the `entry` context, then the column is hidden.

Columns that are hidden/ignored are also added to the `defaults` parameter when submitting form data so that the sever will fill in those columns for us.

##### To Test:
This feature is live on [synapse-dev](https://synapse-dev.isrd.isi.edu/~jessie/chaise/data-entry/#2/Zebrafish:Subject). The Zebrafish:Subject table has both `tag:misd.isi.edu,2015:hidden` and `tag:isrd.isi.edu,2016:ignore` annotations on the `ID` and `Sub-sequence` columns. The code can be pulled from [`de-hide-columns#352`](https://github.com/informatics-isi-edu/chaise/tree/de-hide-columns%23352).