### PR TITLE
Sync annotation visibility from Chaise to OSD

### DIFF
--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -16,6 +16,7 @@
         vm.resetSearch = resetSearch;
         vm.filterAnnotations = filterAnnotations;
         vm.sortSectionsFirst = sortSectionsFirst;
+        vm.setVisibility = setVisibility;
 
         vm.createMode = false;
         vm.newAnnotation = {config:{color: vm.defaultColor}};
@@ -93,7 +94,11 @@
         });
 
         function filterAnnotations(annotation) {
+            var typeIsVisible = vm.filterByType[annotation.type]; // boolean that answers "are annotations of a certain type visible?"
             if (!vm.filter) {
+                if (typeIsVisible) {
+                    annotation.config.visible = true;
+                }
                 return true;
             }
 
@@ -104,6 +109,9 @@
             var numProps = props.length;
             for (var i = 0; i < numProps; i++) {
                 if (props[i] && props[i].toLowerCase().indexOf(vm.filter) > -1) {
+                    if (typeIsVisible) {
+                        annotation.config.visible = true;
+                    }
                     return true;
                 }
             }
@@ -118,12 +126,15 @@
                     var numCommentProps = commentProps.length;
                     for (var p = 0; p < numCommentProps; p++) {
                         if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.filter) > -1) {
+                            if (typeIsVisible) {
+                                annotation.config.visible = true;
+                            }
                             return true;
                         }
                     }
                 }
             }
-
+            annotation.config.visible = false;
             return false;
         }
 
@@ -276,44 +287,24 @@
 
         function submitSearch() {
             vm.filter = vm.query;
-
-        }
-
-        function setAnnotationVisibilityInOSD() {
-            // Get all the annotations
-            for (var i = 0; i < vm.annotations.length; i++) {
-                console.log(vm.annotations[i].id);
-
-                console.log(
-                    angular.element(
-                        document.getElementById(
-                            'annotation-' + vm.annotations[i].id
-                        )
-                    )
-                );
-
-                console.log(
-                    angular.element(
-                        document.getElementById(
-                            'annotation-' + vm.annotations[i].id
-                        )
-                    ).hasClass(
-                        'ng-hide'
-                    )
-                );
-
-                // if (angular.element(document.getElementById('annotation-'+vm.annotations[i].id)).hasClass('ng-hide')) {
-                //     console.log(vm.annotations[i].id + ' is hidden');
-                // }
-            }
-            // Send them to Annotorious via postmessage
-
-            // In Annotorious: in the event (toggleVisibility?), loop thru the array and run updateDisplayType2Style(convertedAnnotation, display type);
+            AnnotationsService.syncVisibility();
         }
 
         function resetSearch() {
             vm.query = '';
             vm.filter = '';
+        }
+
+        function setVisibility(annotationType) {
+            var annotations = vm.annotations;
+            var visibility = vm.filterByType[annotationType];
+            for (var i = 0, len = annotations.length; i < len; i++) {
+                var annotation = annotations[i];
+                if (annotation.type == annotationType) {
+                    annotation.config.visible = visibility;
+                }
+            }
+            AnnotationsService.syncVisibility();
         }
     }]);
 })();

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -12,7 +12,6 @@
         vm.annotationTypes = ['rectangle', 'arrow']; // 'section' excluded b/c once you set an annotation as a section, it can't be changed to other types
         vm.filterByType = {section: true, rectangle: true, arrow: true}; // show all annotation types by default
 
-        vm.submitSearch = submitSearch;
         vm.resetSearch = resetSearch;
         vm.filterAnnotations = filterAnnotations;
         vm.sortSectionsFirst = sortSectionsFirst;
@@ -89,21 +88,19 @@
 
         function filterAnnotations(annotation) {
             var typeIsVisible = vm.filterByType[annotation.type]; // boolean that answers "are annotations of a certain type visible?"
-            if (!vm.filter) {
+            if (!vm.query) {
                 if (typeIsVisible) {
                     annotation.config.visible = true;
                     AnnotationsService.syncVisibility();
                 }
                 return true;
             }
-
-            vm.filter = vm.filter.toLowerCase();
-
+            vm.query = vm.query.toLowerCase();
             var author = annotation.author;
             var props = [annotation.anatomy, annotation.description, author.display_name, author.full_name, author.email, annotation.created];
             var numProps = props.length;
             for (var i = 0; i < numProps; i++) {
-                if (props[i] && props[i].toLowerCase().indexOf(vm.filter) > -1) {
+                if (props[i] && props[i].toLowerCase().indexOf(vm.query) > -1) {
                     if (typeIsVisible) {
                         annotation.config.visible = true;
                         AnnotationsService.syncVisibility();
@@ -111,7 +108,6 @@
                     return true;
                 }
             }
-
             var commentsArr = comments[annotation.id];
             if (commentsArr) {
                 var numComments = commentsArr.length;
@@ -121,7 +117,7 @@
                     var commentProps = [comment.comment, comment.created, commentAuthor.display_name, commentAuthor.full_name, commentAuthor.email];
                     var numCommentProps = commentProps.length;
                     for (var p = 0; p < numCommentProps; p++) {
-                        if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.filter) > -1) {
+                        if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.query) > -1) {
                             if (typeIsVisible) {
                                 annotation.config.visible = true;
                                 AnnotationsService.syncVisibility();
@@ -283,13 +279,8 @@
             }
         }
 
-        function submitSearch() {
-            vm.filter = vm.query;
-        }
-
         function resetSearch() {
             vm.query = '';
-            vm.filter = '';
         }
 
         function setVisibility(annotationType) {
@@ -311,7 +302,11 @@
                     counter++;
                 }
             }
-            return counter;
+            return vm.numVisibleAnnotations = counter;
         }
+
+        $scope.$watch(function() {
+            return vm.annotations;
+        }, getNumVisibleAnnotations, true);
     }]);
 })();

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -12,6 +12,8 @@
         vm.annotationTypes = ['rectangle', 'arrow']; // 'section' excluded b/c once you set an annotation as a section, it can't be changed to other types
         vm.filterByType = {section: true, rectangle: true, arrow: true}; // show all annotation types by default
 
+        vm.submitSearch = submitSearch;
+        vm.resetSearch = resetSearch;
         vm.filterAnnotations = filterAnnotations;
         vm.sortSectionsFirst = sortSectionsFirst;
 
@@ -91,17 +93,17 @@
         });
 
         function filterAnnotations(annotation) {
-            if (!vm.query) {
+            if (!vm.filter) {
                 return true;
             }
 
-            vm.query = vm.query.toLowerCase();
+            vm.filter = vm.filter.toLowerCase();
 
             var author = annotation.author;
             var props = [annotation.anatomy, annotation.description, author.display_name, author.full_name, author.email, annotation.created];
             var numProps = props.length;
             for (var i = 0; i < numProps; i++) {
-                if (props[i] && props[i].toLowerCase().indexOf(vm.query) > -1) {
+                if (props[i] && props[i].toLowerCase().indexOf(vm.filter) > -1) {
                     return true;
                 }
             }
@@ -115,7 +117,7 @@
                     var commentProps = [comment.comment, comment.created, commentAuthor.display_name, commentAuthor.full_name, commentAuthor.email];
                     var numCommentProps = commentProps.length;
                     for (var p = 0; p < numCommentProps; p++) {
-                        if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.query) > -1) {
+                        if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.filter) > -1) {
                             return true;
                         }
                     }
@@ -270,6 +272,48 @@
             if (annotation.type == 'section') {
                 return 0;
             }
+        }
+
+        function submitSearch() {
+            vm.filter = vm.query;
+
+        }
+
+        function setAnnotationVisibilityInOSD() {
+            // Get all the annotations
+            for (var i = 0; i < vm.annotations.length; i++) {
+                console.log(vm.annotations[i].id);
+
+                console.log(
+                    angular.element(
+                        document.getElementById(
+                            'annotation-' + vm.annotations[i].id
+                        )
+                    )
+                );
+
+                console.log(
+                    angular.element(
+                        document.getElementById(
+                            'annotation-' + vm.annotations[i].id
+                        )
+                    ).hasClass(
+                        'ng-hide'
+                    )
+                );
+
+                // if (angular.element(document.getElementById('annotation-'+vm.annotations[i].id)).hasClass('ng-hide')) {
+                //     console.log(vm.annotations[i].id + ' is hidden');
+                // }
+            }
+            // Send them to Annotorious via postmessage
+
+            // In Annotorious: in the event (toggleVisibility?), loop thru the array and run updateDisplayType2Style(convertedAnnotation, display type);
+        }
+
+        function resetSearch() {
+            vm.query = '';
+            vm.filter = '';
         }
     }]);
 })();

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -98,6 +98,7 @@
             if (!vm.filter) {
                 if (typeIsVisible) {
                     annotation.config.visible = true;
+                    AnnotationsService.syncVisibility();
                 }
                 return true;
             }
@@ -111,6 +112,7 @@
                 if (props[i] && props[i].toLowerCase().indexOf(vm.filter) > -1) {
                     if (typeIsVisible) {
                         annotation.config.visible = true;
+                        AnnotationsService.syncVisibility();
                     }
                     return true;
                 }
@@ -128,6 +130,7 @@
                         if (commentProps[p] && commentProps[p].toLowerCase().indexOf(vm.filter) > -1) {
                             if (typeIsVisible) {
                                 annotation.config.visible = true;
+                                AnnotationsService.syncVisibility();
                             }
                             return true;
                         }
@@ -135,6 +138,7 @@
                 }
             }
             annotation.config.visible = false;
+            AnnotationsService.syncVisibility();
             return false;
         }
 
@@ -287,7 +291,6 @@
 
         function submitSearch() {
             vm.filter = vm.query;
-            AnnotationsService.syncVisibility();
         }
 
         function resetSearch() {

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -23,6 +23,7 @@
         vm.drawAnnotation = drawAnnotation;
         vm.createAnnotation = createAnnotation;
         vm.cancelNewAnnotation = cancelNewAnnotation;
+        vm.getNumVisibleAnnotations = getNumVisibleAnnotations;
 
         var originalAnnotation; // Holds the original contents of annotation in the event that a user cancels an edit
         resetEditedValues();
@@ -301,6 +302,11 @@
                 }
             }
             AnnotationsService.syncVisibility();
+        }
+
+        function getNumVisibleAnnotations() {
+            console.log(vm.annotations.length);
+            // return vm.annotations.length;
         }
     }]);
 })();

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -17,6 +17,7 @@
         vm.sortSectionsFirst = sortSectionsFirst;
         vm.setVisibility = setVisibility;
         vm.getNumVisibleAnnotations = getNumVisibleAnnotations;
+        vm.numVisibleAnnotations = 0;
 
         vm.createMode = false;
         vm.newAnnotation = {config:{color: vm.defaultColor, visible: true}};
@@ -92,6 +93,7 @@
                 if (typeIsVisible) {
                     annotation.config.visible = true;
                     AnnotationsService.syncVisibility();
+                    vm.getNumVisibleAnnotations();
                 }
                 return true;
             }
@@ -104,6 +106,7 @@
                     if (typeIsVisible) {
                         annotation.config.visible = true;
                         AnnotationsService.syncVisibility();
+                        vm.getNumVisibleAnnotations();
                     }
                     return true;
                 }
@@ -121,6 +124,7 @@
                             if (typeIsVisible) {
                                 annotation.config.visible = true;
                                 AnnotationsService.syncVisibility();
+                                vm.getNumVisibleAnnotations();
                             }
                             return true;
                         }
@@ -129,6 +133,7 @@
             }
             annotation.config.visible = false;
             AnnotationsService.syncVisibility();
+            vm.getNumVisibleAnnotations();
             return false;
         }
 
@@ -293,6 +298,7 @@
                 }
             }
             AnnotationsService.syncVisibility();
+            vm.getNumVisibleAnnotations();
         }
 
         function getNumVisibleAnnotations() {
@@ -304,9 +310,5 @@
             }
             return vm.numVisibleAnnotations = counter;
         }
-
-        $scope.$watch(function() {
-            return vm.annotations;
-        }, getNumVisibleAnnotations, true);
     }]);
 })();

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -19,7 +19,7 @@
         vm.setVisibility = setVisibility;
 
         vm.createMode = false;
-        vm.newAnnotation = {config:{color: vm.defaultColor}};
+        vm.newAnnotation = {config:{color: vm.defaultColor, visible: true}};
         vm.drawAnnotation = drawAnnotation;
         vm.createAnnotation = createAnnotation;
         vm.cancelNewAnnotation = cancelNewAnnotation;

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -52,30 +52,16 @@
                 var messageType = data.messageType;
 
                 switch (messageType) {
-                    case 'annotoriousReady':
-                        // annotoriousReady case handled in viewer.app.js.
-                        // Repeating the case here to avoid triggering default case
-                        break;
                     case 'annotationDrawn':
                         vm.newAnnotation.shape = data.content.shape;
                         $scope.$apply(function() {
                             vm.createMode = true;
                         });
                         break;
-                    case 'onHighlighted':
-                    // On-hover highlighting behavior no longer needed
-                    // OSD still sends this message out on hover though, so the
-                    // is case here to avoid triggering default case
-                        break;
-                    case 'onUnHighlighted':
-                    // On-hover highlighting behavior no longer needed
-                    // OSD still sends this message out on hover though, so the
-                    // is case here to avoid triggering default case
-                        break;
                     case 'onClickAnnotation':
                         var content = JSON.parse(data.content);
                         //TODO check data object
-                        var annotation = findAnnotation(content.data.shapes[0].geometry);
+                        var annotation = findAnnotation(content.shapes[0].geometry);
                         if (annotation) {
                             var annotationId = annotation.table + '-' + annotation.id;
                             $scope.$apply(function() {
@@ -84,6 +70,13 @@
                             });
                             vm.scrollIntoView(annotationId);
                         }
+                        break;
+                    // The following cases are already handled elsewhere or are
+                    // no longer needed but the case is repeated here to avoid
+                    // triggering the default case.
+                    case 'annotoriousReady': // handled in viewer.app.js.
+                    case 'onHighlighted':
+                    case 'onUnHighlighted':
                         break;
                     default:
                         console.log('Invalid event message type "' + messageType + '"');

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -17,13 +17,13 @@
         vm.filterAnnotations = filterAnnotations;
         vm.sortSectionsFirst = sortSectionsFirst;
         vm.setVisibility = setVisibility;
+        vm.getNumVisibleAnnotations = getNumVisibleAnnotations;
 
         vm.createMode = false;
         vm.newAnnotation = {config:{color: vm.defaultColor, visible: true}};
         vm.drawAnnotation = drawAnnotation;
         vm.createAnnotation = createAnnotation;
         vm.cancelNewAnnotation = cancelNewAnnotation;
-        vm.getNumVisibleAnnotations = getNumVisibleAnnotations;
 
         var originalAnnotation; // Holds the original contents of annotation in the event that a user cancels an edit
         resetEditedValues();
@@ -305,8 +305,13 @@
         }
 
         function getNumVisibleAnnotations() {
-            console.log(vm.annotations.length);
-            // return vm.annotations.length;
+            var counter = 0;
+            for (var i = 0, len = annotations.length; i < len; i++) {
+                if (annotations[i].config.visible) {
+                    counter++;
+                }
+            }
+            return counter;
         }
     }]);
 })();

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -105,17 +105,6 @@
 
         function syncVisibility() {
             iframe.postMessage({messageType: 'syncVisibility', content: annotations}, origin);
-            return getNumVisibleAnnotations();
-        }
-
-        function getNumVisibleAnnotations() {
-            var counter = 0;
-            for (var i = 0, len = annotations.length; i < len; i++) {
-                if (annotations[i].visible) {
-                    counter++;
-                }
-            }
-            return counter;
         }
 
         return {

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -97,7 +97,11 @@
 
         function centerAnnotation(annotation) {
             iframe.postMessage({messageType: 'centerAnnotation', content: annotation}, origin);
-        };
+        }
+
+        function syncVisibility() {
+            iframe.postMessage({messageType: 'syncVisibility', content: annotations}, origin);
+        }
 
         return {
             drawAnnotation: drawAnnotation,
@@ -105,7 +109,8 @@
             cancelNewAnnotation: cancelNewAnnotation,
             updateAnnotation: updateAnnotation,
             deleteAnnotation: deleteAnnotation,
-            centerAnnotation: centerAnnotation
+            centerAnnotation: centerAnnotation,
+            syncVisibility: syncVisibility
         };
 
     }]);

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -105,6 +105,17 @@
 
         function syncVisibility() {
             iframe.postMessage({messageType: 'syncVisibility', content: annotations}, origin);
+            return getNumVisibleAnnotations();
+        }
+
+        function getNumVisibleAnnotations() {
+            var counter = 0;
+            for (var i = 0, len = annotations.length; i < len; i++) {
+                if (annotations[i].visible) {
+                    counter++;
+                }
+            }
+            return counter;
         }
 
         return {

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -91,6 +91,10 @@
 
                 iframe.postMessage({messageType: 'deleteAnnotation', content: annotation}, origin);
             }, function error(response) {
+                AlertsService.addAlert({
+                    type: 'error',
+                    message: response
+                });
                 console.log(response);
             });
         }

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -290,6 +290,7 @@
                 <!-- CONTROLLER: AnnotationsController-->
                 <div ng-show="sidebar.sidebar == 'annotations'" ng-controller="AnnotationsController as annotations" id="annotations-panel" class="row">
                     <div class="col-md-12">
+                        <!-- <a ng-click="annotations.getNumVisibleAnnotations();">Get Visible Annotations</a> -->
                         <div ng-if="annotations.allowCreate();" class="row">
                             <div class="btn-group col-md-12 new-annotation">
                                 <button type="button" role="button" class="btn btn-sm btn-success dropdown-toggle form-control" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -424,9 +425,9 @@
                                         <!-- Annotation Description -->
                                         <div ng-if="annotation.description" class="row">
                                             <div class="col-md-12">
-                                                <span class="h5 annotation-description">
-                                                    {{annotation.description}}<br>
-                                                </span>
+                                                <div class="h5 annotation-description">
+                                                    {{annotation.description}}
+                                                </div>
                                             </div>
                                         </div>
                                         <!-- Annotation Author, Date & Comment Icon -->

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -596,8 +596,8 @@
                         <span class="glyphicon glyphicon-info-sign pull-right" data-toggle="tooltip" title="<p class='text-left'><strong>Recommended browsers:</strong> Firefox and Chrome<br><br><strong>Safari users:</strong> The screenshot will be saved as 'Unknown.jpg'.</p>"></span>
                         <div class="btn-group btn-group-sm pull-right" role="group">
                             <button ng-click="osd.toggleAnnotations();" class="btn btn-success" type="button" role="button">
-                                <span class="glyphicon" ng-class="{'glyphicon-eye-open': !osd.hideMode, 'glyphicon-eye-close': osd.hideMode}"></span>
-                                <span ng-show="!osd.hideMode">Show</span><span ng-show="osd.hideMode">Hide</span>
+                                <span class="glyphicon" ng-class="{'glyphicon-eye-open': osd.annotationsAreHidden, 'glyphicon-eye-close': !osd.annotationsAreHidden}"></span>
+                                <span ng-show="osd.annotationsAreHidden">Show</span><span ng-show="!osd.annotationsAreHidden">Hide</span>
                             </button>
                             <button ng-click="osd.zoomInView();" class="btn btn-success" type="button" role="button">
                                 <span class="glyphicon glyphicon-zoom-in"></span> Zoom In

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -305,7 +305,13 @@
                         <br>
                         <div class="row">
                             <div class="col-md-12">
-                                <input ng-model="annotations.query" class="form-control" type="search" placeholder="Type to search...">
+                                <div class="input-group searchbar">
+                                    <input ng-model="annotations.query" class="form-control" type="search" placeholder="Search annotations...">
+                                    <span class="input-group-btn">
+                                        <button ng-click="annotations.submitSearch();" class="btn btn-primary" type="button"><span class="glyphicon glyphicon-search"></span></button>
+                                        <button ng-click="annotations.resetSearch();" class="btn btn-primary" type="button"><span class="glyphicon glyphicon-refresh"></span></button>
+                                    </span>
+                                </div>
                                 <div class="checkbox row">
                                     <div class="col-md-2">
                                         <strong>Show:&nbsp;&nbsp;</strong>
@@ -382,48 +388,176 @@
                             </div>
                         </form>
                         <!-- Annotations List -->
-                        <div ng-repeat="annotation in annotations.annotations | orderBy:[annotations.sortSectionsFirst, 'anatomy', 'id'] | filter:annotations.filterAnnotations track by $index"
-                        ng-class="{highlighted: annotations.highlightedAnnotation == (annotation.table + '-' + annotation.id), section: annotation.type == 'section'}"
-                        ng-show="annotations.filterByType[annotation.type]" id="{{annotation.table + '-' + annotation.id}}" class="annotation">
-                            <!-- Annotation Display Card -->
-                            <div ng-show="annotations.editedAnnotationDomId != (annotation.table + '-' + annotation.id)">
-                                <div class="annotation-card">
-                                    <div class="row">
-                                        <!-- Annotation Title/Label/Heading -->
-                                        <div class="col-md-8" ng-class="{'annotation-anatomy-text': annotation.type != 'section'}">
-                                            <span ng-if="annotation.type == 'section'" class="label section-label">{{'Section' | uppercase}}</span>
-                                            <small ng-if="annotation.type != 'section'"><strong>
-                                                <span class="glyphicon" ng-class="{'glyphicon-stop': annotation.type == 'rectangle', 'glyphicon-tag': annotation.type == 'arrow'}" ng-style="{'color': annotation.config.color || annotations.defaultColor}"></span>
-                                                <span>{{annotation.anatomy || 'No Anatomy' | uppercase}}</span>
-                                            </strong></small>
+                        <div id="annotations-list">
+                            <div ng-repeat="annotation in annotations.annotations | orderBy:[annotations.sortSectionsFirst, 'anatomy', 'id'] | filter:annotations.filterAnnotations track by $index"
+                            ng-class="{highlighted: annotations.highlightedAnnotation == (annotation.table + '-' + annotation.id), section: annotation.type == 'section'}"
+                            ng-show="annotations.filterByType[annotation.type]" id="{{annotation.table + '-' + annotation.id}}" class="annotation">
+                                <!-- Annotation Display Card -->
+                                <div ng-show="annotations.editedAnnotationDomId != (annotation.table + '-' + annotation.id)">
+                                    <div class="annotation-card">
+                                        <div class="row">
+                                            <!-- Annotation Title/Label/Heading -->
+                                            <div class="col-md-8" ng-class="{'annotation-anatomy-text': annotation.type != 'section'}">
+                                                <span ng-if="annotation.type == 'section'" class="label section-label">{{'Section' | uppercase}}</span>
+                                                <small ng-if="annotation.type != 'section'"><strong>
+                                                    <span class="glyphicon" ng-class="{'glyphicon-stop': annotation.type == 'rectangle', 'glyphicon-tag': annotation.type == 'arrow'}" ng-style="{'color': annotation.config.color || annotations.defaultColor}"></span>
+                                                    <span>{{annotation.anatomy || 'No Anatomy' | uppercase}}</span>
+                                                </strong></small>
+                                            </div>
+                                            <!-- Annotation Edit/Delete Buttons -->
+                                            <div class="col-md-4">
+                                                <small class="pull-right">
+                                                    <a ng-click="annotations.centerAnnotation(annotation);" title="Find this annotation in the viewer" class="cardlink"><span class="glyphicon glyphicon-eye-open"></span></a>
+                                                    <span ng-if="annotations.allowEdit(annotation);">
+                                                        <a ng-click="annotations.editAnnotation(annotation);" title="Edit this annotation" class="cardlink"><span class="glyphicon glyphicon-pencil"><span></a>
+                                                    </span>
+                                                    <span ng-if="annotations.allowDelete(annotation);">
+                                                        <a ng-if="annotations.allowDelete(annotation);" ng-click="annotations.deleteAnnotation(annotation);" title="Delete this annotation" class="cardlink"><span class="glyphicon glyphicon-trash"></span></a>
+                                                    </span>
+                                                </small>
+                                            </div>
                                         </div>
-                                        <!-- Annotation Edit/Delete Buttons -->
-                                        <div class="col-md-4">
-                                            <small class="pull-right">
-                                                <a ng-click="annotations.centerAnnotation(annotation);" title="Find this annotation in the viewer" class="cardlink"><span class="glyphicon glyphicon-eye-open"></span></a>
-                                                <span ng-if="annotations.allowEdit(annotation);">
-                                                    <a ng-click="annotations.editAnnotation(annotation);" title="Edit this annotation" class="cardlink"><span class="glyphicon glyphicon-pencil"><span></a>
+                                        <br>
+                                        <!-- Annotation Description -->
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <span class="h5 annotation-description">
+                                                    {{annotation.description}}
                                                 </span>
-                                                <span ng-if="annotations.allowDelete(annotation);">
-                                                    <a ng-if="annotations.allowDelete(annotation);" ng-click="annotations.deleteAnnotation(annotation);" title="Delete this annotation" class="cardlink"><span class="glyphicon glyphicon-trash"></span></a>
-                                                </span>
-                                            </small>
+                                            </div>
+                                        </div>
+                                        <br>
+                                        <!-- Annotation Author, Date & Comment Icon -->
+                                        <div class="row">
+                                            <div class="col-md-8">
+                                                <small>{{annotations.authorName(annotation.author)}} &mdash; {{annotation.created | date:'MMM d, y'}}</small>
+                                            </div>
+                                            <div ng-if="annotation.type != 'section'" class="col-md-4">
+                                                <small class="pull-right">
+                                                    <span class="glyphicon glyphicon-comment"></span>
+                                                    {{annotations.getNumComments(annotation);}}
+                                                </small>
+                                            </div>
                                         </div>
                                     </div>
-                                    <br>
-                                    <!-- Annotation Description -->
+                                    <div ng-if="annotation.type != 'section'" ng-controller="CommentsController as comments" class="comments">
+                                        <div ng-if="annotations.getNumComments(annotation) !== 0" class="row comments-list">
+                                            <hr class="separator comment-separator">
+                                            <div class="col-md-12">
+                                                <div ng-repeat="comment in comments.comments[annotation.id] | orderBy: ['created', 'id'] track by $index" class="row">
+                                                    <div class="col-md-12 comment">
+                                                        <strong>{{annotations.authorName(comment.author)}}</strong>
+                                                        <small><span class="text-muted pull-right">{{comment.created | date:'MMM d, y'}}</span></small>
+                                                        <div ng-if="comments.editedComment == (comment.table + '-' + comment.id)">
+                                                            <div class="input-group input-group-sm" id="edit-comment-form">
+                                                                <input ng-focus="annotations.centerAnnotation(annotation);" ng-model="comment.comment" type="text" class="form-control">
+                                                                <span class="input-group-btn">
+                                                                    <button ng-click="comments.updateComment(comment);" class="btn btn-success" type="submit" role="button">
+                                                                        Update
+                                                                    </button>
+                                                                </span>
+                                                            </div>
+                                                            <small><a ng-click="comments.cancelEdit(comment);" class="cardlink delete pull-right">Cancel this edit</a></small>
+                                                        </div>
+                                                        <div ng-if="comments.editedComment != (comment.table + '-' + comment.id)">
+                                                            {{comment.comment}}<br>
+                                                            <div class="pull-right">
+                                                                <small ng-if="comments.allowEdit(comment);">
+                                                                    <a ng-click="comments.editComment(comment);" class="cardlink edit" title="Edit this comment"><span class="glyphicon glyphicon-pencil"></span></a>
+                                                                </small>
+                                                                <small ng-if="comments.allowDelete(comment);">
+                                                                    <a ng-click="comments.deleteComment(comment);" class="cardlink" title="Delete this comment"><span class="glyphicon glyphicon-trash"></span></a>
+                                                                </small>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <hr class="separator comment-separator" ng-show="!$last">
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div ng-if="comments.allowCreate();" ng-hide="comments.editedComment" class="row comment-input">
+                                            <hr class="separator">
+                                            <div class="col-md-12">
+                                                <div class="input-group input-group-sm">
+                                                    <input ng-focus="annotations.centerAnnotation(annotation);" ng-model="comments.newComment.comment" type="text" class="form-control" placeholder="Add a comment...">
+                                                    <span class="input-group-btn">
+                                                        <button ng-click="comments.createComment(annotation.id);" class="btn btn-success" type="submit" role="button">
+                                                            Post
+                                                        </button>
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div><!-- /Annotation Display Card -->
+                                <form ng-show="annotations.editedAnnotationDomId == (annotation.table + '-' + annotation.id)" id="edit-annotation-form">
                                     <div class="row">
-                                        <div class="col-md-12">
-                                            <span class="h5 annotation-description">
-                                                {{annotation.description}}
+                                        <div class="col-md-10">
+                                            <span class="h4">
+                                                Edit {{annotations.editedAnnotation.type | toTitleCase}}
+                                                <span ng-if="annotations.editedAnnotation.type == 'section'"> of Interest</span>
+                                                <span ng-if="annotations.editedAnnotation.type != 'section'"> Annotation</span>
                                             </span>
                                         </div>
+                                        <div class="col-md-2">
+                                            <button ng-click="annotations.cancelEdit(annotation);" type="button" class="close pull-right" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <!-- Commenting this out while we wait for OSD to support editing annotation type -->
+                                    <!-- <div ng-if="annotations.editedAnnotation.data.type != 'section'" class="row">
+                                        <br>
+                                        <div class="col-md-12">
+                                            <label>Annotation Type</label>
+                                            <ui-select ng-model="annotations.editedAnnotation.type" theme="select2" ng-disabled="disabled">
+                                                <ui-select-match placeholder="Select a type">{{annotations.editedAnnotation.type | toTitleCase}}</ui-select-match>
+                                                <ui-select-choices repeat="type in (annotations.annotationTypes | filter: $select.search) track by type">
+                                                    <div ng-bind-html="type | toTitleCase | highlight: $select.search"></div>
+                                                </ui-select-choices>
+                                            </ui-select>
+                                        </div>
+                                    </div> -->
+                                    <!-- Edit Form: Annotation Anatomy -->
+                                    <div ng-if="annotations.editedAnnotation.type != 'section'" class="row">
+                                        <br>
+                                        <div class="col-md-10">
+                                            <label>Anatomy</label>
+                                            <ui-select ng-model="annotations.editedAnnotation.anatomy" theme="select2" ng-disabled="disabled">
+                                                <ui-select-match placeholder="Select an anatomy term">{{annotations.editedAnnotation.anatomy | toTitleCase}}</ui-select-match>
+                                                <ui-select-choices repeat="anatomy in (annotations.anatomies | filter: $select.search) track by anatomy">
+                                                    <div ng-bind-html="anatomy | toTitleCase | highlight: $select.search"></div>
+                                                </ui-select-choices>
+                                            </ui-select>
+                                        </div>
                                     </div>
                                     <br>
-                                    <!-- Annotation Author, Date & Comment Icon -->
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <label>Description</label>
+                                            <textarea ng-model="annotations.editedAnnotation.description" rows="3" class="form-control"></textarea>
+                                        </div>
+                                    </div>
+                                    <div ng-if="annotations.editedAnnotation.type == 'arrow'" class="row">
+                                        <br>
+                                        <div class="col-md-12">
+                                            <label>Color</label>
+                                            <ui-select ng-model="annotations.editedAnnotation.config.color" theme="select2" ng-disabled="disabled">
+                                                <ui-select-match placeholder="Select a color">{{$select.selected | toTitleCase}}</ui-select-match>
+                                                <ui-select-choices repeat="color in (annotations.colors | filter: $select.search) track by color">
+                                                    <div ng-bind-html="color | toTitleCase | highlight: $select.search"></div>
+                                                </ui-select-choices>
+                                            </ui-select>
+                                        </div>
+                                    </div>
+                                    <br>
+                                    <!-- Edit Form: Annotation Author and Date -->
                                     <div class="row">
                                         <div class="col-md-8">
-                                            <small>{{annotations.authorName(annotation.author)}} &mdash; {{annotation.created | date:'MMM d, y'}}</small>
+                                            <small>
+                                                {{annotations.authorName(annotation.author)}} &mdash;
+                                                {{annotation.created | date: 'MMM d, y'}}
+                                            </small>
                                         </div>
                                         <div ng-if="annotation.type != 'section'" class="col-md-4">
                                             <small class="pull-right">
@@ -432,143 +566,17 @@
                                             </small>
                                         </div>
                                     </div>
-                                </div>
-                                <div ng-if="annotation.type != 'section'" ng-controller="CommentsController as comments" class="comments">
-                                    <div ng-if="annotations.getNumComments(annotation) !== 0" class="row comments-list">
-                                        <hr class="separator comment-separator">
+                                    <br>
+                                    <!-- Edit Form: Save buttons -->
+                                    <div class="row">
                                         <div class="col-md-12">
-                                            <div ng-repeat="comment in comments.comments[annotation.id] | orderBy: ['created', 'id'] track by $index" class="row">
-                                                <div class="col-md-12 comment">
-                                                    <strong>{{annotations.authorName(comment.author)}}</strong>
-                                                    <small><span class="text-muted pull-right">{{comment.created | date:'MMM d, y'}}</span></small>
-                                                    <div ng-if="comments.editedComment == (comment.table + '-' + comment.id)">
-                                                        <div class="input-group input-group-sm" id="edit-comment-form">
-                                                            <input ng-focus="annotations.centerAnnotation(annotation);" ng-model="comment.comment" type="text" class="form-control">
-                                                            <span class="input-group-btn">
-                                                                <button ng-click="comments.updateComment(comment);" class="btn btn-success" type="submit" role="button">
-                                                                    Update
-                                                                </button>
-                                                            </span>
-                                                        </div>
-                                                        <small><a ng-click="comments.cancelEdit(comment);" class="cardlink delete pull-right">Cancel this edit</a></small>
-                                                    </div>
-                                                    <div ng-if="comments.editedComment != (comment.table + '-' + comment.id)">
-                                                        {{comment.comment}}<br>
-                                                        <div class="pull-right">
-                                                            <small ng-if="comments.allowEdit(comment);">
-                                                                <a ng-click="comments.editComment(comment);" class="cardlink edit" title="Edit this comment"><span class="glyphicon glyphicon-pencil"></span></a>
-                                                            </small>
-                                                            <small ng-if="comments.allowDelete(comment);">
-                                                                <a ng-click="comments.deleteComment(comment);" class="cardlink" title="Delete this comment"><span class="glyphicon glyphicon-trash"></span></a>
-                                                            </small>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <hr class="separator comment-separator" ng-show="!$last">
-                                            </div>
+                                            <button ng-click="annotations.updateAnnotation(annotation);" role="button" class="btn btn-xs btn-primary form-control" type="button">
+                                                Save
+                                            </button>
                                         </div>
                                     </div>
-                                    <div ng-if="comments.allowCreate();" ng-hide="comments.editedComment" class="row comment-input">
-                                        <hr class="separator">
-                                        <div class="col-md-12">
-                                            <div class="input-group input-group-sm">
-                                                <input ng-focus="annotations.centerAnnotation(annotation);" ng-model="comments.newComment.comment" type="text" class="form-control" placeholder="Add a comment...">
-                                                <span class="input-group-btn">
-                                                    <button ng-click="comments.createComment(annotation.id);" class="btn btn-success" type="submit" role="button">
-                                                        Post
-                                                    </button>
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div><!-- /Annotation Display Card -->
-                            <form ng-show="annotations.editedAnnotationDomId == (annotation.table + '-' + annotation.id)" id="edit-annotation-form">
-                                <div class="row">
-                                    <div class="col-md-10">
-                                        <span class="h4">
-                                            Edit {{annotations.editedAnnotation.type | toTitleCase}}
-                                            <span ng-if="annotations.editedAnnotation.type == 'section'"> of Interest</span>
-                                            <span ng-if="annotations.editedAnnotation.type != 'section'"> Annotation</span>
-                                        </span>
-                                    </div>
-                                    <div class="col-md-2">
-                                        <button ng-click="annotations.cancelEdit(annotation);" type="button" class="close pull-right" aria-label="Close">
-                                            <span aria-hidden="true">&times;</span>
-                                        </button>
-                                    </div>
-                                </div>
-                                <!-- Commenting this out while we wait for OSD to support editing annotation type -->
-                                <!-- <div ng-if="annotations.editedAnnotation.data.type != 'section'" class="row">
-                                    <br>
-                                    <div class="col-md-12">
-                                        <label>Annotation Type</label>
-                                        <ui-select ng-model="annotations.editedAnnotation.type" theme="select2" ng-disabled="disabled">
-                                            <ui-select-match placeholder="Select a type">{{annotations.editedAnnotation.type | toTitleCase}}</ui-select-match>
-                                            <ui-select-choices repeat="type in (annotations.annotationTypes | filter: $select.search) track by type">
-                                                <div ng-bind-html="type | toTitleCase | highlight: $select.search"></div>
-                                            </ui-select-choices>
-                                        </ui-select>
-                                    </div>
-                                </div> -->
-                                <!-- Edit Form: Annotation Anatomy -->
-                                <div ng-if="annotations.editedAnnotation.type != 'section'" class="row">
-                                    <br>
-                                    <div class="col-md-10">
-                                        <label>Anatomy</label>
-                                        <ui-select ng-model="annotations.editedAnnotation.anatomy" theme="select2" ng-disabled="disabled">
-                                            <ui-select-match placeholder="Select an anatomy term">{{annotations.editedAnnotation.anatomy | toTitleCase}}</ui-select-match>
-                                            <ui-select-choices repeat="anatomy in (annotations.anatomies | filter: $select.search) track by anatomy">
-                                                <div ng-bind-html="anatomy | toTitleCase | highlight: $select.search"></div>
-                                            </ui-select-choices>
-                                        </ui-select>
-                                    </div>
-                                </div>
-                                <br>
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <label>Description</label>
-                                        <textarea ng-model="annotations.editedAnnotation.description" rows="3" class="form-control"></textarea>
-                                    </div>
-                                </div>
-                                <div ng-if="annotations.editedAnnotation.type == 'arrow'" class="row">
-                                    <br>
-                                    <div class="col-md-12">
-                                        <label>Color</label>
-                                        <ui-select ng-model="annotations.editedAnnotation.config.color" theme="select2" ng-disabled="disabled">
-                                            <ui-select-match placeholder="Select a color">{{$select.selected | toTitleCase}}</ui-select-match>
-                                            <ui-select-choices repeat="color in (annotations.colors | filter: $select.search) track by color">
-                                                <div ng-bind-html="color | toTitleCase | highlight: $select.search"></div>
-                                            </ui-select-choices>
-                                        </ui-select>
-                                    </div>
-                                </div>
-                                <br>
-                                <!-- Edit Form: Annotation Author and Date -->
-                                <div class="row">
-                                    <div class="col-md-8">
-                                        <small>
-                                            {{annotations.authorName(annotation.author)}} &mdash;
-                                            {{annotation.created | date: 'MMM d, y'}}
-                                        </small>
-                                    </div>
-                                    <div ng-if="annotation.type != 'section'" class="col-md-4">
-                                        <small class="pull-right">
-                                            <span class="glyphicon glyphicon-comment"></span>
-                                            {{annotations.getNumComments(annotation);}}
-                                        </small>
-                                    </div>
-                                </div>
-                                <br>
-                                <!-- Edit Form: Save buttons -->
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <button ng-click="annotations.updateAnnotation(annotation);" role="button" class="btn btn-xs btn-primary form-control" type="button">
-                                            Save
-                                        </button>
-                                    </div>
-                                </div>
-                            </form>
+                                </form>
+                            </div>
                         </div><!-- /Annotations List-->
                     </div>
                 </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -408,7 +408,7 @@
                                                     <span>{{annotation.anatomy || 'No Anatomy' | uppercase}}</span>
                                                 </strong></small>
                                             </div>
-                                            <!-- Annotation Edit/Delete Buttons -->
+                                            <!-- Annotation Edit/Delete/Zoom Buttons -->
                                             <div class="col-md-4">
                                                 <small class="pull-right">
                                                     <a ng-click="annotations.centerAnnotation(annotation);" title="Find this annotation in the viewer" class="cardlink"><span class="glyphicon glyphicon-eye-open"></span></a>
@@ -421,16 +421,14 @@
                                                 </small>
                                             </div>
                                         </div>
-                                        <br>
                                         <!-- Annotation Description -->
-                                        <div class="row">
+                                        <div ng-if="annotation.description" class="row">
                                             <div class="col-md-12">
                                                 <span class="h5 annotation-description">
-                                                    {{annotation.description}}
+                                                    {{annotation.description}}<br>
                                                 </span>
                                             </div>
                                         </div>
-                                        <br>
                                         <!-- Annotation Author, Date & Comment Icon -->
                                         <div class="row">
                                             <div class="col-md-8">
@@ -464,7 +462,7 @@
                                                             <small><a ng-click="comments.cancelEdit(comment);" class="cardlink delete pull-right">Cancel this edit</a></small>
                                                         </div>
                                                         <div ng-if="comments.editedComment != (comment.table + '-' + comment.id)">
-                                                            {{comment.comment}}<br>
+                                                            {{comment.comment}}
                                                             <div class="pull-right">
                                                                 <small ng-if="comments.allowEdit(comment);">
                                                                     <a ng-click="comments.editComment(comment);" class="cardlink edit" title="Edit this comment"><span class="glyphicon glyphicon-pencil"></span></a>
@@ -596,6 +594,10 @@
                     <div class="col-md-6">
                         <span class="glyphicon glyphicon-info-sign pull-right" data-toggle="tooltip" title="<p class='text-left'><strong>Recommended browsers:</strong> Firefox and Chrome<br><br><strong>Safari users:</strong> The screenshot will be saved as 'Unknown.jpg'.</p>"></span>
                         <div class="btn-group btn-group-sm pull-right" role="group">
+                            <button ng-click="osd.toggleAnnotations();" class="btn btn-success" type="button" role="button">
+                                <span class="glyphicon" ng-class="{'glyphicon-eye-open': !osd.hideMode, 'glyphicon-eye-close': osd.hideMode}"></span>
+                                <span ng-show="!osd.hideMode">Show</span><span ng-show="osd.hideMode">Hide</span>
+                            </button>
                             <button ng-click="osd.zoomInView();" class="btn btn-success" type="button" role="button">
                                 <span class="glyphicon glyphicon-zoom-in"></span> Zoom In
                             </button>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -290,7 +290,6 @@
                 <!-- CONTROLLER: AnnotationsController-->
                 <div ng-show="sidebar.sidebar == 'annotations'" ng-controller="AnnotationsController as annotations" id="annotations-panel" class="row">
                     <div class="col-md-12">
-                        {{annotations.getNumVisibleAnnotations();}}
                         <div ng-if="annotations.allowCreate();" class="row">
                             <div class="btn-group col-md-12 new-annotation">
                                 <button type="button" role="button" class="btn btn-sm btn-success dropdown-toggle form-control" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -306,17 +305,17 @@
                         <br>
                         <div class="row">
                             <div class="col-md-12">
-                                <div class="input-group searchbar">
-                                    <input ng-model="annotations.query" ng-keyup="$event.keyCode == 13 && annotations.submitSearch();" class="form-control" type="search" placeholder="Search annotations...">
+                                <form class="input-group searchbar">
+                                    <input ng-model="annotations.query" ng-model-options="{updateOn: 'submit'}" class="form-control" type="search" placeholder="Search annotations...">
                                     <span class="input-group-btn">
-                                        <button ng-click="annotations.submitSearch();" class="btn btn-success" type="button" role="button">
+                                        <button class="btn btn-success" type="submit" role="button">
                                             &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
                                         </button>
                                         <button ng-click="annotations.resetSearch();" class="btn btn-success" type="button" role="button">
                                             Reset
                                         </button>
                                     </span>
-                                </div>
+                                </form>
                                 <div class="checkbox row">
                                     <div class="col-md-2">
                                         <strong>Show:&nbsp;&nbsp;</strong>
@@ -393,6 +392,7 @@
                             </div>
                         </form>
                         <!-- Annotations List -->
+                        <div class="h5 text-muted text-center">{{annotations.numVisibleAnnotations}} annotation<span ng-show="annotations.numVisibleAnnotations > 1">s</span> found.</div>
                         <div id="annotations-list">
                             <div ng-repeat="annotation in annotations.annotations | orderBy:[annotations.sortSectionsFirst, 'anatomy', 'id'] | filter:annotations.filterAnnotations track by $index"
                             ng-class="{highlighted: annotations.highlightedAnnotation == (annotation.table + '-' + annotation.id), section: annotation.type == 'section'}"

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -433,7 +433,7 @@
                                         <!-- Annotation Author, Date & Comment Icon -->
                                         <div class="row">
                                             <div class="col-md-8">
-                                                <small>{{annotations.authorName(annotation.author)}} &mdash; {{annotation.created | date:'MMM d, y'}}</small>
+                                                <small class="text-muted">{{annotations.authorName(annotation.author)}} &mdash; {{annotation.created | date:'MMM d, y'}}</small>
                                             </div>
                                             <div ng-if="annotation.type != 'section'" class="col-md-4">
                                                 <small class="pull-right">

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -290,7 +290,7 @@
                 <!-- CONTROLLER: AnnotationsController-->
                 <div ng-show="sidebar.sidebar == 'annotations'" ng-controller="AnnotationsController as annotations" id="annotations-panel" class="row">
                     <div class="col-md-12">
-                        <!-- <a ng-click="annotations.getNumVisibleAnnotations();">Get Visible Annotations</a> -->
+                        {{annotations.getNumVisibleAnnotations();}}
                         <div ng-if="annotations.allowCreate();" class="row">
                             <div class="btn-group col-md-12 new-annotation">
                                 <button type="button" role="button" class="btn btn-sm btn-success dropdown-toggle form-control" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -324,13 +324,13 @@
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <label for="showSections">
-                                                    <input ng-model="annotations.filterByType.section" ng-change="annotations.setVisibility('section');" id="showSections" type="checkbox">Sections&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.section" ng-change="annotations.setTypeVisibility('section');" id="showSections" type="checkbox">Sections&nbsp;&nbsp;
                                                 </label>
                                                 <label for="showRectangles">
-                                                    <input ng-model="annotations.filterByType.rectangle" ng-change="annotations.setVisibility('rectangle');" id="showRectangles" type="checkbox">Rectangles&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.rectangle" ng-change="annotations.setTypeVisibility('rectangle');" id="showRectangles" type="checkbox">Rectangles&nbsp;&nbsp;
                                                 </label>
                                                 <label for="showArrows">
-                                                    <input ng-model="annotations.filterByType.arrow" ng-change="annotations.setVisibility('arrow');" id="showArrows" type="checkbox">Arrows&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.arrow" ng-change="annotations.setTypeVisibility('arrow');" id="showArrows" type="checkbox">Arrows&nbsp;&nbsp;
                                                 </label>
                                             </div>
                                         </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -306,10 +306,14 @@
                         <div class="row">
                             <div class="col-md-12">
                                 <div class="input-group searchbar">
-                                    <input ng-model="annotations.query" class="form-control" type="search" placeholder="Search annotations...">
+                                    <input ng-model="annotations.query" ng-keyup="$event.keyCode == 13 && annotations.submitSearch();" class="form-control" type="search" placeholder="Search annotations...">
                                     <span class="input-group-btn">
-                                        <button ng-click="annotations.submitSearch();" class="btn btn-primary" type="button"><span class="glyphicon glyphicon-search"></span></button>
-                                        <button ng-click="annotations.resetSearch();" class="btn btn-primary" type="button"><span class="glyphicon glyphicon-refresh"></span></button>
+                                        <button ng-click="annotations.submitSearch();" class="btn btn-success" type="button" role="button">
+                                            &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
+                                        </button>
+                                        <button ng-click="annotations.resetSearch();" class="btn btn-success" type="button" role="button">
+                                            Reset
+                                        </button>
                                     </span>
                                 </div>
                                 <div class="checkbox row">

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -392,7 +392,7 @@
                             </div>
                         </form>
                         <!-- Annotations List -->
-                        <div class="h5 text-muted text-center">{{annotations.numVisibleAnnotations}} annotation<span ng-show="annotations.numVisibleAnnotations > 1">s</span> found.</div>
+                        <div class="h5 text-muted text-center">{{annotations.numVisibleAnnotations}} annotation<span ng-show="annotations.numVisibleAnnotations != 1">s</span> found.</div>
                         <div id="annotations-list">
                             <div ng-repeat="annotation in annotations.annotations | orderBy:[annotations.sortSectionsFirst, 'anatomy', 'id'] | filter:annotations.filterAnnotations track by $index"
                             ng-class="{highlighted: annotations.highlightedAnnotation == (annotation.table + '-' + annotation.id), section: annotation.type == 'section'}"

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -320,13 +320,13 @@
                                         <div class="row">
                                             <div class="col-md-12">
                                                 <label for="showSections">
-                                                    <input ng-model="annotations.filterByType.section" id="showSections" type="checkbox">Sections&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.section" ng-change="annotations.setVisibility('section');" id="showSections" type="checkbox">Sections&nbsp;&nbsp;
                                                 </label>
                                                 <label for="showRectangles">
-                                                    <input ng-model="annotations.filterByType.rectangle" id="showRectangles" type="checkbox">Rectangles&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.rectangle" ng-change="annotations.setVisibility('rectangle');" id="showRectangles" type="checkbox">Rectangles&nbsp;&nbsp;
                                                 </label>
                                                 <label for="showArrows">
-                                                    <input ng-model="annotations.filterByType.arrow" id="showArrows" type="checkbox">Arrows&nbsp;&nbsp;
+                                                    <input ng-model="annotations.filterByType.arrow" ng-change="annotations.setVisibility('arrow');" id="showArrows" type="checkbox">Arrows&nbsp;&nbsp;
                                                 </label>
                                             </div>
                                         </div>

--- a/viewer/osd/osd.controller.js
+++ b/viewer/osd/osd.controller.js
@@ -12,7 +12,7 @@
         vm.zoomInView = zoomInView;
         vm.zoomOutView = zoomOutView;
         vm.homeView = homeView;
-        vm.hideMode = false; // if true, then all annotations should be hidden in viewer
+        vm.annotationsAreHidden = false;
         vm.toggleAnnotations = toggleAnnotations;
 
         function downloadView() {
@@ -40,9 +40,9 @@
         }
 
         function toggleAnnotations() {
-            var messageType = vm.hideMode ? 'hideAllAnnotations' : 'showAllAnnotations';
+            var messageType = vm.annotationsAreHidden ? 'showAllAnnotations' : 'hideAllAnnotations';
             iframe.postMessage({messageType: messageType}, origin);
-            vm.hideMode = !vm.hideMode;
+            vm.annotationsAreHidden = !vm.annotationsAreHidden;
         }
     }]);
 })();

--- a/viewer/osd/osd.controller.js
+++ b/viewer/osd/osd.controller.js
@@ -12,6 +12,8 @@
         vm.zoomInView = zoomInView;
         vm.zoomOutView = zoomOutView;
         vm.homeView = homeView;
+        vm.hideMode = false; // if true, then all annotations should be hidden in viewer
+        vm.toggleAnnotations = toggleAnnotations;
 
         function downloadView() {
             var filename = vm.image.entity.slide_id;
@@ -35,6 +37,12 @@
 
         function homeView() {
             iframe.postMessage({messageType: 'homeView'}, origin);
+        }
+
+        function toggleAnnotations() {
+            var messageType = vm.hideMode ? 'hideAllAnnotations' : 'showAllAnnotations';
+            iframe.postMessage({messageType: messageType}, origin);
+            vm.hideMode = !vm.hideMode;
         }
     }]);
 })();

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -170,6 +170,9 @@
                         for (var i = 0; i < length; i++) {
                             _annotations[i].table = annotationPath.context.table.name;
                             var annotation = _annotations[i];
+                            if (!annotation.config) {
+                                annotation.config = {};
+                            }
                             annotations.push(annotation);
                         }
                         chaiseReady = true;

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -44,12 +44,13 @@ html, body {
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
 }
 
-.annotation-card {
-    margin-bottom: 20px;
-}
-
 .annotation-anatomy-text {
     color: #444;
+}
+
+.annotation-description {
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .annotation-control-button {
@@ -85,7 +86,7 @@ a.cardlink.delete {
 }
 
 .comments {
-    margin: -10px;
+    margin: 10px -10px -10px -10px;
     padding: 0 10px 0 10px;
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;

--- a/viewer/viewer.css
+++ b/viewer/viewer.css
@@ -40,7 +40,7 @@ html, body {
     border-left: 5px solid green;
 }
 
-.annotation, input[type=search] {
+.annotation, .searchbar {
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
 }
 


### PR DESCRIPTION
This PR brings some new features to the Image Viewer app; it addresses issues #480, #481, #483, and #487.

- #480: 
 - The annotations visible in OSD are now consistent with search results on the left panel. If an annotation appears/disappears on the left panel, it also appears/disappears in OSD, _but not the other way around_.
 - Searching through annotations in the left panel is no longer instantaneous. Clicking the new search (🔍 ) button or pressing Enter while the search input is focused executes the search.
 - Clicking the Reset button clears the search input, and all annotations become visible in both the left panel and OSD.
- #481: A new Show/Hide toggle button has been added above OSD. Clicking this button toggles the visibility of annotations currently displayed in the left panel.
- #483/style tweaks: Each annotation "card" is now a little more compact. Particularly, if an annotation has no description, the description area's margins are now collapsed.
- #487: A number of annotation matches is now displayed above the search results. It's basically a count of currently visible annotations in the left panel.

**To Test**
Visit [this page](https://dev.rebuildingakidney.org/~jessie/chaise/viewer/#1/rbk:image/id=1) on dev rbk to test these new features. This branch can also be pulled down to your own user directory for testing.

