### PR TITLE
Changes to not rely on annotations.get()

### DIFF
--- a/data-entry/dataEntry.app.js
+++ b/data-entry/dataEntry.app.js
@@ -97,19 +97,13 @@
                         /* SECOND USE CASE: conditional if the table is tagged as a vocabulary */
 
                         try {
+                            var vocabAnnotationTag = "tag:misd.isi.edu,2015:vocabulary";
+                            var displayAnnotationTag = "tag:misd.isi.edu,2015:display";
 
-                            try {
-                                var vocabAnnotation = ftable.annotations.get("tag:misd.isi.edu,2015:vocabulary");
-                                // An error being caught means the `vocabulary` annotation is not defined and that's okay
-                            } catch (exception) { }
-
-                            try {
-                                var displayAnnotation = ftable.annotations.get("tag:misd.isi.edu,2015:display");
-                                // An error being caught means the `display` annotation is not defined and that's okay
-                            } catch (exception) { }
-
-
-                            if (vocabAnnotation) {
+                            if (ftable.annotations.includes(vocabAnnotationTag)) {
+                                // no need to catch this, using `.includes` verifies it exists or not
+                                // if an exception is thrown at this point it will be caught by generic exception case
+                                var vocabAnnotation = ftable.annotations.get(vocabAnnotationTag);
                                 if (vocabAnnotation.content.term) {
                                     var termColumn = ftable.columns.get(vocabAnnotation.content.term); // caught by generic exception case
                                     displayColumns.push(termColumn); // the array is now [keyColumn, termColumn]
@@ -132,7 +126,10 @@
                             }
                             /* THIRD USE CASE: not a vocabulary but it has a “display : row name” annotation */
                             /* Git issue #358 */
-                            else if (displayAnnotation) {
+                            else if (ftable.annotations.includes(displayAnnotationTag)) {
+                                // no need to catch this, using `.includes` verifies it exists or not
+                                // if an exception is thrown at this point it will be caught by generic exception case
+                                var displayAnnotation = ftable.annotations.get(displayAnnotationTag);
                                 if (displayAnnotation.content.row_name) {
                                     // TODO
                                     // var array_of_col_names = REGEX THE array of column_name strings from “ … `{` column_name `}` …” patterns

--- a/data-entry/form.controller.js
+++ b/data-entry/form.controller.js
@@ -255,20 +255,18 @@
         // Returns true if a column has a 2015:hidden annotation or a 2016:ignore
         // (with entry context) annotation.
         function isHiddenColumn(column) {
-            var ignore, hidden;
-            try {
-                try {
-                    ignore = column.annotations.get('tag:isrd.isi.edu,2016:ignore');
-                // catch does nothing, if it returns an exception ignore should be undefined
-                } catch (e) { }
+            var ignore, ignoreCol, hidden;
+            var ignoreAnnotation = 'tag:isrd.isi.edu,2016:ignore';
 
-                try {
-                    hidden = column.annotations.get('tag:misd.isi.edu,2015:hidden');
-                // catch does nothing, if it returns an exception hidden should be undefined
-                } catch (e) { }
+            try {
+                ignore = column.annotations.include(ignoreAnnotation);
+                if (ignore) {
+                    ignoreCol = column.annotations.get(ignoreAnnotation); // still needs to be caught in case something gets out of sync
+                }
+                hidden = column.annotations.include('tag:misd.isi.edu,2015:hidden');
 
             } finally {
-               if ((ignore && (ignore.content.length === 0 || ignore.content === null || ignore.content.indexOf('entry') !== -1)) || hidden) {
+               if ((ignore && (ignoreCol.content.length === 0 || ignoreCol.content === null || ignoreCol.content.indexOf('entry') !== -1)) || hidden) {
                    return true;
                }
                return false;


### PR DESCRIPTION
The following changes were made to correspond with [PR #47](https://github.com/informatics-isi-edu/ermrestjs/pull/47) in ermrestJS. Assigning to @howdyjessie for review. This code can be tested on my [dev machine](https://synapse-dev.isrd.isi.edu/~jchudy/chaise/data-entry/#2/Zebrafish:Subject).

This code should be merged when the corresponding code in ermrestJS is merged.