### PR TITLE
Add app name param to .getServer() calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ HTML=search/index.html \
 	 recordset/index.html \
 	 matrix/index.html \
 	 viewer/index.html \
-	 recordedit/index.html
+	 recordedit/index.html \
+	 record-two/index.html
 
 # ERMrestjs Deps
 ERMRESTJS_DIR=../../ermrestjs

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -17,8 +17,9 @@
             UriUtils.setOrigin();
             // The context object won't change unless the app is reloaded
             var context = $rootScope.context = UriUtils.parseURLFragment(window.location);
+            context.appName = 'record-two';
 
-            var server = context.server = ermrestServerFactory.getServer(context.serviceURL);
+            var server = context.server = ermrestServerFactory.getServer(context.serviceURL, {cid: context.appName});
             server.catalogs.get(context.catalogID).then(function success(catalog) {
                 var schema = catalog.schemas.get(context.schemaName);
                 var table = $rootScope.table = schema.tables.get(context.tableName);

--- a/recordedit/context.js
+++ b/recordedit/context.js
@@ -5,6 +5,7 @@
     angular.module('chaise.recordEdit')
 
     .constant('context', {
+        appName: 'recordedit',
         serviceURL: null,
         catalogID: null,
         schemaName: null,

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -58,7 +58,7 @@
         }
         // generic try/catch
         try {
-            var server = context.server = ermrestServerFactory.getServer(context.serviceURL);
+            var server = context.server = ermrestServerFactory.getServer(context.serviceURL, {cid: context.appName});
         } catch (exception) {
             ErrorService.catchAll(exception);
         }

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -20,6 +20,7 @@ angular.module('recordset', ['ERMrest', 'chaise.navbar', 'chaise.utils', 'chaise
 // Register the 'context' object which can be accessed by config and other
 // services.
 .constant('context', {
+    appName: 'recordset',
     chaiseURL: '',  // 'https://www.example.org/chaise
     serviceURL: '', // 'https://www.example.org/ermrest'
     catalogID: '',  // '1'
@@ -309,7 +310,7 @@ angular.module('recordset', ['ERMrest', 'chaise.navbar', 'chaise.utils', 'chaise
     $rootScope.errorMessage='';
 
     // Get rowset data from ermrest
-    var server = context.server = ermrestServerFactory.getServer(context.serviceURL);
+    var server = context.server = ermrestServerFactory.getServer(context.serviceURL, {cid: context.appName});
 
     server.catalogs.get(context.catalogID).then(function(catalog) {
         console.log(catalog);

--- a/viewer/common/providers/context.js
+++ b/viewer/common/providers/context.js
@@ -5,6 +5,7 @@
     angular.module('chaise.viewer')
 
     .constant('context', {
+        appName: 'viewer',
         serviceURL: null,
         catalogID: null,
         schemaName: null,

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -47,7 +47,7 @@
     // in a .config block, you append 'Provider' to the dependency name and call
     // .$get() on it. This returns a Provider instance of the factory/service.
     .config(['ermrestServerFactoryProvider', 'context', function configureClient(ermrestServerFactoryProvider, context) {
-        client = ermrestServerFactoryProvider.$get().getServer(context.serviceURL);
+        client = ermrestServerFactoryProvider.$get().getServer(context.serviceURL, {cid: context.appName});
     }])
 
     // Set user info


### PR DESCRIPTION
This is related to informatics-isi-edu/ermrestjs#69.

For the record2, recordset, recordedit, and viewer apps, each of these apps now pass in a second argument, the app's name, in its respective `ermrestFactory.getServer(...)` call so that ermrestjs can append the app names to the relevant async calls.

**Question**: I currently store an app's name inside its `context` provider (`$rootScope.context` for record2), and then pass in `context.appName` into the `.getServer` call. Is this sufficient? Should I create a mapping in `common` so that app names aren't as closely coupled with each app's code? Another way?

