### PR TITLE
Url routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ testrecordedit:
 
 #Rule to run viewer app tests
 .PHONY: testviewer
-testrecordedit:
+testviewer:
 	$(BIN)/protractor $(E2EDviewer)
 
 # Rule to make html

--- a/Makefile
+++ b/Makefile
@@ -438,6 +438,12 @@ testrecord:
 testrecordadd:
 	$(BIN)/protractor $(E2EDIrecordAdd)
 
+#Rule to run recordset app tests
+.PHONY: testrecordset
+testrecordset:
+	$(BIN)/protractor $(E2EDrecordset)
+
+
 .PHONY: testrecordedit
 testrecordedit:
 	$(BIN)/protractor $(E2EDIrecordEdit)

--- a/common/utils.js
+++ b/common/utils.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.utils', [])
 
-    .factory('UriUtils', ['$injector', '$window', 'parsedFilter', '$rootScope', '$window', function($injector, $window, ParsedFilter, $rootScope, $window) {
+    .factory('UriUtils', ['$injector', '$window', 'parsedFilter', '$rootScope', function($injector, $window, ParsedFilter, $rootScope) {
 
         /**
          * @function

--- a/common/utils.js
+++ b/common/utils.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.utils', [])
 
-    .factory('UriUtils', ['$injector', '$window', 'parsedFilter', function($injector, $window, ParsedFilter) {
+    .factory('UriUtils', ['$injector', '$window', 'parsedFilter', '$rootScope', '$window', function($injector, $window, ParsedFilter, $rootScope, $window) {
 
         /**
          * @function
@@ -365,12 +365,40 @@
             }
         }
 
+        /**
+         * 
+         * This code handles address bar changes
+         * Normally when user changes the url in the address bar,
+         * nothing happens.
+         *
+         * This code listens when address bar is changes outside the code,
+         * and redirects to the new location.
+         *
+         * Whenever app updates the url (no reloading and no history stack),
+         * it saves the location in $rootScope.location.
+         * When address bar is changed, this code compares the address bar location
+         * with the last save recordset location. If it's the same, the change of url was
+         * done internally, do not refresh page. If not, the change was done manually
+         * outside recordset, refresh page.
+         *
+         */
+        function setLocationChangeHandling() {
+            $window.onhashchange = function() {
+                // when address bar changes by user
+                if ($window.location.href !== $rootScope.location) {
+                    location.reload();
+                }
+            };
+        }
+
+
         return {
             chaiseURItoErmrestURI: chaiseURItoErmrestURI,
             fixedEncodeURIComponent: fixedEncodeURIComponent,
             parseURLFragment: parseURLFragment,
             setOrigin: setOrigin,
-            parsedFilterToERMrestFilter: parsedFilterToERMrestFilter
+            parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
+            setLocationChangeHandling: setLocationChangeHandling
         }
     }])
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -121,5 +121,30 @@
         } catch (exception) {
             ErrorService.errorPopup(exception.message, exception.code, "home page");
         }
+
+        /**
+         * Do Not Delete
+         *
+         * This code handles address bar changes
+         * Normally when user changes the url in the address bar,
+         * nothing happens.
+         *
+         * This code listens when address bar is changes outside the code,
+         * and redirects to the new location.
+         *
+         * Whenever recordset updates the url (no reloading and no history stack),
+         * it saves the location in $rootScope.location.
+         * When address bar is changed, this code compares the address bar location
+         * with the last save recordset location. If it's the same, the change of url was
+         * done internally, do not refresh page. If not, the change was done manually
+         * outside recordset, refresh page.
+         *
+         */
+        $window.onhashchange = function() {
+            // when address bar changes by user
+            if ($window.location.href !== $rootScope.location) {
+                location.reload();
+            }
+        };
     }]);
 })();

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -123,16 +123,6 @@
         }
 
         /**
-         * Do Not Delete
-         *
-         * This code handles address bar changes
-         * Normally when user changes the url in the address bar,
-         * nothing happens.
-         *
-         * This code listens when address bar is changes outside the code,
-         * and redirects to the new location.
-         *
-         * Whenever recordset updates the url (no reloading and no history stack),
          * it saves the location in $rootScope.location.
          * When address bar is changed, this code compares the address bar location
          * with the last save recordset location. If it's the same, the change of url was
@@ -140,11 +130,6 @@
          * outside recordset, refresh page.
          *
          */
-        $window.onhashchange = function() {
-            // when address bar changes by user
-            if ($window.location.href !== $rootScope.location) {
-                location.reload();
-            }
-        };
+        UriUtils.setLocationChangeHandling();
     }]);
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -32,7 +32,7 @@
         console.log('Context:',context);
     }])
 
-    .run(['headInjector', 'context', 'ERMrest', 'recordEditModel', 'AlertsService', 'ErrorService', 'Session', 'UriUtils', '$log', '$uibModal', '$window', function runApp(headInjector, context, ERMrest, recordEditModel, AlertsService, ErrorService, Session, UriUtils, $log, $uibModal, $window) {
+    .run(['headInjector', 'context', 'ERMrest', 'recordEditModel', 'AlertsService', 'ErrorService', 'Session','$rootScope', 'UriUtils', '$log', '$uibModal', '$window', function runApp(headInjector, context, ERMrest, recordEditModel, AlertsService, ErrorService, Session, $rootScope, UriUtils, $log, $uibModal, $window) {
         headInjector.addTitle();
         headInjector.addCustomCSS();
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -198,20 +198,16 @@
         }).catch(function(exception) {
             ErrorService.catchAll(exception);
         });
+
+        /**
+         * Whenever recordedit updates the url (no reloading and no history stack),
+         * it saves the location in $rootScope.location.
+         * When address bar is changed, this code compares the address bar location
+         * with the last save recordset location. If it's the same, the change of url was
+         * done internally, do not refresh page. If not, the change was done manually
+         * outside recordset, refresh page.
+         */
+        UriUtils.setLocationChangeHandling();
     }]);
 
-    // Refresh the page when the window's hash changes. Needed because Angular
-    // normally doesn't refresh page when hash changes.
-    window.onhashchange = function() {
-        if (window.location.hash != '#undefined') {
-            location.reload();
-        } else {
-            history.replaceState("", document.title, window.location.pathname);
-            location.reload();
-        }
-        function goBack() {
-            window.location.hash = window.location.lasthash[window.location.lasthash.length-1];
-            window.location.lasthash.pop();
-        }
-    }
 })();

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -337,31 +337,14 @@
             });
 
         /**
-         * Do Not Delete
-         *
-         * This code handles address bar changes
-         * Normally when user changes the url in the address bar,
-         * nothing happens.
-         *
-         * This code listens when address bar is changes outside the code,
-         * and redirects to the new location.
-         *
          * Whenever recordset updates the url (no reloading and no history stack),
          * it saves the location in $rootScope.location.
          * When address bar is changed, this code compares the address bar location
          * with the last save recordset location. If it's the same, the change of url was
          * done internally, do not refresh page. If not, the change was done manually
          * outside recordset, refresh page.
-         *
          */
-        $window.onhashchange = function() {
-            // when address bar changes by user
-            if ($window.location.href !== $rootScope.location) {
-                location.reload();
-            }
-        };
-
-
+        UriUtils.setLocationChangeHandling();
     }]);
 
 /* end recordset */

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -31,6 +31,14 @@
         'ui.bootstrap',
         'ngSanitize'])
 
+    .config(['$provide', function ($provide){
+        $provide.decorator('$browser', ['$delegate', function ($delegate) {
+            $delegate.onUrlChange = function () {};
+            $delegate.url = function () { return ""};
+            return $delegate;
+        }]);
+    }])
+
     // Register the 'context' object which can be accessed by config and other
     // services.
     .constant('context', {

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -31,14 +31,6 @@
         'ui.bootstrap',
         'ngSanitize'])
 
-    .config(['$provide', function ($provide){
-        $provide.decorator('$browser', ['$delegate', function ($delegate) {
-            $delegate.onUrlChange = function () {};
-            $delegate.url = function () { return ""};
-            return $delegate;
-        }]);
-    }])
-
     // Register the 'context' object which can be accessed by config and other
     // services.
     .constant('context', {
@@ -48,6 +40,8 @@
         schemaName: null,
         tableName: null
     })
+
+
 
     // Register the 'recordsetModel' object, which can be accessed by other
     // services, but cannot be access by providers (and config, apparently).
@@ -360,12 +354,12 @@
          * outside recordset, refresh page.
          *
          */
-        //$window.onhashchange = function() {
-        //    // when address bar changes by user
-        //    if ($window.location.href !== $rootScope.location) {
-        //        location.reload();
-        //    }
-        //};
+        $window.onhashchange = function() {
+            // when address bar changes by user
+            if ($window.location.href !== $rootScope.location) {
+                location.reload();
+            }
+        };
 
 
     }]);

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -126,7 +126,7 @@
                 // update the address bar
                 // page does not reload
                 $window.location.replace($scope.permalink());
-                //$rootScope.location = $window.location.href;
+                $rootScope.location = $window.location.href;
 
             }, function error(response) {
                 $log.warn(response);
@@ -193,7 +193,7 @@
                     // update the address bar without adding to history stack
                     // page does not reload
                     $window.location.replace($scope.permalink());
-                    //$rootScope.location = $window.location.href;
+                    $rootScope.location = $window.location.href;
 
                 }, function error(response) {
                     $log.warn(response);
@@ -240,7 +240,7 @@
                     // update the address bar
                     // page does not reload
                     $window.location.replace($scope.permalink());
-                    //$rootScope.location = $window.location.href;
+                    $rootScope.location = $window.location.href;
 
                 }, function error(response) {
                     $log.warn(response);
@@ -276,7 +276,7 @@
             // parse the URL
             var p_context = UriUtils.parseURLFragment($window.location);
 
-            //$rootScope.location = $window.location.href;
+            $rootScope.location = $window.location.href;
             pageInfo.loading = true;
             pageInfo.previousButtonDisabled = true;
             pageInfo.nextButtonDisabled = true;

--- a/test/e2e/specs/detailed/data-dependent/00-search.result.column.spec.js
+++ b/test/e2e/specs/detailed/data-dependent/00-search.result.column.spec.js
@@ -5,6 +5,7 @@ describe('Search result columns,', function () {
     var EC = protractor.ExpectedConditions;
     var timeout  = 10000;
     beforeAll(function (done) {
+        browser.ignoreSynchronization = true;
         browser.get('');
         var sidebar = element(by.id('sidebar'));
         browser.ignoreSynchronization = true;

--- a/test/e2e/specs/detailed/data-dependent/01-result.detail.page.spec.js
+++ b/test/e2e/specs/detailed/data-dependent/01-result.detail.page.spec.js
@@ -4,6 +4,7 @@ describe('Search result detail page,', function () {
     var waitTimeAfterClickingEditFilter = 10000;
     var EC = protractor.ExpectedConditions;
     beforeEach(function (done) {
+        browser.ignoreSynchronization = true;
         browser.get('');
         var sidebar = element(by.id('sidebar'));
         browser.wait(EC.visibilityOf(sidebar), 10000).then(function () {

--- a/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
@@ -2,6 +2,7 @@ describe('Navbar ', function() {
     var navbar, menu, chaiseConfig, EC = protractor.ExpectedConditions;
 
     beforeAll(function (done) {
+        browser.ignoreSynchronization=true;
         browser.get(browser.params.url || "");
         navbar = element(by.id('mainnav'));
         menu = element(by.id('navbar-menu'));

--- a/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
+++ b/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
@@ -18,6 +18,7 @@ describe('View existing record,', function() {
 					tupleParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+                    browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
 					browser.sleep(2000);

--- a/test/e2e/specs/record/data-dependent/01-record.editbutton.spec.js
+++ b/test/e2e/specs/record/data-dependent/01-record.editbutton.spec.js
@@ -18,6 +18,7 @@ describe('View existing record,', function() {
 					tupleParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+					browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
 					browser.sleep(2000);

--- a/test/e2e/specs/record/data-dependent/02-record.createbutton.spec.js
+++ b/test/e2e/specs/record/data-dependent/02-record.createbutton.spec.js
@@ -18,6 +18,7 @@ describe('View existing record,', function() {
 					tupleParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+					browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
 					browser.sleep(2000);

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -197,7 +197,7 @@ exports.testEditButton = function () {
         var EC = protractor.ExpectedConditions,
             editButton = chaisePage.recordPage.getEditRecordButton();
 
-        browser.wait(EC.elementToBeClickable(editButton), 10000);
+        //browser.wait(EC.elementToBeClickable(editButton), 10000);
 
         editButton.click().then(function() {
             return browser.driver.getCurrentUrl();
@@ -212,7 +212,7 @@ exports.testCreateButton = function () {
         var EC = protractor.ExpectedConditions,
             createButton = chaisePage.recordPage.getCreateRecordButton();
 
-        browser.wait(EC.elementToBeClickable(createButton), 10000);
+        //browser.wait(EC.elementToBeClickable(createButton), 10000);
 
         createButton.click().then(function() {
             return browser.driver.getCurrentUrl();

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -197,7 +197,7 @@ exports.testEditButton = function () {
         var EC = protractor.ExpectedConditions,
             editButton = chaisePage.recordPage.getEditRecordButton();
 
-        //browser.wait(EC.elementToBeClickable(editButton), 10000);
+        browser.wait(EC.elementToBeClickable(editButton), 10000);
 
         editButton.click().then(function() {
             return browser.driver.getCurrentUrl();
@@ -212,7 +212,7 @@ exports.testCreateButton = function () {
         var EC = protractor.ExpectedConditions,
             createButton = chaisePage.recordPage.getCreateRecordButton();
 
-        //browser.wait(EC.elementToBeClickable(createButton), 10000);
+        browser.wait(EC.elementToBeClickable(createButton), 10000);
 
         createButton.click().then(function() {
             return browser.driver.getCurrentUrl();

--- a/test/e2e/specs/record/related-table/03-record.related-table-link.spec.js
+++ b/test/e2e/specs/record/related-table/03-record.related-table-link.spec.js
@@ -18,6 +18,7 @@ describe('View existing record,', function() {
 					tupleParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+					browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
 					browser.sleep(2000);

--- a/test/e2e/specs/recordedit/data-independent/add/00-record.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-record.add.spec.js
@@ -14,6 +14,7 @@ describe('Record Add', function() {
     			+ tableParams.records + " record(s) for table " + tableParams.table_name + ",", function() {
 
 				beforeAll(function () {
+					browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tableParams.table_name);
 					table = browser.params.defaultSchema.content.tables[tableParams.table_name];
 					browser.sleep(3000);

--- a/test/e2e/specs/recordedit/data-independent/edit/00-record.edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/00-record.edit.spec.js
@@ -18,6 +18,7 @@ describe('Edit existing record,', function() {
 					tableParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+					browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tableParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tableParams.table_name];
 					

--- a/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
+++ b/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
@@ -18,6 +18,7 @@ describe('View recordset,', function() {
                     tupleParams.keys.forEach(function(key) {
                         keys.push(key.name + key.operator + key.value);
                     });
+                    browser.ignoreSynchronization=true;
                     browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&") + "@sort(" + tupleParams.sortby + ")");
                     browser.sleep(2000);
                 });

--- a/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
+++ b/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
@@ -18,6 +18,7 @@ describe('Viewer app', function() {
 					tupleParams.keys.forEach(function(key) {
 						keys.push(key.name + key.operator + key.value);
 					});
+                    browser.ignoreSynchronization=true;
 					browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
 					table = browser.params.defaultSchema.content.tables[tupleParams.table_name];
 					browser.sleep(2000);


### PR DESCRIPTION
Fixes issue #581  by enabling the location hash change handling. 

To avoid any interference with Angular rotuing, the test-cases should specify following statement before doing a `browser.get`.

```js
browser.ignoreSynchronization = true;
```