### PR TITLE
Empty tables

### DIFF
--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -8,8 +8,8 @@
 <body>
     <navbar></navbar>
 
-    <div class="container-fluid" ng-controller="RecordController as ctrl">
-        <div id="record2-bookmark-container" class="col-xs-12 meta-icons">
+    <div class="container-fluid">
+        <div id="record2-bookmark-container" class="col-xs-12 meta-icons" ng-controller="RecordController as ctrl">
             <a id="create-record" ng-if="reference && reference.canCreate && ctrl.modifyRecord" title="Click here to create a record" ng-click="::ctrl.createRecord()">
                 <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
             </a>&nbsp;&nbsp;

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -8,8 +8,8 @@
 <body>
     <navbar></navbar>
 
-    <div class="container-fluid">
-        <div id="record2-bookmark-container" class="col-xs-12 meta-icons" ng-controller="RecordController as ctrl">
+    <div class="container-fluid" ng-controller="RecordController as ctrl">
+        <div id="record2-bookmark-container" class="col-xs-12 meta-icons">
             <a id="create-record" ng-if="reference && reference.canCreate && ctrl.modifyRecord" title="Click here to create a record" ng-click="::ctrl.createRecord()">
                 <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
             </a>&nbsp;&nbsp;
@@ -31,14 +31,12 @@
             <record-display columns="columns" values="recordValues"></record-display>
         </div>
 
-        <!-- prevents initialization of the directive until the data is available | wait until all data values have been fetched -->
-        <div ng-if="relatedReferences.length == tableModels.length">
-            <uib-accordion close-others="false">
-                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index" ng-if="tableModels[$index].rowValues.length > 0"
-                    heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
-                    <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
-                </div>
-            </uib-accordion>
-        </div>
+        <uib-accordion close-others="false">
+            <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
+                ng-if="($index === 0 || tableModels[$index-1].hasLoaded) && tableModels[$index].rowValues.length > 0"
+                heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
+                <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+            </div>
+        </uib-accordion>
     </div>
 </body>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -34,7 +34,7 @@
         <!-- prevents initialization of the directive until the data is available | wait until all data values have been fetched -->
         <div ng-if="relatedReferences.length == tableModels.length">
             <uib-accordion close-others="false">
-                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
+                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index" ng-if="tableModels[$index].rowValues.length > 0"
                     heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
                     <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
                 </div>

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -75,6 +75,7 @@
                             $rootScope.relatedReferences[i].read(5).then(function (page) {
                                 var model = {
                                     columns: $rootScope.relatedReferences[i].columns,
+                                    hasLoaded: true,     // used to determine if the current table and next table should be rendered
                                     open: true,         // to define if the accordion is open or closed
                                     sortby: null,       // column name, user selected or null
                                     sortOrder: null,    // asc (default) or desc

--- a/test/e2e/data_setup/config/record2.dev.json
+++ b/test/e2e/data_setup/config/record2.dev.json
@@ -49,7 +49,8 @@
                             { "id" : 3008, "filename" : "Four Points Sherathon 4", "uri" : "http://images.trvl-media.com/hotels/1000000/30000/28200/28110/28110_193_z.jpg", "content_type" : "image/jpeg", "bytes" : 0, "timestamp" : "2016-01-03T00:00:00-08:00", "image_width" : null, "image_height" : null, "preview" : null },
                             { "id" : 30007, "filename" : "Four Points Sherathon 3", "uri" : "http://images.trvl-media.com/hotels/1000000/30000/28200/28110/28110_191_z.jpg", "content_type" : "image/jpeg", "bytes" : 0, "timestamp" : "2016-06-05T00:00:00-07:00", "image_width" : null, "image_height" : null, "preview" : null }
                         ]
-                    }],
+                    }
+                ],
                 "columns" : [
                     { "title" : "Id", "value": "2002", "type": "serial4"},
                     { "title" : "Name of Accommodation", "value": "Sherathon Hotel", "type": "text"},

--- a/test/e2e/data_setup/config/record2.dev.json
+++ b/test/e2e/data_setup/config/record2.dev.json
@@ -10,7 +10,7 @@
             "schema": {
                 "name": "product",
                 "createNew": true,
-                "path": "test/e2e/data_setup/schema/product.json"
+                "path": "test/e2e/data_setup/schema/product-record.json"
             },
             "tables": {
                 "createNew": true

--- a/test/e2e/data_setup/data/product/media.json
+++ b/test/e2e/data_setup/data/product/media.json
@@ -1,0 +1,2 @@
+[{"accommodation_id": 2001},
+ {"accommodation_id": 2004}]

--- a/test/e2e/data_setup/schema/product-record.json
+++ b/test/e2e/data_setup/schema/product-record.json
@@ -338,7 +338,8 @@
         "tag:isrd.isi.edu,2016:visible-foreign-keys" : {
           "*" : [
               ["product", "fk_booking_accommodation"],
-              ["product", "fk_accommodation_image"]
+              ["product", "fk_accommodation_image"],
+              ["product", "fk_media_accommodation"]
           ]
         }
       }
@@ -744,6 +745,78 @@
           "display": "Categories"
         }
       }
+    },
+    "media": {
+      "comment": null,
+      "kind": "table",
+      "entityCount": 0,
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id",
+            "accommodation_id"
+          ]
+        }
+      ],
+      "foreign_keys": [
+        {
+          "names" : [["product", "fk_media_accommodation"]],
+          "comment": null,
+          "foreign_key_columns": [
+            {
+              "table_name": "media",
+              "schema_name": "product",
+              "column_name": "accommodation_id"
+            }
+          ],
+          "annotations": {},
+          "referenced_columns": [
+            {
+              "table_name": "accommodation",
+              "schema_name": "product",
+              "column_name": "id"
+            }
+          ]
+        }
+      ],
+      "table_name": "media",
+      "schema_name": "product",
+      "column_definitions": [
+        {
+          "comment": null,
+          "name": "id",
+          "default": null,
+          "nullok": false,
+          "type": {
+            "typename": "serial4"
+          },
+          "annotations": {
+            "comment": ["hidden"]
+          }
+        },
+        {
+          "comment": null,
+          "name": "accommodation_id",
+          "default": null,
+          "nullok": false,
+          "type": {
+            "typename": "int4"
+          },
+          "annotations": {
+            "comment": ["hidden"]
+          }
+        }
+      ],
+      "annotations": {
+        "comment": [
+          "association"
+        ],
+        "description": {
+          "display": "Media"
+        }
+      }
     }
   },
   "table_names": [
@@ -751,7 +824,8 @@
     "file",
     "accommodation",
     "accommodation_image",
-    "booking"
+    "booking",
+    "media"
   ],
   "comment": null,
   "annotations": {

--- a/test/e2e/data_setup/schema/product.json
+++ b/test/e2e/data_setup/schema/product.json
@@ -338,7 +338,8 @@
         "tag:isrd.isi.edu,2016:visible-foreign-keys" : {
           "*" : [
               ["product", "fk_booking_accommodation"],
-              ["product", "fk_accommodation_image"]
+              ["product", "fk_accommodation_image"],
+              ["product", "fk_media_accommodation"]
           ]
         }
       }
@@ -744,6 +745,78 @@
           "display": "Categories"
         }
       }
+    },
+    "media": {
+      "comment": null,
+      "kind": "table",
+      "entityCount": 0,
+      "keys": [
+        {
+          "comment": null,
+          "annotations": {},
+          "unique_columns": [
+            "id",
+            "accommodation_id"
+          ]
+        }
+      ],
+      "foreign_keys": [
+        {
+          "names" : [["product", "fk_media_accommodation"]],
+          "comment": null,
+          "foreign_key_columns": [
+            {
+              "table_name": "media",
+              "schema_name": "product",
+              "column_name": "accommodation_id"
+            }
+          ],
+          "annotations": {},
+          "referenced_columns": [
+            {
+              "table_name": "accommodation",
+              "schema_name": "product",
+              "column_name": "id"
+            }
+          ]
+        }
+      ],
+      "table_name": "media",
+      "schema_name": "product",
+      "column_definitions": [
+        {
+          "comment": null,
+          "name": "id",
+          "default": null,
+          "nullok": false,
+          "type": {
+            "typename": "serial4"
+          },
+          "annotations": {
+            "comment": ["hidden"]
+          }
+        },
+        {
+          "comment": null,
+          "name": "accommodation_id",
+          "default": null,
+          "nullok": false,
+          "type": {
+            "typename": "int4"
+          },
+          "annotations": {
+            "comment": ["hidden"]
+          }
+        }
+      ],
+      "annotations": {
+        "comment": [
+          "association"
+        ],
+        "description": {
+          "display": "Media"
+        }
+      }
     }
   },
   "table_names": [
@@ -751,7 +824,8 @@
     "file",
     "accommodation",
     "accommodation_image",
-    "booking"
+    "booking",
+    "media"
   ],
   "comment": null,
   "annotations": {

--- a/test/e2e/specs/record2/helpers.js
+++ b/test/e2e/specs/record2/helpers.js
@@ -26,8 +26,8 @@ exports.testPresentation = function (tableParams) {
             editButton = chaisePage.record2Page.getEditRecordButton(),
             createButton = chaisePage.record2Page.getCreateRecordButton();
 
-        browser.wait(EC.elementToBeClickable(editButton), 5000);
-        browser.wait(EC.elementToBeClickable(createButton), 5000);
+        browser.wait(EC.elementToBeClickable(editButton), 10000);
+        browser.wait(EC.elementToBeClickable(createButton), 10000);
 
         editButton.isDisplayed().then(function (bool) {
             expect(bool).toBeTruthy();
@@ -187,7 +187,7 @@ exports.testEditButton = function () {
         var EC = protractor.ExpectedConditions,
             editButton = chaisePage.record2Page.getEditRecordButton();
 
-        browser.wait(EC.elementToBeClickable(editButton), 5000);
+        browser.wait(EC.elementToBeClickable(editButton), 10000);
 
         editButton.click().then(function() {
             browser.driver.getCurrentUrl().then(function(url) {
@@ -202,7 +202,7 @@ exports.testCreateButton = function () {
         var EC = protractor.ExpectedConditions,
             createButton = chaisePage.record2Page.getCreateRecordButton();
 
-        browser.wait(EC.elementToBeClickable(createButton), 5000);
+        browser.wait(EC.elementToBeClickable(createButton), 10000);
 
         createButton.click().then(function() {
             browser.driver.getCurrentUrl().then(function(url) {

--- a/test/e2e/specs/record2/helpers.js
+++ b/test/e2e/specs/record2/helpers.js
@@ -149,6 +149,11 @@ exports.testPresentation = function (tableParams) {
         });
     });
 
+    // There is a media table linked to accommodations but this accommodation (Sheraton Hotel) doesn't have any media
+    it("should not show a related table with zero values.", function() {
+        expect(chaisePage.record2Page.getRelatedTable("media").isPresent()).toBeFalsy();
+    });
+
     it("clicking the related table heading should change the heading and hide the table.", function() {
         var relatedTable = tableParams.related_tables[0];
         var displayName = relatedTable.title;

--- a/test/e2e/specs/search/data-independent/00-sidebar.morefilter.spec.js
+++ b/test/e2e/specs/search/data-independent/00-sidebar.morefilter.spec.js
@@ -20,7 +20,7 @@ describe('Chaise initial sidebar,', function () {
             browser.get(browser.params.url || "");
         });
 
-        it('d', function () {
+        it('should show the spinner', function () {
             //so icon can be tested before everything settles down(settling down means img is no longer there)
             expect(spinner.isDisplayed()).toBe(true);
         });

--- a/test/e2e/specs/search/data-independent/00-sidebar.morefilter.spec.js
+++ b/test/e2e/specs/search/data-independent/00-sidebar.morefilter.spec.js
@@ -20,7 +20,7 @@ describe('Chaise initial sidebar,', function () {
             browser.get(browser.params.url || "");
         });
 
-        it('should show the spinner', function () {
+        it('d', function () {
             //so icon can be tested before everything settles down(settling down means img is no longer there)
             expect(spinner.isDisplayed()).toBe(true);
         });
@@ -35,7 +35,7 @@ describe('Chaise initial sidebar,', function () {
                 expect(sidebar.isDisplayed()).toBe(true);
             });
         });
-        
+
         it('should have > 1 visible attributes to choose from', function () {
             chaisePage.sidebar.sidebarAttrsDisplayed.count().then(function (num) {
                 numOfAttrs = num;
@@ -52,7 +52,7 @@ describe('Chaise initial sidebar,', function () {
             });
 
             var expectedAttr;
-           
+
             var sidebarAttrTitle = chaisePage.editFilter.sidebarHeader;
 
             it('should change correctly when one attribute is chosen', function () {
@@ -86,7 +86,7 @@ describe('Chaise initial sidebar,', function () {
                 }
             });
         });
-       
+
         it('should not show attributes with bottom', function () {
             var columns = chaisePage.dataUtils.sidebar.getInvisibleSidebarColumns(browser.params.defaultSchema, browser.params.defaultTable);
             columns.forEach(function(column) {
@@ -122,7 +122,7 @@ describe('Chaise initial sidebar,', function () {
                             txt = txt.trim();
                             var found = columns.find(function(c) {
                                 return chaisePage.dataUtils.sidebar.getColumnDisplayName(c) == txt;
-                            }) ? true : false; 
+                            }) ? true : false;
                             expect(found).toBe(true);
                         });
                     }
@@ -167,7 +167,7 @@ describe('Chaise initial sidebar,', function () {
                     expect(displayed).toBe(false);
                 });
             });
-            
+
             it('should entering \'View All Attributes\', check previously unchecked and uncheck ' +
                 'previously checked', function () {
                 viewAll.click();


### PR DESCRIPTION
Changes for issue #554. Related tables only show up when they have data and when the previous table has loaded.

These changes can be tested [here](https://dev.isrd.isi.edu/~jchudy/chaise/record-two/#1/legacy:dataset/id=269).