### PR TITLE
changing the includes function to contains

### DIFF
--- a/data-entry/dataEntry.app.js
+++ b/data-entry/dataEntry.app.js
@@ -100,8 +100,8 @@
                             var vocabAnnotationTag = "tag:misd.isi.edu,2015:vocabulary";
                             var displayAnnotationTag = "tag:misd.isi.edu,2015:display";
 
-                            if (ftable.annotations.includes(vocabAnnotationTag)) {
-                                // no need to catch this, using `.includes` verifies it exists or not
+                            if (ftable.annotations.contains(vocabAnnotationTag)) {
+                                // no need to catch this, using `.contains` verifies it exists or not
                                 // if an exception is thrown at this point it will be caught by generic exception case
                                 var vocabAnnotation = ftable.annotations.get(vocabAnnotationTag);
                                 if (vocabAnnotation.content.term) {
@@ -126,8 +126,8 @@
                             }
                             /* THIRD USE CASE: not a vocabulary but it has a “display : row name” annotation */
                             /* Git issue #358 */
-                            else if (ftable.annotations.includes(displayAnnotationTag)) {
-                                // no need to catch this, using `.includes` verifies it exists or not
+                            else if (ftable.annotations.contains(displayAnnotationTag)) {
+                                // no need to catch this, using `.contains` verifies it exists or not
                                 // if an exception is thrown at this point it will be caught by generic exception case
                                 var displayAnnotation = ftable.annotations.get(displayAnnotationTag);
                                 if (displayAnnotation.content.row_name) {

--- a/data-entry/form.controller.js
+++ b/data-entry/form.controller.js
@@ -259,11 +259,11 @@
             var ignoreAnnotation = 'tag:isrd.isi.edu,2016:ignore';
 
             try {
-                ignore = column.annotations.includes(ignoreAnnotation);
+                ignore = column.annotations.contains(ignoreAnnotation);
                 if (ignore) {
                     ignoreCol = column.annotations.get(ignoreAnnotation); // still needs to be caught in case something gets out of sync
                 }
-                hidden = column.annotations.includes('tag:misd.isi.edu,2015:hidden');
+                hidden = column.annotations.contains('tag:misd.isi.edu,2015:hidden');
 
             } finally {
                if ((ignore && (ignoreCol.content.length === 0 || ignoreCol.content === null || ignoreCol.content.indexOf('entry') !== -1)) || hidden) {


### PR DESCRIPTION
Per a conversation I had with @robes, I changed the `.includes(...)` function to `.contains(...)`. [Here](https://en.wikipedia.org/wiki/Element_(mathematics)#Notation_and_terminology) is the noteworthy information.

"Logician George Boolos strongly urged that "contains" be used for membership only and "includes" for the subset relation only."