### PR TITLE
Added support to specify chaise-config to be used for a spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "webdriver-manager": "x",
     "ermrest-data-utils": "x",
     "set-cookie-parser": "x",
-    "jsonfile": "x"
+    "jsonfile": "x",
+    "execSync": "x"
   }
 }

--- a/test/e2e/specs/recordedit/data-independent/add/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/add/protractor.conf.js
@@ -17,7 +17,7 @@ var config = pConfig.getConfig({
     setBaseUrl: function(browser, data) {
       browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId + "/" + data.schema.name;;
       return browser.params.url;
-    } 
+    }
 });
 
 exports.config = config;

--- a/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
@@ -17,7 +17,10 @@ var config = pConfig.getConfig({
     setBaseUrl: function(browser, data) {
       browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId  + "/" + data.schema.name;;
       return browser.params.url;
-    } 
+    },
+
+    // Specify chaiseConfigPath
+    chaiseConfigFilePath: 'test/e2e/specs/recordedit/data-independent/edit/chaise-config.js'
 });
 
 exports.config = config;

--- a/test/e2e/utils/protractor.configuration.js
+++ b/test/e2e/utils/protractor.configuration.js
@@ -47,6 +47,38 @@ exports.getConfig = function(options) {
       options.setBaseUrl(browser, data);
     } 
   }
+  var chaiseFilePath  = "chaise-config-sample.js";
+  if (typeof options.chaiseConfigFilePath === 'string') {
+    try {
+      var fs = require('fs');
+      fs.accessSync(process.env.PWD + "/" + options.chaiseConfigFilePath);
+      chaiseFilePath = options.chaiseConfigFilePath;
+    } catch (e) { 
+      console.log("Config file " + options.chaiseConfigFilePath  + " doesn't exists");
+    }
+  } 
+
+  var remoteChaiseDirPath = process.env.REMOTE_CHAISE_DIR_PATH;
+  if (typeof remoteChaiseDirPath !== 'string') {
+    var fsExtra = require('fs-extra');
+    try {
+      fsExtra.copySync(process.env.PWD + "/" + chaiseFilePath, process.env.PWD + "/chaise-config.js", { encoding: 'utf8' });
+      console.log("Copied file " + chaiseFilePath + " successfully to chaise-config.js \n");
+    } catch (err) {
+      console.error(err);
+      console.log("Unable to copy file " + chaiseFilePath + " to chaise-config.js \n");
+      process.exit(1);
+    }
+  } else {
+    var execSync = require('child_process').execSync;
+    var code = execSync('scp ' + chaiseFilePath + ' ' + remoteChaiseDirPath  + '/chaise-config.js');
+    console.log(code);
+    if (code == 0) console.log("Copied file " + chaiseFilePath + " successfully to chaise-config.js \n");
+    else {
+      console.log("Unable to copy file " + chaiseFilePath + " to chaise-config.js \n");
+      process.exit(1);
+    }
+  }
 
   dataSetup.parameterize(config, dateSetupOptions);
 


### PR DESCRIPTION
This **PR** addresses the issue #566 **Be able to test chaise with different chaise configs**.

To specify which config you want to use for your spec, set `chaiseConfigFilePath` in your **protractor.conf.js** file as follows.

```js

var pConfig = require('./../../../../utils/protractor.configuration.js');

var config = pConfig.getConfig({
  
    // Change this to your desired filed name
    configFileName: 'recordedit.dev.json',

    page: 'recordedit',
    setBaseUrl: function(browser, data) {
      browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId  + "/" + data.schema.name;;
      return browser.params.url;
    },

    // Specify chaiseConfigPath
    chaiseConfigFilePath: 'test/e2e/specs/recordedit/data-independent/edit/chaise-config.js'
});

exports.config = config;
```

You also need to run the [ssh-agent](http://mah.everybody.org/docs/ssh) in background as well as export a new environment variable that specifies your remote **dev.isrd** sshpath.

For example
```sh
# run ssh-agent in background
$ eval ssh-agent

# add your key to ssh-agent
$ ssh-add PATH/TO/KEY

# export REMOTE_CHAISE_DIR_PATH=USERNAME@HOST:public_html/chaise
$ export REMOTE_CHAISE_DIR_PATH=chirag@dev.isrd.isi.edu:public_html/chaise
```