### PR TITLE
Distinguish row click and html link in record table

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -29,7 +29,6 @@
                     var tuple = scope.vm.page.tuples[index];
                     var t_path = tuple.reference.location.compactPath;
                     var chaiseURL = $window.location.href.replace($window.location.hash, '');
-                    var reload = (chaiseURL.indexOf("/record/") !== -1);
                     var apps = ["recordset", "record", "record-two"]; // TODO add each app that uses record-table directive
 
                     apps.forEach(function(element, index, array) {
@@ -39,11 +38,7 @@
 
                     location.assign(path);
 
-                    // forcing a reload when linking from record to record, which does not automatically reload
-                    // this is an angular issue (if change path AFTER hash, page does not reload)
-                    if (reload)
-                        location.reload();
-                }
+                };
             }
         };
     }]);

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -16,7 +16,7 @@
         <tbody>
             <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="gotoRowLink($index)" ng-style="{'cursor': 'pointer'}">
                 <td ng-repeat="val in row track by $index" ng-switch="val.isHTML">
-                    <span ng-switch-when="true" ng-bind-html="val.value"></span>
+                    <span ng-switch-when="true" ng-bind-html="val.value" ng-click="$event.stopPropagation()" ng-style="{'cursor': 'auto'}"></span>
                     <span ng-switch-default>{{val.value}}</span>
                 </td>
             </tr>


### PR DESCRIPTION
PR for #646 

Two types of click handling in record table: 1) when click on a row, redirect to the record app 2) when click on a hyperlink in the table, redirect to the link. If both redirect to html page, this is fine because (2) takes over. If hyperlink is a downloadable file, both action will fire. This is not desire. This PR fixes this problem. If table cell content is HTML, row click is disabled.