### PR TITLE
Compact brief

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -217,6 +217,9 @@ button .glyphicon-trash {
 .table.nested .panel-body{
     /*overflow-x: scroll;*/
 }
+.table{
+    margin-bottom: 5px;
+}
 tbody{
         display: table-row-group;
     vertical-align: middle;

--- a/common/table.js
+++ b/common/table.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.record.table', [])
 
-    .directive('recordTable', [function() {
+    .directive('recordTable', ['$window', function($window) {
 
         return {
             restrict: 'E',
@@ -22,6 +22,14 @@
 
                 scope.gotoRowLinkIndex = function (index) {
                     scope.gotoRowLink({index : index});
+                };
+
+                scope.toRecordSet = function() {
+                    var refLocation = scope.vm.reference.location,
+                        recordsetPathname = $window.location.pathname.replace("record-two", "recordset");
+
+                    var uri = $window.location.origin + recordsetPathname + '#' + refLocation.catalog + '/' + refLocation.path;
+                    $window.location.href = uri;
                 };
             }
         };

--- a/common/table.js
+++ b/common/table.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.record.table', [])
 
-    .directive('recordTable', ['$window', function($window) {
+    .directive('recordTable', [function() {
 
         return {
             restrict: 'E',
@@ -22,16 +22,6 @@
 
                 scope.gotoRowLinkIndex = function (index) {
                     scope.gotoRowLink({index : index});
-                };
-
-                scope.toRecordSet = function() {
-                    var refLocation = scope.vm.reference.location,
-                        // This uses $window location because we need the origin and pathname relative to chaise,
-                        // whereas refLocation gives you that info but relative to ermrestJS
-                        recordsetPathname = $window.location.pathname.replace("record-two", "recordset");
-
-                    var uri = $window.location.origin + recordsetPathname + '#' + refLocation.catalog + '/' + refLocation.path;
-                    $window.location.href = uri;
                 };
             }
         };

--- a/common/table.js
+++ b/common/table.js
@@ -26,6 +26,8 @@
 
                 scope.toRecordSet = function() {
                     var refLocation = scope.vm.reference.location,
+                        // This uses $window location because we need the origin and pathname relative to chaise,
+                        // whereas refLocation gives you that info but relative to ermrestJS
                         recordsetPathname = $window.location.pathname.replace("record-two", "recordset");
 
                     var uri = $window.location.origin + recordsetPathname + '#' + refLocation.catalog + '/' + refLocation.path;

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -12,11 +12,6 @@
             </tr>
         </thead>
 
-        <!-- footer -->
-        <tfoot>
-            <tr ng-if="vm.appName && vm.hasNextPage"><td class="text-right" colspan="100%"><a ng-click="toRecordSet()">Click here to access more records</a></td></tr>
-        </tfoot>
-
         <!-- rows -->
         <tbody>
             <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="gotoRowLink({index : $index})" ng-style="{'cursor': 'pointer'}">

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -12,9 +12,16 @@
             </tr>
         </thead>
 
+        <!-- footer -->
+        <tfoot>
+            <tr ng-if="vm.appName && vm.hasNextPage"><td class="text-right" colspan="100%"><a ng-click="toRecordSet()">Click here to access more records</a></td></tr>
+        </tfoot>
+
         <!-- rows -->
-        <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="gotoRowLink({index : $index})" ng-style="{'cursor': 'pointer'}">
-            <td ng-repeat="val in row track by $index">{{val}}</td>
-        </tr>
+        <tbody>
+            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="gotoRowLink({index : $index})" ng-style="{'cursor': 'pointer'}">
+                <td ng-repeat="val in row track by $index">{{val}}</td>
+            </tr>
+        </tbody>
     </table>
 </div>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -37,9 +37,14 @@
                 heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
                 <!-- for different elements inside the accordion -->
                 <div ng-switch on="relatedRef.display.type">
-                    <!-- Currently only support ng-switch-when="tabular" which is also the default case --> 
+                    <div ng-switch-when="markdown">
+                        <span ng-bind-html="page.content"></span>
+                        <span ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</span>
+                    </div>
+                    <!-- ng-switch-when="table" is also the default case -->
                     <div ng-switch-default>
                         <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+                        <a ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
                     </div>
                 </div>
             </div>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -39,13 +39,12 @@
                 <div ng-switch on="relatedRef.display.type">
                     <div ng-switch-when="markdown">
                         <span ng-bind-html="page.content"></span>
-                        <span ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</span>
                     </div>
                     <!-- ng-switch-when="table" is also the default case -->
                     <div ng-switch-default>
                         <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
-                        <a ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
                     </div>
+                    <a ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
                 </div>
             </div>
         </uib-accordion>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -35,7 +35,13 @@
             <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
                 ng-if="($index === 0 || tableModels[$index-1].hasLoaded) && tableModels[$index].rowValues.length > 0"
                 heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
-                <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+                <!-- for different elements inside the accordion -->
+                <div ng-switch on="relatedRef.display.type">
+                    <!-- Currently only support ng-switch-when="tabular" which is also the default case --> 
+                    <div ng-switch-default>
+                        <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+                    </div>
+                </div>
             </div>
         </uib-accordion>
     </div>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -44,7 +44,7 @@
                     <!-- ng-switch-when="table" is also the default case -->
                     <div ng-switch-default>
                         <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
-                        <a ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
+                        <a ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
                     </div>
                 </div>
             </div>

--- a/record-two/index.html.in
+++ b/record-two/index.html.in
@@ -44,7 +44,7 @@
                     <div ng-switch-default>
                         <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
                     </div>
-                    <a ng-if="page.hasNext" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
+                    <a ng-if="tableModels[$index].hasNext" class="more-results-link" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">Click here to access more records</a>
                 </div>
             </div>
         </uib-accordion>

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -69,7 +69,7 @@
                     $rootScope.tableModels = [];
 
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
-                        // $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
+                        $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
                         // We want to limit the number of values shown by default
                         // Maybe have a chaise config option
                         (function(i) {

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -69,17 +69,21 @@
                     $rootScope.tableModels = [];
 
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
+                        // $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
                         // We want to limit the number of values shown by default
                         // Maybe have a chaise config option
                         (function(i) {
                             $rootScope.relatedReferences[i].read(5).then(function (page) {
                                 var model = {
+                                    reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
-                                    hasLoaded: true,     // used to determine if the current table and next table should be rendered
-                                    open: true,         // to define if the accordion is open or closed
-                                    sortby: null,       // column name, user selected or null
-                                    sortOrder: null,    // asc (default) or desc
-                                    rowValues: []       // array of rows values
+                                    appName: context.appName,   // used to decide the context that the table is displayed in
+                                    hasNextPage: true,          // used to determine if a link to more data should be present
+                                    hasLoaded: true,            // used to determine if the current table and next table should be rendered
+                                    open: true,                 // to define if the accordion is open or closed
+                                    sortby: null,               // column name, user selected or null
+                                    sortOrder: null,            // asc (default) or desc
+                                    rowValues: []               // array of rows values
                                 };
                                 model.rowValues = page.tuples.map(function (tuple, index, array) {
                                     return tuple.values;

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -69,7 +69,7 @@
                     $rootScope.tableModels = [];
 
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
-                        // $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
+                        $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
                         // We want to limit the number of values shown by default
                         // Maybe have a chaise config option
                         (function(i) {
@@ -78,7 +78,7 @@
                                     reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
                                     appName: context.appName,   // used to decide the context that the table is displayed in
-                                    hasNextPage: true,          // used to determine if a link to more data should be present
+                                    hasNextPage: page.hasNext,  // used to determine if a link to more data should be present
                                     hasLoaded: true,            // used to determine if the current table and next table should be rendered
                                     open: true,                 // to define if the accordion is open or closed
                                     sortby: null,               // column name, user selected or null

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -50,6 +50,7 @@
                     // There should only ever be one entity related to this reference
                     return $rootScope.reference.read(1);
                 }).then(function getPage(page) {
+                    $rootScope.page = page;
                     var tuple = page.tuples[0];
                     // Used directly in the record-display directive
                     $rootScope.recordDisplayname = tuple.displayname;
@@ -69,7 +70,7 @@
                     $rootScope.tableModels = [];
 
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
-                        $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
+                        // $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
                         // We want to limit the number of values shown by default
                         // Maybe have a chaise config option
                         (function(i) {
@@ -77,8 +78,6 @@
                                 var model = {
                                     reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
-                                    appName: context.appName,   // used to decide the context that the table is displayed in
-                                    hasNextPage: page.hasNext,  // used to determine if a link to more data should be present
                                     hasLoaded: true,            // used to determine if the current table and next table should be rendered
                                     open: true,                 // to define if the accordion is open or closed
                                     sortby: null,               // column name, user selected or null

--- a/record-two/record.app.js
+++ b/record-two/record.app.js
@@ -50,7 +50,6 @@
                     // There should only ever be one entity related to this reference
                     return $rootScope.reference.read(1);
                 }).then(function getPage(page) {
-                    $rootScope.page = page;
                     var tuple = page.tuples[0];
                     // Used directly in the record-display directive
                     $rootScope.recordDisplayname = tuple.displayname;
@@ -75,9 +74,11 @@
                         // Maybe have a chaise config option
                         (function(i) {
                             $rootScope.relatedReferences[i].read(5).then(function (page) {
+
                                 var model = {
                                     reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
+                                    hasNext: page.hasNext,      // used to determine if a link should be shown
                                     hasLoaded: true,            // used to determine if the current table and next table should be rendered
                                     open: true,                 // to define if the accordion is open or closed
                                     sortby: null,               // column name, user selected or null

--- a/record-two/record.controller.js
+++ b/record-two/record.controller.js
@@ -24,5 +24,15 @@
             }
             return $rootScope.context.mainURI;
         };
+
+        vm.toRecordSet = function(ref) {
+            var refLocation = ref.location,
+                // This uses $window location because we need the origin and pathname relative to chaise,
+                // whereas refLocation gives you that info but relative to ermrestJS
+                recordsetPathname = $window.location.pathname.replace("record-two", "recordset");
+
+            var uri = $window.location.origin + recordsetPathname + '#' + refLocation.catalog + '/' + refLocation.path;
+            $window.location.href = uri;
+        };
     }]);
 })();

--- a/test/e2e/data_setup/config/related-table-link.dev.json
+++ b/test/e2e/data_setup/config/related-table-link.dev.json
@@ -10,7 +10,7 @@
             "schema": {
                 "name": "product",
                 "createNew": true,
-                "path": "test/e2e/data_setup/schema/product-record.json"
+                "path": "test/e2e/data_setup/schema/product-unordered-related-tables.json"
             },
             "tables": {
                 "createNew": true
@@ -27,7 +27,10 @@
         "params": {
             "tuples" : [{
                 "table_name" : "accommodation",
-                "keys" : [{ "name": "id", "value": "2004", "operator" : "="}],
+                "related_table_name_with_more_results" : "booking",
+                "related_table_name_with_link_in_table" : "file",
+                "keys" : [{ "name": "id", "value": "2004", "operator": "=" }],
+                "tables_order" : ["- booking (5)", "- file (3)", "- media (1)"]
             }]
         }
     }

--- a/test/e2e/data_setup/config/relatedTableLink.json
+++ b/test/e2e/data_setup/config/relatedTableLink.json
@@ -1,0 +1,34 @@
+{
+    "setup": {
+        "schemaConfigurations": [{
+            "catalog": {
+                "acls": [
+                    {"name": "content_write_user", "user": "*" },
+                    {"name": "content_read_user", "user": "*" }
+                ]
+            },
+            "schema": {
+                "name": "product",
+                "createNew": true,
+                "path": "test/e2e/data_setup/schema/product-record.json"
+            },
+            "tables": {
+                "createNew": true
+            },
+            "entities": {
+                "createNew": true,
+                "path": "test/e2e/data_setup/data/product"
+            }
+        }],
+        "schema": "product"
+    },
+    "cleanup" : true,
+    "tests" : {
+        "params": {
+            "tuples" : [{
+                "table_name" : "accommodation",
+                "keys" : [{ "name": "id", "value": "2004", "operator" : "="}],
+            }]
+        }
+    }
+}

--- a/test/e2e/data_setup/data/product/booking.json
+++ b/test/e2e/data_setup/data/product/booking.json
@@ -6,4 +6,8 @@
  {"accommodation_id":2003,"price":240,"booking_date":"2016-01-25T00:00:00-08:00"},
  {"accommodation_id":2003,"price":280,"booking_date":"2016-03-07T00:00:00-08:00"},
  {"accommodation_id":2004,"price":100,"booking_date":"2016-06-01T00:00:00-07:00"},
- {"accommodation_id":2004,"price":120,"booking_date":"2015-11-10T00:00:00-08:00"}]
+ {"accommodation_id":2004,"price":120,"booking_date":"2015-11-10T00:00:00-08:00"},
+ {"accommodation_id":2004,"price":125,"booking_date":"2016-03-12T00:00:00-08:00"},
+ {"accommodation_id":2004,"price":110,"booking_date":"2016-05-19T00:00:00-08:00"},
+ {"accommodation_id":2004,"price":80,"booking_date":"2016-01-01T00:00:00-08:00"},
+ {"accommodation_id":2004,"price":180,"booking_date":"2016-09-04T00:00:00-08:00"}]

--- a/test/e2e/data_setup/schema/product-unordered-related-tables.json
+++ b/test/e2e/data_setup/schema/product-unordered-related-tables.json
@@ -333,14 +333,6 @@
         },
         "tag:isrd.isi.edu,2016:visible-columns" : {
           "record" : ["id", "category", "website", "rating", "summary", "description", "thumbnail", "opened_on", "luxurious"]
-        },
-
-        "tag:isrd.isi.edu,2016:visible-foreign-keys" : {
-          "*" : [
-              ["product", "fk_booking_accommodation"],
-              ["product", "fk_accommodation_image"],
-              ["product", "fk_media_accommodation"]
-          ]
         }
       }
     },

--- a/test/e2e/specs/record2/helpers.js
+++ b/test/e2e/specs/record2/helpers.js
@@ -211,3 +211,46 @@ exports.testCreateButton = function () {
         });
     });
 };
+
+exports.relatedTablesDefaultOrder = function (tableParams) {
+    it("should have the tables in default order.", function() {
+        chaisePage.record2Page.getRelatedTableHeadings().getAttribute("heading").then(function(headings) {
+            // tables should be in order based on the default order because no visible foreign keys annotation is defined
+            // Headings have a '-' when page loads, and a count after them
+            expect(headings).toEqual(tableParams.tables_order);
+        });
+    });
+};
+
+exports.relatedTableLinks = function (tableParams) {
+    it("should create a functional link for table rows with links in them.", function() {
+        var relatedTableName = tableParams.related_table_name_with_link_in_table;
+        chaisePage.record2Page.getRelatedTableRows(relatedTableName).then(function(rows) {
+            return rows[0].all(by.tagName("td"));
+        }).then(function(cells) {
+            return cells[2].getInnerHtml();
+        }).then(function(cell) {
+            // check that an element was created inside the td with an href attribute
+            expect(cell.indexOf("href")).toBeGreaterThan(-1);
+        });
+    });
+
+    it("should have a link if more than 5 values are present for an entity and redirect to recordset.", function() {
+        var EC = protractor.ExpectedConditions,
+            relatedTableName = tableParams.related_table_name_with_more_results,
+            relatedTableLink = chaisePage.record2Page.getMoreResultsLink(relatedTableName);
+
+        browser.wait(EC.elementToBeClickable(relatedTableLink), 10000);
+
+        chaisePage.record2Page.getRelatedTableRows(relatedTableName).count().then(function(count) {
+            expect(count).toBe(5);
+
+            expect(relatedTableLink.isDisplayed()).toBeTruthy();
+            return relatedTableLink.click();
+        }).then(function() {
+            return browser.driver.getCurrentUrl();
+        }).then(function(url) {
+            expect(url.indexOf('recordset')).toBeGreaterThan(-1);
+        });
+    });
+};

--- a/test/e2e/specs/record2/related-table/03-record.related-table-link.spec.js
+++ b/test/e2e/specs/record2/related-table/03-record.related-table-link.spec.js
@@ -1,0 +1,38 @@
+var chaisePage = require('../../../utils/chaise.page.js');
+var record2Helpers = require('../helpers.js');
+
+describe('View existing record,', function() {
+
+	var params, testConfiguration = browser.params.configuration.tests, testParams = testConfiguration.params;
+
+    for (var i=0; i< testParams.tuples.length; i++) {
+
+    	(function(tupleParams, index) {
+
+    		describe("For table " + tupleParams.table_name + ",", function() {
+
+    			var table, record;
+
+				beforeAll(function () {
+					var keys = [];
+					tupleParams.keys.forEach(function(key) {
+						keys.push(key.name + key.operator + key.value);
+					});
+					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
+					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
+					browser.sleep(2000);
+			    });
+
+                describe("Show the related entity tables,", function() {
+					var params = record2Helpers.relatedTablesDefaultOrder(tupleParams);
+					var params = record2Helpers.relatedTableLinks(tupleParams);
+				});
+
+    		});
+
+    	})(testParams.tuples[i], i);
+
+
+    }
+
+});

--- a/test/e2e/specs/record2/related-table/protractor.conf.js
+++ b/test/e2e/specs/record2/related-table/protractor.conf.js
@@ -1,0 +1,23 @@
+var pConfig = require('./../../../utils/protractor.configuration.js');
+
+var config = pConfig.getConfig({
+
+  // Change this to your desired filed name and Comment below testConfiguration object declaration
+    configFileName: 'related-table-link.dev.json',
+
+  /* Just in case if you plan on not giving a file for configuration, you can always specify a testConfiguration object
+   * Comment above 2 lines
+   * Empty configuration will run test cases against catalog 1 and default schema
+    testConfiguration: {
+      ....
+    },
+  */
+
+    page: 'record-two',
+    setBaseUrl: function(browser, data) {
+      browser.params.url = process.env.CHAISE_BASE_URL + "/record-two/#" + data.catalogId + "/" + data.schema.name;
+      return browser.params.url;
+    }
+});
+
+exports.config = config;

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -483,6 +483,15 @@ var record2Page = function() {
         return element(by.id("rt-" + displayName)).all(by.css(".table-row"));
     };
 
+    this.getMoreResultsLink = function(displayName) {
+        // the link is not a child of the table, rather one of the accordion group
+        return element(by.id("rt-heading-" + displayName)).element(by.css(".more-results-link"));
+    };
+
+    this.getRelatedTableRowValues = function(displayName) {
+        return that.getRelatedTableRows(displayName).all(by.tagName("td"));    
+    };
+
     this.getCreateRecordButton = function() {
         return element(by.id("create-record"));
     };


### PR DESCRIPTION
This PR addresses the following:

- using the `compact/brief` context for references in record2 for the related tables (#570)
- a link after the related tables that goes to recordset when there are more than 5 values
- a link after markdown content as well
- created DOM structure for different display types in record2 (#580)

I don't have a link to an entity that has a related table with more than 5 values associated. I did write a test that makes sure that is working properly though.