### PR TITLE
Use annotated page size for recordset tables

### DIFF
--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -32,6 +32,17 @@
                 <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">Items per page
                     <span class="caret"></span></button>
                 <ul class="dropdown-menu">
+                    <li ng-if="pageInfo.pageLimit !== 10 &&
+                        pageInfo.pageLimit !== 10 &&
+                        pageInfo.pageLimit !== 25 &&
+                        pageInfo.pageLimit !== 50 &&
+                        pageInfo.pageLimit !== 75 &&
+                        pageInfo.pageLimit !== 100 &&
+                        pageInfo.pageLimit !== 200"><a href ng-click="pageLimit(pageInfo.pageLimit)">
+                        <span ng-show="true" class="glyphicon glyphicon-ok"></span>
+                        <span ng-show="false" class="glyphicon glyphicon-invisible"></span>
+                        {{ pageInfo.pageLimit }} (Custom)</a>
+                    </li>
                     <li><a href ng-click="pageLimit(10)">
                         <span ng-show="pageInfo.pageLimit === 10" class="glyphicon glyphicon-ok"></span>
                         <span ng-show="pageInfo.pageLimit !== 10" class="glyphicon glyphicon-invisible"></span>

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -33,13 +33,11 @@
                     <span class="caret"></span></button>
                 <ul class="dropdown-menu">
                     <li ng-if="pageLimits.indexOf(pageInfo.pageLimit) === -1"><a id="custom-page-size" href ng-click="pageLimit(pageInfo.pageLimit)">
-                        <span ng-show="true" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="false" class="glyphicon glyphicon-invisible"></span>
+                        <span class="glyphicon glyphicon-ok"></span>
                         {{ pageInfo.pageLimit }} (Custom)</a>
                     </li>
                     <li ng-repeat="limit in pageLimits"><a href ng-click="pageLimit(limit)">
-                        <span ng-show="pageInfo.pageLimit === limit" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== limit" class="glyphicon glyphicon-invisible"></span>
+                        <span class="glyphicon" ng-class="pageInfo.pageLimit === limit ? glyphicon-ok : glyphicon-invisible"></span>
                         {{ limit }}</a>
                     </li>
                 </ul>

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -32,46 +32,15 @@
                 <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">Items per page
                     <span class="caret"></span></button>
                 <ul class="dropdown-menu">
-                    <li ng-if="pageInfo.pageLimit !== 10 &&
-                        pageInfo.pageLimit !== 10 &&
-                        pageInfo.pageLimit !== 25 &&
-                        pageInfo.pageLimit !== 50 &&
-                        pageInfo.pageLimit !== 75 &&
-                        pageInfo.pageLimit !== 100 &&
-                        pageInfo.pageLimit !== 200"><a id="custom-page-size" href ng-click="pageLimit(pageInfo.pageLimit)">
+                    <li ng-if="pageLimits.indexOf(pageInfo.pageLimit) === -1"><a id="custom-page-size" href ng-click="pageLimit(pageInfo.pageLimit)">
                         <span ng-show="true" class="glyphicon glyphicon-ok"></span>
                         <span ng-show="false" class="glyphicon glyphicon-invisible"></span>
                         {{ pageInfo.pageLimit }} (Custom)</a>
                     </li>
-                    <li><a href ng-click="pageLimit(10)">
-                        <span ng-show="pageInfo.pageLimit === 10" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 10" class="glyphicon glyphicon-invisible"></span>
-                        10</a>
-                    </li>
-                    <li><a href ng-click="pageLimit(25)">
-                        <span ng-show="pageInfo.pageLimit === 25" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 25" class="glyphicon glyphicon-invisible"></span>
-                        25</a>
-                    </li>
-                    <li><a href ng-click="pageLimit(50)">
-                        <span ng-show="pageInfo.pageLimit === 50" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 50" class="glyphicon glyphicon-invisible"></span>
-                        50</a>
-                    </li>
-                    <li><a href ng-click="pageLimit(75)">
-                        <span ng-show="pageInfo.pageLimit === 75" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 75" class="glyphicon glyphicon-invisible"></span>
-                        75</a>
-                    </li>
-                    <li><a href ng-click="pageLimit(100)">
-                        <span ng-show="pageInfo.pageLimit === 100" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 100" class="glyphicon glyphicon-invisible"></span>
-                        100</a>
-                    </li>
-                    <li><a href ng-click="pageLimit(200)">
-                        <span ng-show="pageInfo.pageLimit === 200" class="glyphicon glyphicon-ok"></span>
-                        <span ng-show="pageInfo.pageLimit !== 200" class="glyphicon glyphicon-invisible"></span>
-                        200</a>
+                    <li ng-repeat="limit in pageLimits"><a href ng-click="pageLimit(limit)">
+                        <span ng-show="pageInfo.pageLimit === limit" class="glyphicon glyphicon-ok"></span>
+                        <span ng-show="pageInfo.pageLimit !== limit" class="glyphicon glyphicon-invisible"></span>
+                        {{ limit }}</a>
                     </li>
                 </ul>
             </span>

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -38,7 +38,7 @@
                         pageInfo.pageLimit !== 50 &&
                         pageInfo.pageLimit !== 75 &&
                         pageInfo.pageLimit !== 100 &&
-                        pageInfo.pageLimit !== 200"><a href ng-click="pageLimit(pageInfo.pageLimit)">
+                        pageInfo.pageLimit !== 200"><a id="custom-page-size" href ng-click="pageLimit(pageInfo.pageLimit)">
                         <span ng-show="true" class="glyphicon glyphicon-ok"></span>
                         <span ng-show="false" class="glyphicon glyphicon-invisible"></span>
                         {{ pageInfo.pageLimit }} (Custom)</a>

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -57,7 +57,7 @@
             loading: true,
             previousButtonDisabled: true,
             nextButtonDisabled: true,
-            pageLimit: 10
+            pageLimit: 25
         };
 
     }])
@@ -289,7 +289,7 @@
             if (p_context.limit)
                 pageInfo.pageLimit = p_context.limit;
             else
-                pageInfo.pageLimit = 10;
+                pageInfo.pageLimit = 25;
             pageInfo.previousButtonDisabled = true;
             pageInfo.nextButtonDisabled = true;
 

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -70,6 +70,8 @@
 
         $scope.pageInfo = pageInfo;
 
+        $scope.pageLimits = [10, 25, 50, 75, 100, 200];
+
         $scope.pageLimit = function(limit) {
             pageInfo.pageLimit = limit;
             $scope.read();
@@ -286,10 +288,6 @@
 
             //$rootScope.location = $window.location.href;
             pageInfo.loading = true;
-            if (p_context.limit)
-                pageInfo.pageLimit = p_context.limit;
-            else
-                pageInfo.pageLimit = 25;
             pageInfo.previousButtonDisabled = true;
             pageInfo.nextButtonDisabled = true;
 
@@ -314,8 +312,12 @@
         ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
             $rootScope.reference = reference.contextualize.compact;
             $log.info("Reference:", $rootScope.reference);
-            if ($rootScope.reference.display.defaultPageSize)
+            if (p_context.limit)
+                pageInfo.pageLimit = p_context.limit;
+            else if ($rootScope.reference.display.defaultPageSize)
                 pageInfo.pageLimit = $rootScope.reference.display.defaultPageSize;
+            else
+                pageInfo.pageLimit = 25;
             recordsetModel.tableDisplayName = $rootScope.reference.displayname;
             recordsetModel.columns = $rootScope.reference.columns;
 

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -314,7 +314,8 @@
         ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
             $rootScope.reference = reference.contextualize.compact;
             $log.info("Reference:", $rootScope.reference);
-
+            if ($rootScope.reference.display.defaultPageSize)
+                pageInfo.pageLimit = $rootScope.reference.display.defaultPageSize;
             recordsetModel.tableDisplayName = $rootScope.reference.displayname;
             recordsetModel.columns = $rootScope.reference.columns;
 

--- a/test/e2e/data_setup/schema/product.json
+++ b/test/e2e/data_setup/schema/product.json
@@ -341,6 +341,11 @@
               ["product", "fk_booking_accommodation"],
               ["product", "fk_accommodation_image"]
           ]
+        },
+        "tag:isrd.isi.edu,2016:table-display": {
+          "compact": {
+            "page_size": 15
+          }
         }
       }
     },

--- a/test/e2e/specs/recordset/helpers.js
+++ b/test/e2e/specs/recordset/helpers.js
@@ -9,6 +9,9 @@ exports.testPresentation = function (tableParams) {
 	});
 
 	it("should use annotated page size", function() {
+		var EC = protractor.ExpectedConditions;
+		var e = element(by.id('custom-page-size'));
+		browser.wait(EC.presenceOf(e), 2000);
 		chaisePage.recordsetPage.getCustomPageSize().then(function(text) {
 			expect(text).toBe("15 (Custom)");
 		})

--- a/test/e2e/specs/recordset/helpers.js
+++ b/test/e2e/specs/recordset/helpers.js
@@ -8,6 +8,12 @@ exports.testPresentation = function (tableParams) {
 		});
 	});
 
+	it("should use annotated page size", function() {
+		chaisePage.recordsetPage.getCustomPageSize().then(function(text) {
+			expect(text).toBe("15 (Custom)");
+		})
+	});
+
 	it("should show correct table rows", function() {
 		chaisePage.recordsetPage.getRows().then(function(rows) {
 			expect(rows.length).toBe(3);

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -501,6 +501,10 @@ var recordsetPage = function() {
         return browser.executeScript("return $('#page-title').text();");
     };
 
+    this.getCustomPageSize = function() {
+        return browser.executeScript("return $('#custom-page-size').text().trim();");
+    };
+
     this.getColumns = function() {
         return element.all(by.css(".table-column-displayname"));
     };


### PR DESCRIPTION
PR for issue #578 
Use `tag:isrd.isi.edu,2016:table-display` `page_size` annotation as the default page size. If it's not specified, set default page size to 25.