### PR TITLE
Fixed test failures in record app tests

### DIFF
--- a/record/record.app.js
+++ b/record/record.app.js
@@ -20,7 +20,7 @@
             loading: true,
             previousButtonDisabled: true,
             nextButtonDisabled: true,
-            pageLimit: 25
+            defaultPageLimit: 25
         };
     }])
 
@@ -74,7 +74,10 @@
 
                         if ($rootScope.relatedReferences[i].display.defaultPageSize) {
                             pageInfo.pageLimit = $rootScope.relatedReferences[i].display.defaultPageSize;
+                        } else {
+                            pageInfo.pageLimit = pageInfo.defaultPageLimit;
                         }
+
                         (function(i) {
                             $rootScope.relatedReferences[i].read(pageInfo.pageLimit).then(function (page) {
 
@@ -132,7 +135,7 @@
          */
         UriUtils.setLocationChangeHandling();
 
-        // This is to allow the dropdown button to open at the top/bottom depending on the space available 
+        // This is to allow the dropdown button to open at the top/bottom depending on the space available
         UiUtils.setBootstrapDropdownButtonBehavior();
     }]);
 })();

--- a/test/e2e/data_setup/config/record.dev.json
+++ b/test/e2e/data_setup/config/record.dev.json
@@ -8,7 +8,7 @@
                 ]
             },
             "schema": {
-                "name": "product",
+                "name": "product-record",
                 "createNew": true,
                 "path": "test/e2e/data_setup/schema/product-record.json"
             },
@@ -30,8 +30,8 @@
                 "keys" : [{ "name": "id", "value": "2002", "operator" : "="}],
                 "title": "Sherathon Hotel",
                 "subTitle" : "Accommodations",
-                "tables_order" : ["- booking (2)", "- file (2)"],
-                "related_table_name_with_page_size_annotation" : "file",
+                "tables_order" : ["- booking (2)", "- accommodation_image (2)"],
+                "related_table_name_with_page_size_annotation" : "accommodation_image",
                 "page_size" : 2,
                 "related_tables" : [
                     {
@@ -43,7 +43,7 @@
                         ]
                     },
                     {
-                        "title" : "file",
+                        "title" : "accommodation_image",
                         "columns" : [ "id", "filename", "uri", "content_type", "bytes", "timestamp", "image_width", "image_height", "preview" ],
                         "data" : [
                             { "id" : 3005, "filename" : "Four Points Sherathon 1", "uri" : "http://images.trvl-media.com/hotels/1000000/30000/28200/28110/28110_190_z.jpg", "content_type" : "image/jpeg", "bytes" : 0, "timestamp" : "2016-01-18T00:00:00-08:00", "image_width" : null, "image_height" : null, "preview" : null },

--- a/test/e2e/data_setup/config/related-table-link.dev.json
+++ b/test/e2e/data_setup/config/related-table-link.dev.json
@@ -8,7 +8,7 @@
                 ]
             },
             "schema": {
-                "name": "product",
+                "name": "product-unordered-related-tables",
                 "createNew": true,
                 "path": "test/e2e/data_setup/schema/product-unordered-related-tables.json"
             },
@@ -28,10 +28,10 @@
             "tuples" : [{
                 "table_name" : "accommodation",
                 "related_table_name_with_more_results" : "booking",
-                "related_table_name_with_link_in_table" : "file",
-                "related_table_name_with_page_size_annotation" : "file",
+                "related_table_name_with_link_in_table" : "accommodation_image",
+                "related_table_name_with_page_size_annotation" : "accommodation_image",
                 "keys" : [{ "name": "id", "value": "2004", "operator": "=" }],
-                "tables_order" : ["- booking (6)", "- file (2)", "- media (1)"],
+                "tables_order" : [ "- accommodation_image (2)", "- booking (6)", "- media (1)" ],
                 "booking_count" : 6,
                 "page_size" : 2
             }]

--- a/test/e2e/data_setup/schema/product-record.json
+++ b/test/e2e/data_setup/schema/product-record.json
@@ -19,7 +19,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "category"
             }
           ],
@@ -27,7 +27,7 @@
           "referenced_columns": [
             {
               "table_name": "category",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "term"
             }
           ]
@@ -37,7 +37,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "thumbnail"
             }
           ],
@@ -47,7 +47,7 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
@@ -57,7 +57,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "cover"
             }
           ],
@@ -67,14 +67,14 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "accommodation",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -337,9 +337,9 @@
 
         "tag:isrd.isi.edu,2016:visible-foreign-keys" : {
           "*" : [
-              ["product", "fk_booking_accommodation"],
-              ["product", "fk_accommodation_image"],
-              ["product", "fk_media_accommodation"]
+              ["product-record", "fk_booking_accommodation"],
+              ["product-record", "fk_accommodation_image"],
+              ["product-record", "fk_media_accommodation"]
           ]
         }
       }
@@ -360,12 +360,12 @@
       ],
       "foreign_keys": [
         {
-          "names" : [["product", "fk_booking_accommodation"]],
+          "names" : [["product-record", "fk_booking_accommodation"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "booking",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "accommodation_id"
             }
           ],
@@ -373,14 +373,14 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "booking",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -461,7 +461,7 @@
       "entityCount": 0,
       "foreign_keys": [],
       "table_name": "file",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -615,12 +615,12 @@
       "entityCount": 0,
       "foreign_keys": [
         {
-          "names" : [["product", "fk_accommodation_image"]],
+          "names" : [["product-record", "fk_accommodation_image"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "accommodation_image",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "accommodation_id"
             }
           ],
@@ -628,7 +628,7 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
@@ -638,7 +638,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation_image",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "image_id"
             }
           ],
@@ -646,14 +646,14 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "accommodation_image",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -718,7 +718,7 @@
       "entityCount": 0,
       "foreign_keys": [],
       "table_name": "category",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -772,12 +772,12 @@
       ],
       "foreign_keys": [
         {
-          "names" : [["product", "fk_media_accommodation"]],
+          "names" : [["product-record", "fk_media_accommodation"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "media",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "accommodation_id"
             }
           ],
@@ -785,14 +785,14 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-record",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "media",
-      "schema_name": "product",
+      "schema_name": "product-record",
       "column_definitions": [
         {
           "comment": null,
@@ -843,5 +843,5 @@
       "name": "accommodation"
     }
   },
-  "schema_name": "product"
+  "schema_name": "product-record"
 }

--- a/test/e2e/data_setup/schema/product-unordered-related-tables.json
+++ b/test/e2e/data_setup/schema/product-unordered-related-tables.json
@@ -19,7 +19,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "category"
             }
           ],
@@ -27,7 +27,7 @@
           "referenced_columns": [
             {
               "table_name": "category",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "term"
             }
           ]
@@ -37,7 +37,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "thumbnail"
             }
           ],
@@ -47,7 +47,7 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
@@ -57,7 +57,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "cover"
             }
           ],
@@ -67,14 +67,14 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "accommodation",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -352,12 +352,12 @@
       ],
       "foreign_keys": [
         {
-          "names" : [["product", "fk_booking_accommodation"]],
+          "names" : [["product-unordered-related-tables", "fk_booking_accommodation"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "booking",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "accommodation_id"
             }
           ],
@@ -365,14 +365,14 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "booking",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -453,7 +453,7 @@
       "entityCount": 0,
       "foreign_keys": [],
       "table_name": "file",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -607,12 +607,12 @@
       "entityCount": 0,
       "foreign_keys": [
         {
-          "names" : [["product", "fk_accommodation_image"]],
+          "names" : [["product-unordered-related-tables", "fk_accommodation_image"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "accommodation_image",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "accommodation_id"
             }
           ],
@@ -620,7 +620,7 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
@@ -630,7 +630,7 @@
           "foreign_key_columns": [
             {
               "table_name": "accommodation_image",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "image_id"
             }
           ],
@@ -638,14 +638,14 @@
           "referenced_columns": [
             {
               "table_name": "file",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "accommodation_image",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -710,7 +710,7 @@
       "entityCount": 0,
       "foreign_keys": [],
       "table_name": "category",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -764,12 +764,12 @@
       ],
       "foreign_keys": [
         {
-          "names" : [["product", "fk_media_accommodation"]],
+          "names" : [["product-unordered-related-tables", "fk_media_accommodation"]],
           "comment": null,
           "foreign_key_columns": [
             {
               "table_name": "media",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "accommodation_id"
             }
           ],
@@ -777,14 +777,14 @@
           "referenced_columns": [
             {
               "table_name": "accommodation",
-              "schema_name": "product",
+              "schema_name": "product-unordered-related-tables",
               "column_name": "id"
             }
           ]
         }
       ],
       "table_name": "media",
-      "schema_name": "product",
+      "schema_name": "product-unordered-related-tables",
       "column_definitions": [
         {
           "comment": null,
@@ -835,5 +835,5 @@
       "name": "accommodation"
     }
   },
-  "schema_name": "product"
+  "schema_name": "product-unordered-related-tables"
 }


### PR DESCRIPTION
Fixed test failures in record app tests after changes to associative table displaynames. This uncovered a bug in record where if the default page size was overridden because of an annotation, it would always use that value for subsequent tables without the annotation.