### PR TITLE
Support 'shorttext' and 'longttext' column types

### DIFF
--- a/data-entry/form.controller.js
+++ b/data-entry/form.controller.js
@@ -157,6 +157,10 @@
                     case 'boolean':
                         displayType = 'boolean';
                         break;
+                    case 'longtext':
+                        displayType = 'longtext';
+                        break;
+                    case 'shorttext':
                     default:
                         displayType = 'text';
                         break;

--- a/data-entry/index.html.in
+++ b/data-entry/index.html.in
@@ -116,7 +116,9 @@
                                             </ui-select-choices>
                                         </ui-select>
                                     </div>
-                                    <!-- text input -->
+                                    <!-- longtext/textarea input -->
+                                    <textarea ng-switch-when="longtext" ng-model="form.dataEntryModel.rows[rowIndex][column.name]" rows="5" name="{{::column.name}}" class="form-control" ng-required="!column.nullok"></textarea>
+                                    <!-- shorttext/default text input -->
                                     <input ng-switch-default ng-model="form.dataEntryModel.rows[rowIndex][column.name]"
                                         name="{{::column.name}}" type="text" class="form-control" ng-required="!column.nullok">
 


### PR DESCRIPTION
Cross-posted from #356:

> Columns with type `shorttext` now display the usual one-line, unresizeable text input. Columns with type `longtext` now use a resizable `textarea` with a default height of 5 rows and 100% width.

> This feature can be seen [here](https://dev.isrd.isi.edu/~jessie/chaise/data-entry/#4/rbk:testtoo), where the "testtoo" table features the following relevant column types: "Name" is `shorttext`; "Comment" is `longttext`; "Other" is `text`.