### PR TITLE
Git version info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ index.html
 chaise-config.js
 sftp-config.json
 npm-debug.log
+version.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
   - git clone https://github.com/informatics-isi-edu/ermrestjs.git
   - cd ermrestjs
   - sudo npm install
+  - bower install
   - sudo make build
   - sudo make install
   - cd ../chaise

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ before_install:
 
 install:
   - sudo make build
-  - sudo sh git_version_info.sh
   - sudo make installTravis
   - sudo service apache2 restart
   - sudo cat /var/www/html/chaise/chaise-config.js
+  - sudo cat /var/www/html/chaise/version.txt
 
 before_script:
   - sudo -H -u webauthn webauthn2-manage adduser test1

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_install:
 
 install:
   - sudo make build
+  - sudo sh git_version_info.sh
   - sudo make installTravis
   - sudo service apache2 restart
   - sudo cat /var/www/html/chaise/chaise-config.js

--- a/Makefile
+++ b/Makefile
@@ -605,7 +605,7 @@ $(JS_CONFIG): chaise-config-sample.js
 # Rule for installing on dev.isrd
 .PHONY: install
 install: $(HTML)
-	sh git_version_info.sh
+	sudo sh ./git_version_info.sh
 	test -d $(dir $(CHAISEDIR)) && mkdir -p $(CHAISEDIR)
 	rsync -a --exclude='.*' --exclude=chaise-config.js ./. $(CHAISEDIR)/
 	

--- a/Makefile
+++ b/Makefile
@@ -612,7 +612,7 @@ install: $(HTML)
 # Rule for installing on Travis
 .PHONY: installTravis
 installTravis: $(HTML)
-	sh git_version_info.sh
+	sudo sh ./git_version_info.sh
 	test -d $(dir $(CHAISETRAVISDIR)) && mkdir -p $(CHAISETRAVISDIR)
 	rsync -a --exclude='.*' ./. $(CHAISETRAVISDIR)/
 

--- a/Makefile
+++ b/Makefile
@@ -605,12 +605,14 @@ $(JS_CONFIG): chaise-config-sample.js
 # Rule for installing on dev.isrd
 .PHONY: install
 install: $(HTML)
+	sh git_version_info.sh
 	test -d $(dir $(CHAISEDIR)) && mkdir -p $(CHAISEDIR)
 	rsync -a --exclude='.*' --exclude=chaise-config.js ./. $(CHAISEDIR)/
 	
 # Rule for installing on Travis
 .PHONY: installTravis
 installTravis: $(HTML)
+	sh git_version_info.sh
 	test -d $(dir $(CHAISETRAVISDIR)) && mkdir -p $(CHAISETRAVISDIR)
 	rsync -a --exclude='.*' ./. $(CHAISETRAVISDIR)/
 

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# checks if branch has something pending
+function parse_git_dirty() {
+  git diff --quiet --ignore-submodules HEAD 2>/dev/null; [ $? -eq 1 ] && echo "*"
+}
+
+# gets the current git branch
+function parse_git_branch() {
+  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
+}
+
+# get last commit message with author and date
+function parse_git_hash() {
+  git log -1
+}
+
+VERSION=version.txt
+DATE=$(date)
+
+TITLE="**************************CHAISE BUILD INFO******************************\n\nBUILD DATE : "$DATE
+
+CHAISECOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+
+cd ../ermrestjs
+
+ERMRESTJSCOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+
+cd ../ermrest
+
+ERMRESTCOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+
+cd ../chaise
+echo $TITLE"\n\nCHAISE : "$CHAISECOMMIT"\n\nEMRESTJS : "$ERMRESTJSCOMMIT"\n\nEMREST : "$ERMRESTCOMMIT> $VERSION

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -20,15 +20,20 @@ DATE=$(date)
 
 TITLE="**************************CHAISE BUILD INFO******************************\n\nBUILD DATE : "$DATE
 
-CHAISECOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+CHAISECOMMIT="\n\nCHAISE : $(parse_git_branch)"\n"$(parse_git_hash)"
 
 cd ../ermrestjs
 
-ERMRESTJSCOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+ERMRESTJSCOMMIT="\n\nEMRESTJS : $(parse_git_branch)"\n"$(parse_git_hash)"
 
+
+if [ -n "$TRAVIS"]
+then
 cd ../ermrest
-
-ERMRESTCOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
+ERMRESTCOMMIT="\n\nEMREST : $(parse_git_branch)"\n"$(parse_git_hash)"
+else
+ERMRESTCOMMIT=""
+fi
 
 cd ../chaise
-echo "${TITLE}\n\nCHAISE : ${CHAISECOMMIT}\n\nEMRESTJS : ${ERMRESTJSCOMMIT}\n\nEMREST : ${ERMRESTCOMMIT}" > $VERSION
+echo "${TITLE}${CHAISECOMMIT}${ERMRESTJSCOMMIT}${ERMRESTCOMMIT}" > $VERSION

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # checks if branch has something pending
 function parse_git_dirty() {

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -20,17 +20,17 @@ DATE=$(date)
 
 TITLE="**************************CHAISE BUILD INFO******************************\n\nBUILD DATE : "$DATE
 
-CHAISECOMMIT="\n\nCHAISE : $(parse_git_branch)"\n"$(parse_git_hash)"
+CHAISECOMMIT="\n\nCHAISE : $(parse_git_branch)\n$(parse_git_hash)"
 
 cd ../ermrestjs
 
-ERMRESTJSCOMMIT="\n\nEMRESTJS : $(parse_git_branch)"\n"$(parse_git_hash)"
+ERMRESTJSCOMMIT="\n\nEMRESTJS : $(parse_git_branch)\n$(parse_git_hash)"
 
 
 if [ -n "$TRAVIS"]
 then
 cd ../ermrest
-ERMRESTCOMMIT="\n\nEMREST : $(parse_git_branch)"\n"$(parse_git_hash)"
+ERMRESTCOMMIT="\n\nEMREST : $(parse_git_branch)\n$(parse_git_hash)"
 else
 ERMRESTCOMMIT=""
 fi

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # checks if branch has something pending
 function parse_git_dirty() {

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -31,4 +31,4 @@ cd ../ermrest
 ERMRESTCOMMIT=$(parse_git_branch)"\n"$(parse_git_hash)
 
 cd ../chaise
-echo $TITLE"\n\nCHAISE : "$CHAISECOMMIT"\n\nEMRESTJS : "$ERMRESTJSCOMMIT"\n\nEMREST : "$ERMRESTCOMMIT> $VERSION
+echo "${TITLE}\n\nCHAISE : ${CHAISECOMMIT}\n\nEMRESTJS : ${ERMRESTJSCOMMIT}\n\nEMREST : ${ERMRESTCOMMIT}" > $VERSION

--- a/git_version_info.sh
+++ b/git_version_info.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 # checks if branch has something pending
-function parse_git_dirty() {
+parse_git_dirty() {
   git diff --quiet --ignore-submodules HEAD 2>/dev/null; [ $? -eq 1 ] && echo "*"
 }
 
 # gets the current git branch
-function parse_git_branch() {
+parse_git_branch() {
   git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e "s/* \(.*\)/\1$(parse_git_dirty)/"
 }
 
 # get last commit message with author and date
-function parse_git_hash() {
+parse_git_hash() {
   git log -1
 }
 


### PR DESCRIPTION
This **PR** allows to generate a **version.txt** file on `make install` using [git_version_info.sh](https://github.com/informatics-isi-edu/chaise/blob/git_version_info/git_version_info.sh). It contains the git log for **chaise** and **ermrestjs** version which is being used. 

You can browse this file in the browser using the **Chaise** App url *https://[CHAISE_URL]/chaise/version.txt*. 

The file **version.txt** looks like this
```
**************************CHAISE BUILD INFO******************************

BUILD DATE : Fri Aug  5 10:35:08 PDT 2016

CHAISE : git_version_info*ncommit 367de825223ec301c906713e09407684351a8fa7
Author: Chirag Sanghvi <csanghvi@appacitive.com>
Date:   Fri Aug 5 10:29:43 2016 -0700

    added bower install in travis.yml

EMRESTJS : masterncommit 7fc961bf8be9d040fdedddeeb3b0aad543c497b4
Author: Chirag Sanghvi <csanghvi@appacitive.com>
Date:   Thu Aug 4 15:33:18 2016 -0700

    Fixed failing http retry testcase

```