### PR TITLE
Add markdown-container to record app

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -525,3 +525,14 @@ tbody{
     -moz-box-shadow:    0 0 5px black;
     box-shadow:         0 0 5px black;
 }
+
+/************ Markdown **************/
+.markdown-container li {
+    list-style-type: inherit;
+}
+.markdown-container ul {
+    list-style-type: disc;
+}
+.markdown-container ol {
+    list-style-type: decimal;
+}

--- a/record/assets/javascripts/app.js
+++ b/record/assets/javascripts/app.js
@@ -159,8 +159,9 @@ chaiseRecordApp.service('ermrestService', ['$http', '$rootScope', '$sce', 'schem
 
             entity.sequences = []; // array of sequence columns
             entity.colTooltips = {}; // column tool tips
+            entity.colDataTypes = {}; // column types
 
-            // apply sequence formatting & get column tooltips
+            // apply sequence formatting & get column tooltips & get column types
             var columnDefinitions = schema.tables[tableName].column_definitions;
             for (var i = 0; i < columnDefinitions.length; i++) {
                 var cdAnnotation = columnDefinitions[i].annotations;
@@ -187,6 +188,11 @@ chaiseRecordApp.service('ermrestService', ['$http', '$rootScope', '$sce', 'schem
                 // tooltips
                 if (columnDefinitions[i].comment != null) {
                     entity.colTooltips[columnDefinitions[i].name] = columnDefinitions[i].comment;
+                }
+
+                // column types
+                if (columnDefinitions[i].type && columnDefinitions[i].type.typename) {
+                    entity.colDataTypes[columnDefinitions[i].name] = columnDefinitions[i].type.typename;
                 }
             }
 
@@ -1766,7 +1772,7 @@ chaiseRecordApp.filter('filteredEntity', ['schemaService', function(schemaServic
             if (value !== null &&
                 (!Array.isArray(value) || (Array.isArray(value) && value.length > 0 && typeof(value[0]) != 'object')) &&
                 key != 'internal' && key != 'embedTables' && !key.match(".*_link") &&
-                key != 'colTooltips' && key != 'sequences'){
+                key != 'colTooltips' && key != 'sequences' && key != 'colDataTypes'){
 
                 // Only include column (key) if column is not hidden
                 if (!schemaService.isHiddenColumn(entity.internal.schemaName, entity.internal.tableName, key)){

--- a/record/assets/javascripts/app.js
+++ b/record/assets/javascripts/app.js
@@ -187,13 +187,11 @@ chaiseRecordApp.service('ermrestService', ['$http', '$rootScope', '$sce', 'schem
 
                 // tooltips
                 if (columnDefinitions[i].comment != null) {
-                    entity.colTooltips[columnDefinitions[i].name] = columnDefinitions[i].comment;
+                    entity.colTooltips[displayColumns[columnDefinitions[i].name] || columnDefinitions[i].name] = columnDefinitions[i].comment;
                 }
 
                 // column types
-                if (columnDefinitions[i].type && columnDefinitions[i].type.typename) {
-                    entity.colDataTypes[columnDefinitions[i].name] = columnDefinitions[i].type.typename;
-                }
+                entity.colDataTypes[displayColumns[columnDefinitions[i].name] || columnDefinitions[i].name] = columnDefinitions[i].type.typename;
             }
 
 

--- a/record/assets/views/record.html
+++ b/record/assets/views/record.html
@@ -38,7 +38,7 @@
                                 {{value | sanitizeValue }}
                         </a>
                         <div ng-class="{'fixed-font' : entity.sequences.indexOf(key) > -1, '' : entity.sequences.indexOf(key) == -1}">
-                            <span ng-if="!entity[key + '_link'] || value === null" ng-bind-html="value | sanitizeValue" ng-class="entity.colDataTypes[key]=='markdown'?'markdown-container':''"></span>
+                            <span ng-if="!entity[key + '_link'] || value === null" ng-bind-html="value | sanitizeValue" ng-class="'markdown-container': entity.colDataTypes[key]=='markdown'"></span>
                         </div>
                     </td>
                 </tr>

--- a/record/assets/views/record.html
+++ b/record/assets/views/record.html
@@ -38,7 +38,7 @@
                                 {{value | sanitizeValue }}
                         </a>
                         <div ng-class="{'fixed-font' : entity.sequences.indexOf(key) > -1, '' : entity.sequences.indexOf(key) == -1}">
-                            <span ng-if="!entity[key + '_link'] || value === null" ng-bind-html="value | sanitizeValue"></span>
+                            <span ng-if="!entity[key + '_link'] || value === null" ng-bind-html="value | sanitizeValue" ng-class="entity.colDataTypes[key]=='markdown'?'markdown-container':''"></span>
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
In order to customize the css for markdown, I added the `markdown-container` class to app.css. 

Record app will attach this class to the elements that are `markdown` typed and therefore they have the correct styles. Take a look at [this example](https://dev.isrd.isi.edu/~ashafaei/chaise/record/#2939/resource:markdown/id=123).

For now, the only css rules are, showing bullets in ordered and unordered lists. New rules can be added.