### PR TITLE
Disable Sort for PseudoColumns

### DIFF
--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -4,10 +4,10 @@
         <thead class="table-heading">
             <tr>
                 <th nowrap ng-repeat="col in vm.columns track by $index">
-                    <span class="table-column-displayname" ng-class="{'coltooltiplabel': col.comment}" title="{{col.comment}}" ng-click="sortby({colname: col.name})">{{::col.displayname}}</span>
-                    <span ng-show="vm.sortby==col.name && vm.sortOrder=='asc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-asc" ng-style="{'cursor': 'pointer'}"></span>
-                    <span ng-show="vm.sortby==col.name && vm.sortOrder=='desc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-desc" ng-style="{'cursor': 'pointer'}"></span>
-                    <span ng-show="vm.sortby!==col.name" class="fa fa-fw fa-sort" ng-click="sortby({colname: col.name})" ng-style="{'cursor': 'pointer'}"></span>
+                    <span class="table-column-displayname" ng-class="{'coltooltiplabel': col.comment}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby({colname: col.name})">{{::col.displayname}}</span>
+                    <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='asc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-asc" ng-style="{'cursor': 'pointer'}"></span>
+                    <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='desc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-desc" ng-style="{'cursor': 'pointer'}"></span>
+                    <span ng-show="!col.isPseudo && vm.sortby!==col.name" class="fa fa-fw fa-sort" ng-click="sortby({colname: col.name})" ng-style="{'cursor': 'pointer'}"></span>
                 </th>
             </tr>
         </thead>


### PR DESCRIPTION
Since `reference.columns` is going to return a list of `Column` and `PseudoColumn`s, the sort functionality in recordset will break. Because we are using the column.name for sorting and in case of `PseudoColumn` the returned value is not valid.

This PR will disable the sort buttons for `PseudoColumn`s until we find a better solution for it.