### PR TITLE
Added a polyfill for string.endswith and string.startswith 

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -5,6 +5,7 @@
 
     .factory('UriUtils', ['$injector', '$window', 'parsedFilter', function($injector, $window, ParsedFilter) {
 
+
         /**
          * @function
          * @param {Object} location - location Object from the $window resource
@@ -25,13 +26,13 @@
 
             return baseUri + path;
         }
-
+        
         /**
-         * @function
-         * @param {String} str string to be encoded.
-         * @desc
-         * converts a string to an URI encoded string
-         */
+        * @function
+        * @param {String} str string to be encoded.
+        * @desc
+        * converts a string to an URI encoded string
+        */
         function fixedEncodeURIComponent(str) {
             return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
                 return '%' + c.charCodeAt(0).toString(16).toUpperCase();
@@ -154,6 +155,7 @@
             }
         }
 
+
         /**
          *
          * @param filterString
@@ -189,7 +191,7 @@
          *
          * @param {[String]} filterStrings array representation of conjunction and disjunction of filters
          *     without parenthesis. i.e., ['id=123', ';', 'id::gt::234', ';', 'id::le::345']
-         * @return {ParsedFilter}
+         * @return {ParsedFilter} 
          *
          */
         function processMultiFilterString(filterStrings) {
@@ -248,7 +250,6 @@
         return {
             chaiseURItoErmrestURI: chaiseURItoErmrestURI,
             fixedEncodeURIComponent: fixedEncodeURIComponent,
-            parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
             parseURLFragment: parseURLFragment,
             setOrigin: setOrigin,
             parsedFilterToERMrestFilter: parsedFilterToERMrestFilter

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -13,7 +13,30 @@ function emptyJSON(obj) {
 	$.each(obj, function(key, value) {
 		delete obj[key];
 	});
+};
+
+
+// Polyfill for string.endswith
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+      var subjectString = this.toString();
+      if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+        position = subjectString.length;
+      }
+      position -= searchString.length;
+      var lastIndex = subjectString.indexOf(searchString, position);
+      return lastIndex !== -1 && lastIndex === position;
+  };
 }
+
+// Polyfill for string.startswith
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      position = position || 0;
+      return this.substr(position, searchString.length) === searchString;
+  };
+}
+
 
 function initLocation() {
 	if (chaiseConfig['ermrestLocation'] != null) {


### PR DESCRIPTION
@robes @jrchudy @RFSH @hongsudt @howdyjessie This commit fixes issue #490 by adding a polyfill for `startsWith` and `endsWith` function for strings.

It also removes a syntax error in utils.js regarding IE 11 browser error  **Multiple definitions of a property not allowed in strict mode**

