### PR TITLE
Recordedit: Add 'create' button to foreign key columns

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -527,3 +527,7 @@ tbody{
 .markdown-container .embed-block {
     margin: 10px 10px 10px 0px; 
 }
+
+.input-timestamptz {
+    min-width: 112px;
+}

--- a/common/table.js
+++ b/common/table.js
@@ -3,26 +3,107 @@
 
     angular.module('chaise.record.table', [])
 
-    .directive('recordTable', ['$window', 'UriUtils', 'AlertsService', function($window, UriUtils, AlertsService) {
+    /**
+     * Ways to use recordTable directive:
+     *
+     * 1. Table only, default row click action (go to record)
+     *    <record-table vm="vm" default-row-linking="true"></record-table>
+     *
+     * 2. Table only, customized row click function
+     *    <record-table vm="vm" on-row-click="gotoRowLink(tuple)"></record-table>
+     *
+     * 3. Table with search, page size, previous/next, default row click action (go to record)
+     *    <recordset vm="vm" default-row-linking="true"></recordset>
+     *
+     * 4. Table with search, page size, previous/next, customized row click function
+     *    <recordset vm="vm" on-row-click="gotoRowLink(tuple)"></recordset>
+     *
+     *
+     * vm is the table model, should have this format:
+     *
+     *      { hasLoaded,    // data is ready, loading icon should not be visible
+     *        reference,    // reference object
+     *        tableDisplayName,
+     *        columns,      // array of Column objects
+     *        sortby,       // column name, user selected or null
+     *        sortOrder,    // asc (default) or desc
+     *        page,         // current page object
+     *        pageLimit,    // number of rows per page
+     *        rowValues,    // array of rows values, each value has this structure {isHTML:boolean, value:value}
+     *        search: null  // search term
+     *       }
+     *
+     *
+     * Handle recordset/recordTable events in your controller:
+     *
+     * 1. recordset-update - data model has been updated
+     *    your app may want to update address bar, permalink etc.
+     *
+     *      $scope.$on('recordset-update', function() {
+     *          $window.scrollTo(0, 0);
+     *          $window.location.replace($scope.permalink());
+     *          $rootScope.location = $window.location.href;
+     *      });
+     *
+     * 2. error - an exception was caught
+     *
+     *      $scope.$on('error', function(event, exception) {
+     *          $log.warn(exception);
+     *          ErrorService.catchAll(exception);
+     *      });
+     */
+    .factory('recordTableUtils', ['DataUtils', function(DataUtils) {
+        function read(scope) {
+            scope.vm.hasLoaded = false;
+
+            scope.vm.reference.read(scope.vm.pageLimit).then(function (page) {
+
+                scope.vm.page = page;
+                scope.vm.rowValues = DataUtils.getRowValuesFromPage(page);
+                scope.vm.hasLoaded = true;
+
+                // tell parent controller data updated
+                scope.$emit('recordset-update');
+
+            }, function error(response) {
+                scope.vm.hasLoaded = true;
+                scope.$emit('error', response);
+
+            })
+        }
+
+        return {
+            read: read
+        }
+    }])
+        
+    .directive('recordTable', ['AlertsService', 'recordTableUtils', function(AlertsService, recordTableUtils) {
 
         return {
             restrict: 'E',
             templateUrl: '../common/templates/table.html',
             scope: {
-                // vm is the table model, should have this format
-                // { columns: array of Column objects,
-                //   sortby: column name/null,
-                //   sortOrder: asc, dsc or null,
-                //   rowValues: array of rows values, each value has this structure {isHTML:boolean, value:value
-                // }
                 vm: '=',
-                toggleSortOrder: '&',
-                sortby: '&'
+                defaultRowLinking: "=?", // set to true to use default row click action (go to record)
+                onRowClickBind: '=?',    // used by the recordset template to pass down on click function
+                onRowClick: '&?'      // set row click function if not using default
             },
             link: function (scope, elem, attr) {
 
-                scope.sortByColumn = function (colname) {
-                    scope.sortby({ colname: colname });
+                scope.sortby = function(column) {
+                    if (scope.vm.sortby !== column) {
+                        scope.vm.sortby = column;
+                        scope.vm.sortOrder = "asc";
+                        scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
+                        recordTableUtils.read(scope);
+                    }
+
+                };
+
+                scope.toggleSortOrder = function () {
+                    scope.vm.sortOrder = (scope.vm.sortOrder === 'asc' ? scope.vm.sortOrder = 'desc' : scope.vm.sortOrder = 'asc');
+                    scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
+                    recordTableUtils.read(scope);
                 };
 
                 scope.gotoRowLink = function(index) {
@@ -34,6 +115,80 @@
                         AlertsService.addAlert({type: "error", message: "Application Error: row linking undefined for " + tuple.reference.location.compactPath});
                     }
                 };
+
+                scope.rowClickAction = function(index) {
+                    var args = {"tuple":scope.vm.page.tuples[index]};
+                    if (scope.defaultRowLinking !== undefined && scope.defaultRowLinking === true) {
+                        scope.gotoRowLink(index);
+                    } else if (scope.onRowClickBind) {
+                        scope.onRowClickBind(args);
+                    } else if (scope.onRowClick) {
+                        scope.onRowClick(args);
+                    }
+                }
+
+            }
+        };
+    }])
+
+    .directive('recordset', ['recordTableUtils', function(recordTableUtils) {
+
+        return {
+            restrict: 'E',
+            templateUrl: '../common/templates/recordset.html',
+            scope: {
+                vm: '=',
+                defaultRowLinking: "=?", // set true to use default row click action (link to record)
+                onRowClick: '&?'         // set row click function if not using default
+            },
+            link: function (scope, elem, attr) {
+
+                scope.pageLimits = [10, 25, 50, 75, 100, 200];
+
+                scope.setPageLimit = function(limit) {
+                    scope.vm.pageLimit = limit;
+                    recordTableUtils.read(scope);
+                };
+
+                scope.before = function() {
+
+                    var previous = scope.vm.page.previous;
+                    if (previous) {
+
+                        scope.vm.reference = previous;
+                        recordTableUtils.read(scope);
+
+                    }
+                };
+
+                scope.after = function() {
+
+                    var next = scope.vm.page.next;
+                    if (next) {
+
+                        scope.vm.reference = next;
+                        recordTableUtils.read(scope);
+                    }
+
+                };
+
+                scope.search = function(term) {
+
+                    if (term)
+                        term = term.trim();
+
+                    scope.vm.search = term;
+                    scope.vm.reference = scope.vm.reference.search(term); // this will clear previous search first
+                    recordTableUtils.read(scope);
+                };
+
+                scope.clearSearch = function() {
+                    if (scope.vm.reference.location.searchTerm)
+                        scope.search();
+
+                    scope.vm.search = null;
+                };
+
             }
         };
     }]);

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -1,0 +1,53 @@
+<div class="row" style="margin-bottom: 10px;">
+    <div class="col-lg-4">
+        <!-- search box -->
+        <div class="input-group">
+            <input type="text"
+                   id="search-input"
+                   ng-model="vm.search"
+                   class="form-control"
+                   on-enter="search(vm.search)"
+                   placeholder="search {{vm.tableDisplayName}}">
+                <span class="input-group-btn">
+                    <button id="search-submit" class="btn btn-primary" ng-click="search(vm.search)" role="button">
+                        &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
+                    </button>
+                    <button id="search-clear" class="btn btn-primary" ng-disabled="!vm.reference.location.searchTerm" ng-click="clearSearch()" type="button">Reset</button>
+                </span>
+        </div>
+    </div>
+    <div class="col-lg-3 col-md-offset-5" align="right">
+        <!-- pagination -->
+        <div>
+            <span class="dropdown" style="margin-left: 5px">
+                <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">Items per page
+                    <span class="caret"></span></button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                    <li ng-if="pageLimits.indexOf(vm.pageLimit) === -1"><a id="custom-page-size" href ng-click="setPageLimit(vm.pageLimit)">
+                        <span class="glyphicon glyphicon-ok"></span>
+                        {{ vm.pageLimit }} (Custom)</a>
+                    </li>
+                    <li ng-repeat="limit in pageLimits"><a href ng-click="setPageLimit(limit)">
+                        <span class="glyphicon" ng-class="vm.pageLimit === limit ? 'glyphicon-ok' : 'glyphicon-invisible'"></span>
+                        {{ limit }}</a>
+                    </li>
+                </ul>
+            </span>
+        </div>
+    </div>
+</div>
+
+<!-- record table -->
+<div ng-if="vm.rowValues.length > 0">
+    <record-table id="rs-{{vm.tableDisplayName}}" vm="vm" default-row-linking="defaultRowLinking" on-row-click-bind="onRowClick"></record-table>
+</div>
+
+<!-- bottom pagination -->
+<div class="pager">
+    <button type="button" class="btn btn-primary btn-sm" ng-click="before()" ng-disabled="!vm.hasLoaded || !vm.page.hasPrevious">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+    </button>
+    <button type="button" class="btn btn-primary btn-sm" ng-click="after()" ng-disabled="!vm.hasLoaded || !vm.page.hasNext">
+        <span class="glyphicon glyphicon-chevron-right"></span>
+    </button>
+</div>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -4,17 +4,17 @@
         <thead class="table-heading">
             <tr>
                 <th nowrap ng-repeat="col in vm.columns track by $index">
-                    <span class="table-column-displayname" ng-class="{'coltooltiplabel': col.comment}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby({colname: col.name})">{{::col.displayname}}</span>
+                    <span class="table-column-displayname" ng-class="{'coltooltiplabel': col.comment}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby(col.name)">{{::col.displayname}}</span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='asc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-asc" ng-style="{'cursor': 'pointer'}"></span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='desc'" ng-click="toggleSortOrder()" class="fa fa-sort-amount-desc" ng-style="{'cursor': 'pointer'}"></span>
-                    <span ng-show="!col.isPseudo && vm.sortby!==col.name" class="fa fa-fw fa-sort" ng-click="sortby({colname: col.name})" ng-style="{'cursor': 'pointer'}"></span>
+                    <span ng-show="!col.isPseudo && vm.sortby!==col.name" class="fa fa-fw fa-sort" ng-click="sortby(col.name)" ng-style="{'cursor': 'pointer'}"></span>
                 </th>
             </tr>
         </thead>
 
         <!-- rows -->
         <tbody>
-            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="gotoRowLink($index)" ng-style="{'cursor': 'pointer'}">
+            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="rowClickAction($index)" ng-style="{'cursor': 'pointer'}">
                 <td ng-repeat="val in row track by $index" ng-switch="val.isHTML">
                     <span ng-switch-when="true" ng-bind-html="val.value" ng-click="$event.stopPropagation()" ng-style="{'cursor': 'auto'}"></span>
                     <span ng-switch-default>{{val.value}}</span>

--- a/doc/annotation.md
+++ b/doc/annotation.md
@@ -70,7 +70,8 @@ The below tables explains the meaning of the possible values for the two keys.
 | preview_url | The URL of the 3-D preview (view on load). | 
 | viewer_url | The URL of the 3-D viewer. | 
 | top_columns | An array containing the columns to be displayed in the summary table. | 
-| sortedBy | The default column by which the search results will be sorted ascending. | 
+| sortedBy | The default column by which the search results will be sorted. | 
+| sortOrder | The order by which the search results will be sorted. Valid values are **asc** and **desc**. The default is **asc**. | 
 
 - **facet** _key_ _values_
 

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -8,53 +8,54 @@
 <body>
     <navbar></navbar>
 
-    <div class="container-fluid">
+    <div id="main-content" class="container-fluid">
         <div ng-controller="RecordController as ctrl">
+            <div id="record-bookmark-container" class="col-xs-12 meta-icons">
+                <a id="create-record" ng-if="reference && reference.canCreate && ctrl.modifyRecord" title="Click here to create a record" ng-click="::ctrl.createRecord()">
+                    <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
+                </a>&nbsp;&nbsp;
+                <a id="edit-record" ng-if="reference && reference.canUpdate && ctrl.modifyRecord" title="Click here to edit this record" ng-click="::ctrl.editRecord()">
+                    <span class="glyphicon glyphicon-pencil"></span> <strong>Edit Record</strong>
+                </a>&nbsp;&nbsp;
+                <a id="show-all-related-tables" ng-click="ctrl.showEmptyRelatedTables = true">
+                    <span class="glyphicon glyphicon-resize-vertical"></span> <strong>Show All Related Entities</strong>
+                </a>&nbsp;&nbsp;
+                <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord" label="Delete Record" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
+                <a id="permalink" title="This link stores your search criteria as a URL. Right click and save." ng-href="{{ctrl.permalink()}}">
+                    <span class="glyphicon glyphicon-bookmark"></span> <strong>Permalink</strong>
+                </a>
+            </div>
+
             <alerts alerts="ctrl.alerts"></alerts>
-        </div>
 
-        <div id="record-bookmark-container" class="col-xs-12 meta-icons" ng-controller="RecordController as ctrl">
-            <a id="create-record" class="coltooltip" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord">
-                <span class="glyphicon glyphicon-plus"></span> <strong> Create Record</strong>
-                <span class="coltooltiptext">Click here to create a record</span>
-            </a>&nbsp;&nbsp;
-            <a id="edit-record" class="coltooltip" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
-                <span class="glyphicon glyphicon-pencil"></span><strong> Edit Record</strong>
-                <span class="coltooltiptext">Click here to edit this record</span>
-            </a>&nbsp;&nbsp;
-            <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord" label="Delete Record" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
-            <a id="permalink" class="coltooltip" ng-href="{{ctrl.permalink()}}">
-                <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
-                <span class="coltooltiptext">This link stores your search criteria as a URL. Right click and save.</span>
-            </a>
-        </div>
+            <div ng-if="reference">
+                <div id="entity-title">{{ recordDisplayname }}</div>
+                <div id="entity-subtitle">{{ reference.displayname }}</div>
+            </div>
 
-        <div ng-if="reference">
-            <div id="entity-title">{{ recordDisplayname }}</div>
-            <div id="entity-subtitle">{{ reference.displayname }}</div>
-        </div>
+            <!-- defined on $rootScope in run function -->
+            <div ng-if="recordValues && columns">
+                <record-display columns="columns" values="recordValues"></record-display>
+            </div>
 
-        <!-- defined on $rootScope in run function -->
-        <div ng-if="recordValues && columns">
-            <record-display columns="columns" values="recordValues"></record-display>
-        </div>
-
-        <uib-accordion close-others="false">
-            <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
-                ng-if="($index === 0 || tableModels[$index-1].hasLoaded) && tableModels[$index].rowValues.length > 0"
-                heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
-                <!-- for different elements inside the accordion -->
-                <div ng-switch on="relatedRef.display.type">
-                    <a class="more-results-link text-right" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">View All Records</a>
-                    <div ng-switch-when="markdown">
-                        <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
-                    </div>
-                    <!-- ng-switch-when="table" is also the default case -->
-                    <div ng-switch-default>
-                        <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+            <uib-accordion close-others="false">
+                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
+                    ng-if="ctrl.showRelatedTable($index)"
+                    heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
+                    <!-- for different elements inside the accordion -->
+                    <div ng-switch on="relatedRef.display.type">
+                        <!-- <a class="more-results-link text-right" ng-href="{{ctrl.toRecordSet(relatedRef)}}">View All Records</a> -->
+                        <a class="more-results-link text-right" ng-click="ctrl.toRecordSet(relatedRef)">View All Records</a>
+                        <div ng-switch-when="markdown">
+                            <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
+                        </div>
+                        <!-- ng-switch-when="table" is also the default case -->
+                        <div ng-switch-default>
+                            <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]" default-row-linking="true"></record-table>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </uib-accordion>
+            </uib-accordion>
+        </div>
     </div>
 </body>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -15,19 +15,16 @@
         'ui.bootstrap'
     ])
 
-    // The page info object passed to the table directive
-    .factory('pageInfo', [function() {
+    .factory('constants', [function(){
         return {
-            loading: true,
-            previousButtonDisabled: true,
-            nextButtonDisabled: true,
-            defaultPageLimit: 25
+            defaultPageSize: 25,
         };
     }])
 
-    .run(['DataUtils', 'headInjector', 'ERMrest', 'UriUtils', 'ErrorService', 'pageInfo', '$log', '$rootScope', '$window', 'UiUtils', function runApp(DataUtils, headInjector, ERMrest, UriUtils, ErrorService, pageInfo, $log, $rootScope, $window, UiUtils) {
+    .run(['DataUtils', 'headInjector', 'ERMrest', 'UriUtils', 'ErrorService', '$log', '$rootScope', '$window', 'UiUtils', 'constants',
+        function runApp(DataUtils, headInjector, ERMrest, UriUtils, ErrorService, $log, $rootScope, $window, UiUtils, constants) {
+
         var context = {};
-        $rootScope.pageInfo = pageInfo;
         UriUtils.setOrigin();
         headInjector.addTitle();
         headInjector.addCustomCSS();
@@ -76,25 +73,28 @@
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
                         $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
 
+                        var pageSize;
                         if ($rootScope.relatedReferences[i].display.defaultPageSize) {
-                            pageInfo.pageLimit = $rootScope.relatedReferences[i].display.defaultPageSize;
+                            pageSize = $rootScope.relatedReferences[i].display.defaultPageSize;
                         } else {
-                            pageInfo.pageLimit = pageInfo.defaultPageLimit;
+                            pageSize = constants.defaultPageSize;
                         }
 
                         (function(i) {
-                            $rootScope.relatedReferences[i].read(pageInfo.pageLimit).then(function (page) {
+                            $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
 
                                 var model = {
                                     reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
                                     page: page,
+                                    pageLimit: ($rootScope.relatedReferences[i].display.defaultPageSize ? $rootScope.relatedReferences[i].display.defaultPageSize : constants.defaultPageSize),
                                     hasNext: page.hasNext,      // used to determine if a link should be shown
                                     hasLoaded: true,            // used to determine if the current table and next table should be rendered
                                     open: true,                 // to define if the accordion is open or closed
                                     sortby: null,               // column name, user selected or null
                                     sortOrder: null,            // asc (default) or desc
-                                    rowValues: []               // array of rows values
+                                    rowValues: [],              // array of rows values
+                                    search: null                // search term
                                 };
                                 model.rowValues = DataUtils.getRowValuesFromPage(page);
                                 $rootScope.tableModels[i] = model;

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -8,6 +8,7 @@
 
         vm.alerts = AlertsService.alerts;
         vm.modifyRecord = chaiseConfig.editRecord === false ? false : true;
+        vm.showEmptyRelatedTables = false;
 
         vm.createRecord = function() {
             var newRef = $rootScope.reference.contextualize.entryCreate;
@@ -51,10 +52,24 @@
         vm.toRecordSet = function(ref) {
             var appURL = ref.appLink;
             if (!appURL) {
-                AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + ref.compactPath});
+                return AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + ref.compactPath});
             }
-            else {
-                $window.location.href = appURL;
+            return $window.location.href = appURL;
+        };
+
+        vm.showRelatedTable = function(i) {
+            var isFirst = false, prevTableHasLoaded = false;
+            if ($rootScope.tableModels && $rootScope.tableModels[i]) {
+                if (i === 0) {
+                    isFirst = true;
+                } else if ($rootScope.tableModels[i-1]) {
+                    prevTableHasLoaded = $rootScope.tableModels[i-1].hasLoaded;
+                }
+
+                if (vm.showEmptyRelatedTables) {
+                    return isFirst || prevTableHasLoaded;
+                }
+                return (isFirst || prevTableHasLoaded) && $rootScope.tableModels[i].rowValues.length > 0;
             }
         };
     }]);

--- a/record/record.css
+++ b/record/record.css
@@ -1,11 +1,21 @@
 .container-fluid {
+    /* If changing paddings here, change the padding in #record-bookmark-container */
     padding-right: 50px;
     padding-left: 50px;
 }
 
+#main-content {
+    margin-top: 120px;
+}
+
 #record-bookmark-container {
     text-align: right;
-    top: 0;
+    position: fixed;
+    top: 50px;
+    right: 0;
+    padding: 15px 50px 15px 50px; /* padding-left and padding-right sides are to equal the left and right paddings of .container-fluid */
+    background-color: #f1f1f1;
+    box-shadow: 0 4px 2px -2px rgba(0,0,0,0.4);
 }
 
 .more-results-link {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -25,6 +25,7 @@
         vm.readyToSubmit = false;
         vm.redirectAfterSubmission = redirectAfterSubmission;
         vm.showSubmissionError = showSubmissionError;
+        vm.createRecord = createRecord;
         vm.copyFormRow = copyFormRow;
         vm.removeFormRow = removeFormRow;
         vm.deleteRecord = deleteRecord;
@@ -198,6 +199,17 @@
             }
         }
 
+        function createRecord(column) {
+            var newRef = column.reference.contextualize.entryCreate;
+            var appURL = newRef.appLink;
+            if (!appURL) {
+                AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + newRef.compactPath});
+            }
+            else {
+                $window.open(appURL, '_blank');
+            }
+        }
+
         function copyFormRow() {
             // Check if the prototype row to copy has any invalid values. If it
             // does, display an error. Otherwise, copy the row.
@@ -288,7 +300,7 @@
         }
 
         function isForeignKey(column) {
-            return column.memberOfForeignKeys.length > 0
+            return (column.memberOfForeignKeys.length > 0 || column.isPseudo);
         }
 
         // Returns true if a column type is found in the given array of types

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -105,8 +105,8 @@
                                             </div>
                                             <!-- dropdown select input -->
                                             <div ng-switch-when="dropdown">
-                                                <input ng-model="form.recordEditModel.rows[rowIndex][column.name]"></input>
-                                                    <button ng-click="form.createRecord(column)">
+                                                <input ng-model="form.recordEditModel.rows[rowIndex][column.name]">
+                                                    <button class="create-record-btn" ng-click="form.createRecord(column)">
                                                         <span class="glyphicon glyphicon-plus"></span>
                                                     </button>
                                                 <!--<ui-select ng-model="form.recordEditModel.rows[rowIndex][column.name]" theme="select2" ng-disabled="::form.isDisabled(column);">

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -82,7 +82,7 @@
                                                 <div class="col-xs-12" ng-class="{'col-md-4': form.editMode}">
                                                     <div class="input-group">
                                                         <span class="input-group-addon">Date</span>
-                                                        <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].date" placeholder="YYYY-MM-DD" name="{{::column.name}}"
+                                                        <input class="form-control input-timestamptz" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].date" placeholder="YYYY-MM-DD" name="{{::column.name}}"
                                                             ui-mask="9999-99-99" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date>
                                                     </div>
                                                 </div>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -105,12 +105,16 @@
                                             </div>
                                             <!-- dropdown select input -->
                                             <div ng-switch-when="dropdown">
-                                                <ui-select ng-model="form.recordEditModel.rows[rowIndex][column.name]" theme="select2" ng-disabled="::form.isDisabled(column);">
+                                                <input ng-model="form.recordEditModel.rows[rowIndex][column.name]"></input>
+                                                    <button ng-click="form.createRecord(column)">
+                                                        <span class="glyphicon glyphicon-plus"></span>
+                                                    </button>
+                                                <!--<ui-select ng-model="form.recordEditModel.rows[rowIndex][column.name]" theme="select2" ng-disabled="::form.isDisabled(column);">
                                                     <ui-select-match name="{{::column.name}}" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">{{$select.selected.display}}</ui-select-match>
                                                     <ui-select-choices repeat="domainValue.key as domainValue in form.recordEditModel.domainValues[column.name] | filter: $select.search" >
                                                         <div ng-bind-html="domainValue.display | highlight: $select.search"></div>
                                                     </ui-select-choices>
-                                                </ui-select>
+                                                </ui-select>-->
                                             </div>
                                             <!-- int2 input -->
                                             <input ng-switch-when="integer2" ng-model="form.recordEditModel.rows[rowIndex][column.name]"

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -50,6 +50,7 @@
             context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
             context.appName = "recordedit";
 
+            ERMrest.appLinkFn(UriUtils.appTagToURL);
             ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
                 $rootScope.reference = (context.filter ? reference.contextualize.entryEdit : reference.contextualize.entryCreate);
                 $rootScope.reference.session = $rootScope.session;

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -16,64 +16,12 @@
         </div>
 
         <!-- loading spinner -->
-        <div ng-show="pageInfo.loading" id="spinner">
+        <div ng-show="!vm.hasLoaded" id="spinner">
             <img src="spinner.gif" style="display: block; margin: 0 auto; width: 32px; height: 32px; opacity: 0.8;"/>
             <div style="margin-top: 15px;">Loading...</div>
         </div>
 
-        <div class="row" style="margin-bottom: 10px;">
-            <div class="col-lg-4">
-                <!-- search box -->
-                <div class="input-group">
-                    <input type="text"
-                           id="search-input"
-                           ng-model="vm.search"
-                           class="form-control"
-                           on-enter="search(vm.search)"
-                           placeholder="search {{vm.tableDisplayName}}">
-                    <span class="input-group-btn">
-                        <button id="search-submit" class="btn btn-primary" ng-click="search(vm.search)" role="button">
-                            &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
-                        </button>
-                        <button id="search-clear" class="btn btn-primary" ng-disabled="!reference.location.searchTerm" ng-click="clearSearch()" type="button">Reset</button>
-                    </span>
-                </div>
-            </div>
-            <div class="col-lg-3 col-md-offset-5" align="right">
-            <!-- pagination -->
-                <div>
-                    <span class="dropdown" style="margin-left: 5px">
-                        <button class="btn btn-sm btn-default dropdown-toggle" type="button" data-toggle="dropdown">Items per page
-                            <span class="caret"></span></button>
-                        <ul class="dropdown-menu dropdown-menu-right">
-                            <li ng-if="pageLimits.indexOf(pageInfo.pageLimit) === -1"><a id="custom-page-size" href ng-click="pageLimit(pageInfo.pageLimit)">
-                                <span class="glyphicon glyphicon-ok"></span>
-                                {{ pageInfo.pageLimit }} (Custom)</a>
-                            </li>
-                            <li ng-repeat="limit in pageLimits"><a href ng-click="pageLimit(limit)">
-                                <span class="glyphicon" ng-class="pageInfo.pageLimit === limit ? 'glyphicon-ok' : 'glyphicon-invisible'"></span>
-                                {{ limit }}</a>
-                            </li>
-                        </ul>
-                    </span>
-                </div>
-            </div>
-        </div>
-
-        <!-- record table -->
-        <div ng-if="vm.rowValues.length > 0">
-            <record-table id="rs-{{vm.tableDisplayName}}" vm="vm" toggle-sort-order="toggleSortOrder()" sortby="sortby(colname)"></record-table>
-        </div>
-
-            <!-- bottom pagination -->
-        <div class="pager">
-            <button type="button" class="btn btn-primary btn-sm" ng-click="before()" ng-disabled="pageInfo.previousButtonDisabled">
-                <span class="glyphicon glyphicon-chevron-left"></span>
-            </button>
-            <button type="button" class="btn btn-primary btn-sm" ng-click="after()" ng-disabled="pageInfo.nextButtonDisabled">
-                <span class="glyphicon glyphicon-chevron-right"></span>
-            </button>
-        </div>
+        <recordset vm="vm" default-row-linking="true"></recordset>
     </div>
 
 </div>

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -45,39 +45,22 @@
     // Register the 'recordsetModel' object, which can be accessed by other
     // services, but cannot be access by providers (and config, apparently).
     .value('recordsetModel', {
+        hasLoaded: false,
+        reference: null,
         tableDisplayName: null,
         columns: [],
         sortby: null,     // column name, user selected or null
         sortOrder: null,  // asc (default) or desc
         page: null,        // current page
         rowValues: [],      // array of rows values, each value has this structure {isHTML:boolean, value:value}
-        search: null       // search term
+        search: null,       // search term
+        pageLimit: 25       // number of rows per page
     })
 
-    .factory('pageInfo', [function() {
-        return {
-            loading: true,
-            previousButtonDisabled: true,
-            nextButtonDisabled: true,
-            pageLimit: 25
-        };
-
-    }])
-
     // Register the recordset controller
-    .controller('recordsetController', ['$scope', '$rootScope', 'context', 'pageInfo', '$window', 'recordsetModel', 'UriUtils', 'DataUtils', 'Session', '$log', 'ErrorService',
-        function($scope, $rootScope, context, pageInfo, $window, recordsetModel, UriUtils, DataUtils, Session, $log, ErrorService) {
+    .controller('recordsetController', ['$scope', '$rootScope', 'context', '$window', 'recordsetModel', 'UriUtils', 'DataUtils', 'Session', '$log', 'ErrorService',  function($scope, $rootScope, context, $window, recordsetModel, UriUtils, DataUtils, Session, $log, ErrorService) {
 
         $scope.vm = recordsetModel;
-
-        $scope.pageInfo = pageInfo;
-
-        $scope.pageLimits = [10, 25, 50, 75, 100, 200];
-
-        $scope.pageLimit = function(limit) {
-            pageInfo.pageLimit = limit;
-            $scope.read();
-        };
 
         $scope.navbarBrand = (chaiseConfig['navbarBrand'] !== undefined? chaiseConfig.navbarBrand : "");
         $scope.navbarBrandImage = (chaiseConfig['navbarBrandImage'] !== undefined? chaiseConfig.navbarBrandImage : "");
@@ -91,189 +74,48 @@
             Session.logout();
         };
 
-        $scope.sortby = function(column) {
-            if (recordsetModel.sortby !== column) {
-                recordsetModel.sortby = column;
-                recordsetModel.sortOrder = "asc";
-                $rootScope.reference = $rootScope.reference.sort([{"column":recordsetModel.sortby, "descending":(recordsetModel.sortOrder === "desc")}]);
-                $scope.read();
-            }
+        // row data updated from directive
+        // update permalink, address bar without reload
+        $scope.$on('recordset-update', function() {
+            $window.scrollTo(0, 0);
+            $window.location.replace($scope.permalink());
+            $rootScope.location = $window.location.href;
+        });
 
-        };
-
-        $scope.toggleSortOrder = function () {
-            recordsetModel.sortOrder = (recordsetModel.sortOrder === 'asc' ? recordsetModel.sortOrder = 'desc' : recordsetModel.sortOrder = 'asc');
-            $rootScope.reference = $rootScope.reference.sort([{"column":recordsetModel.sortby, "descending":(recordsetModel.sortOrder === "desc")}]);
-            $scope.read();
-        };
-
-        $scope.read = function() {
-
-            pageInfo.previousButtonDisabled = true;
-            pageInfo.nextButtonDisabled = true;
-            pageInfo.loading = true;
-
-            $rootScope.reference.read(pageInfo.pageLimit).then(function (page) {
-                $window.scrollTo(0, 0);
-
-                recordsetModel.page = page;
-                recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
-
-                pageInfo.loading = false;
-                pageInfo.previousButtonDisabled = !page.hasPrevious;
-                pageInfo.nextButtonDisabled = !page.hasNext;
-
-                // update the address bar
-                // page does not reload
-                $window.location.replace($scope.permalink());
-                $rootScope.location = $window.location.href;
-
-            }, function error(response) {
-                $log.warn(response);
-
-                pageInfo.loading = false;
-                pageInfo.previousButtonDisabled = true;
-                pageInfo.nextButtonDisabled = true;
-
-                throw response;
-            }).catch(function genericCatch(exception) {
-                ErrorService.catchAll(exception);
-            });
-        };
+        $scope.$on('error', function(event, exception) {
+            $log.warn(exception);
+            ErrorService.catchAll(exception);
+        });
 
         $scope.permalink = function() {
 
             // before run, use window location
-            if (!$rootScope.reference) {
+            if (!recordsetModel.reference) {
                 return $window.location.href;
             }
 
             //var url = context.mainURI;
-            var url = context.chaiseBaseURL + "#" + UriUtils.fixedEncodeURIComponent($rootScope.reference.location.catalog) + "/" +
-                $rootScope.reference.location.compactPath;
+            var url = context.chaiseBaseURL + "#" + UriUtils.fixedEncodeURIComponent(recordsetModel.reference.location.catalog) + "/" +
+                recordsetModel.reference.location.compactPath;
 
             // add sort modifier
-            if ($rootScope.reference.location.sort)
-                url = url + $rootScope.reference.location.sort;
+            if (recordsetModel.reference.location.sort)
+                url = url + recordsetModel.reference.location.sort;
 
             // add paging modifier
-            if ($rootScope.reference.location.paging)
-                url = url + $rootScope.reference.location.paging;
+            if (recordsetModel.reference.location.paging)
+                url = url + recordsetModel.reference.location.paging;
 
-            url = url + "?limit=" + pageInfo.pageLimit;
+            url = url + "?limit=" + recordsetModel.pageLimit;
 
             return url;
         };
 
-        $scope.before = function() {
-
-            var previous = recordsetModel.page.previous;
-            if (previous) {
-
-                pageInfo.loading = true;
-
-                // disable buttons while loading
-                pageInfo.previousButtonDisabled = true;
-                pageInfo.nextButtonDisabled = true;
-
-                $rootScope.reference = previous;
-                $log.info("Reference:", $rootScope.reference);
-
-                $rootScope.reference.read(pageInfo.pageLimit).then(function getPage(page) {
-                    $window.scrollTo(0, 0);
-
-                    recordsetModel.page = page;
-                    recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
-
-                    pageInfo.loading = false;
-                    pageInfo.previousButtonDisabled = !page.hasPrevious;
-                    pageInfo.nextButtonDisabled = !page.hasNext;
-
-                    // update the address bar without adding to history stack
-                    // page does not reload
-                    $window.location.replace($scope.permalink());
-                    $rootScope.location = $window.location.href;
-
-                }, function error(response) {
-                    $log.warn(response);
-
-                    pageInfo.loading = false;
-                    pageInfo.previousButtonDisabled = true;
-                    pageInfo.nextButtonDisabled = true;
-
-                    throw response;
-                }).catch(function genericCatch(exception) {
-                    ErrorService.catchAll(exception);
-                });
-
-            }
-        };
-
-        $scope.after = function() {
-
-            var next = recordsetModel.page.next;
-            if (next) {
-
-                pageInfo.loading = true;
-
-                // disable buttons while loading
-                pageInfo.previousButtonDisabled = true;
-                pageInfo.nextButtonDisabled = true;
-
-                $rootScope.reference = next;
-                $log.info("Reference:", $rootScope.reference);
-
-                $rootScope.reference.read(pageInfo.pageLimit).then(function getPage(page) {
-                    $window.scrollTo(0, 0);
-
-                    recordsetModel.page = page;
-                    recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
-
-                    pageInfo.loading = false;
-                    pageInfo.previousButtonDisabled = !page.hasPrevious;
-                    pageInfo.nextButtonDisabled = !page.hasNext;
-
-                    // update the address bar
-                    // page does not reload
-                    $window.location.replace($scope.permalink());
-                    $rootScope.location = $window.location.href;
-
-                }, function error(response) {
-                    $log.warn(response);
-
-                    pageInfo.loading = false;
-                    pageInfo.previousButtonDisabled = true;
-                    pageInfo.nextButtonDisabled = true;
-
-                    throw response;
-                }).catch(function genericCatch(exception) {
-                    ErrorService.catchAll(exception);
-                });
-            }
-
-        };
-
-        $scope.search = function(term) {
-
-            if (term)
-                term = term.trim();
-
-            recordsetModel.search = term;
-            $rootScope.reference = $rootScope.reference.search(term); // this will clear previous search first
-            $scope.read(pageInfo.pageLimit);
-        };
-
-        $scope.clearSearch = function() {
-            if ($rootScope.reference.location.searchTerm)
-                $scope.search();
-
-            recordsetModel.search = null;
-        }
     }])
 
     // Register work to be performed after loading all modules
-    .run(['DataUtils', 'headInjector', '$window', 'pageInfo', 'context', 'recordsetModel', 'ERMrest', '$rootScope', 'Session', 'UriUtils', '$log', 'ErrorService', 'UiUtils', 'AlertsService',
-        function(DataUtils, headInjector, $window, pageInfo, context, recordsetModel, ERMrest, $rootScope, Session, UriUtils, $log, ErrorService, UiUtils, AlertsService) {
+    .run(['DataUtils', 'headInjector', '$window', 'context', 'recordsetModel', 'ERMrest', '$rootScope', 'Session', 'UriUtils', '$log', 'ErrorService', 'UiUtils', 'AlertsService',
+        function(DataUtils, headInjector, $window, context, recordsetModel, ERMrest, $rootScope, Session, UriUtils, $log, ErrorService, UiUtils, AlertsService) {
 
         try {
             headInjector.addTitle();
@@ -289,10 +131,8 @@
             var p_context = UriUtils.parseURLFragment($window.location);
 
             $rootScope.location = $window.location.href;
-            pageInfo.loading = true;
+            recordsetModel.hasLoaded = false;
             $rootScope.context = context;
-            pageInfo.previousButtonDisabled = true;
-            pageInfo.nextButtonDisabled = true;
 
             context.mainURI = p_context.mainURI;
 
@@ -310,35 +150,31 @@
 
             ERMrest.appLinkFn(UriUtils.appTagToURL);
             ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
-                $rootScope.reference = reference.contextualize.compact;
-                $log.info("Reference:", $rootScope.reference);
+                recordsetModel.reference = reference.contextualize.compact;
+                $log.info("Reference:", recordsetModel.reference);
                 if (p_context.limit)
-                    pageInfo.pageLimit = p_context.limit;
-                else if ($rootScope.reference.display.defaultPageSize)
-                    pageInfo.pageLimit = $rootScope.reference.display.defaultPageSize;
+                    recordsetModel.pageLimit = p_context.limit;
+                else if (recordsetModel.reference.display.defaultPageSize)
+                    recordsetModel.pageLimit = recordsetModel.reference.display.defaultPageSize;
                 else
-                    pageInfo.pageLimit = 25;
-                recordsetModel.tableDisplayName = $rootScope.reference.displayname;
-                recordsetModel.columns = $rootScope.reference.columns;
-                recordsetModel.search = $rootScope.reference.location.searchTerm;
+                    recordsetModel.pageLimit = 25;
+                recordsetModel.tableDisplayName = recordsetModel.reference.displayname;
+                recordsetModel.columns = recordsetModel.reference.columns;
+                recordsetModel.search = recordsetModel.reference.location.searchTerm;
 
-                return $rootScope.reference.read(pageInfo.pageLimit);
+                return recordsetModel.reference.read(recordsetModel.pageLimit);
             }, function error(response) {
                 throw response;
             }).then(function getPage(page) {
                 recordsetModel.page = page;
                 recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
 
-                pageInfo.loading = false;
-                pageInfo.previousButtonDisabled = !page.hasPrevious;
-                pageInfo.nextButtonDisabled = !page.hasNext;
+                recordsetModel.hasLoaded = true;
             }, function error(response) {
                 throw response;
             }).catch(function genericCatch(exception) {
                 $log.warn(exception);
-                pageInfo.loading = false;
-                pageInfo.previousButtonDisabled = true;
-                pageInfo.nextButtonDisabled = true;
+                recordsetModel.hasLoaded = true;
 
                 if (exception instanceof ERMrest.UnauthorizedError)
                     ErrorService.catchAll(exception);

--- a/scripts/facetsService.js
+++ b/scripts/facetsService.js
@@ -74,6 +74,10 @@ facetsService.service('FacetsService', ['$sce', 'FacetsData', function($sce, Fac
 			if (sortColumn != null) {
 				FacetsData.sortFacet = sortColumn;
 				FacetsData.sortOrder = 'asc';
+				var sortOrder = getTableAnnotation(FacetsData.table, TABLES_MAP_URI, 'sortOrder');
+				if (sortOrder != null) {
+					FacetsData.sortOrder = sortOrder;
+				}
 			}
 		}
 	};

--- a/test/e2e/data_setup/schema/product.json
+++ b/test/e2e/data_setup/schema/product.json
@@ -769,7 +769,7 @@
     "tag:isrd.isi.edu,2016:app-links": {
       "detailed": "tag:isrd.isi.edu,2016:chaise:record",
       "compact": "tag:isrd.isi.edu,2016:chaise:recordset",
-      "entry": "tag:isrd.isi.edu,2016:chaise:viewer"
+      "entry": "tag:isrd.isi.edu,2016:chaise:recordedit"
     }
   },
   "schema_name": "product"

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -25,11 +25,13 @@ exports.testPresentation = function (tableParams) {
         var EC = protractor.ExpectedConditions,
             editButton = chaisePage.recordPage.getEditRecordButton(),
             createButton = chaisePage.recordPage.getCreateRecordButton(),
-            deleteButton = chaisePage.recordPage.getDeleteRecordButton();
+            deleteButton = chaisePage.recordPage.getDeleteRecordButton(),
+            showAllRTButton = chaisePage.recordPage.getShowAllRelatedEntitiesButton();
 
         browser.wait(EC.elementToBeClickable(editButton), 10000);
         browser.wait(EC.elementToBeClickable(createButton), 10000);
         browser.wait(EC.elementToBeClickable(deleteButton), 10000);
+        browser.wait(EC.elementToBeClickable(showAllRTButton), 10000);
 
         editButton.isDisplayed().then(function (bool) {
             expect(bool).toBeTruthy();
@@ -40,6 +42,10 @@ exports.testPresentation = function (tableParams) {
         });
 
         deleteButton.isDisplayed().then(function (bool) {
+            expect(bool).toBeTruthy();
+        });
+
+        showAllRTButton.isDisplayed().then(function (bool) {
             expect(bool).toBeTruthy();
         });
 
@@ -193,6 +199,13 @@ exports.testPresentation = function (tableParams) {
             return tableHeading.getAttribute("class");
         }).then(function(attribute) {
             expect(attribute).not.toMatch("panel-open");
+        });
+    });
+
+    // There is a media table linked to accommodations but this accommodation (Sheraton Hotel) doesn't have any media
+    it("should show a related table with zero values upon clicking a link to show all related entities", function() {
+        chaisePage.recordPage.getShowAllRelatedEntitiesButton().click().then(function() {
+            expect(chaisePage.recordPage.getRelatedTable("media").isPresent()).toBeTruthy();
         });
     });
 };

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -278,7 +278,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 
 			});
 
-			xdescribe("Foreign key fields,", function() {
+			describe("Foreign key fields,", function() {
 
 				var pageColumns = [], columns = [], dropdowns = [];
 
@@ -320,6 +320,29 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 						});
 					});
 				}).pend("Postpone test until foreign key UI is updated for the new reference apis");
+
+				it("should have a `create new` button that opens a new tab", function(done){
+                    var handles;
+					console.log("\n        Foreign Key Fields");
+					var createBtns = chaisePage.recordEditPage.getCreateBtns();
+					expect(createBtns.count()).toBe(columns.length * (recordIndex + 1));
+                    var fkc = columns[0];
+                    browser.executeScript('arguments[0].click();', createBtns.get(recordIndex)).then(function(){
+                        return browser.getAllWindowHandles();
+                    }).then(function(h){
+                        handles = h;
+                        return browser.switchTo().window(handles[1]);
+                    }).then(function(){
+                        return browser.getCurrentUrl();
+                    }).then(function(currentUrl) {
+                        var url = '/recordedit/#' + browser.params.catalogId + "/" + fkc.referencedColumn.schema_name + ":" + fkc.referencedColumn.table_name;
+                        expect(currentUrl.indexOf(url)).toBeGreaterThan(-1);
+                        return browser.close();
+                    }).then(function() {
+                        browser.switchTo().window(handles[0]);
+                    });
+                    done();
+				});
 
 				if (tableParams.records) {
 

--- a/test/e2e/specs/search/data-dependent/02-filters.upon.result.spec.js
+++ b/test/e2e/specs/search/data-dependent/02-filters.upon.result.spec.js
@@ -100,6 +100,7 @@ var testFilters = function(attr, filter, attrCount, filterLen, contentCount) {
 
             it('should show ' + filter.entityCount + ' results for filters ' + filter.content.join(','), function () {
                 if (filter.entityCount != undefined) {
+                    browser.sleep(1000);
                     var allResults = chaisePage.resultContent.getAllResultRows();
                     expect(allResults.count()).toBe(filter.entityCount);
                 }

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -173,9 +173,7 @@ function contentFilter() {
         return that.htmlElement.element(by.cssContainingText('div.filter-item.ng-scope:not(.ng-hide)', attrName))
     };
     this.findFilterWrapperTitleByWrapperName = function (wrapperAttrName) {
-        var titleSpan = that.findFilterWrapperByName(wrapperAttrName)
-            .$('span[ng-attr-title="{{facetResults.displayTitle(facet)}}"]');
-        return titleSpan.getAttribute('title');
+        return browser.executeScript("return $('div.filter-item.ng-scope:not(.ng-hide):contains(\"" + wrapperAttrName + "\") span[ng-attr-title=\"{{facetResults.displayTitle(facet)}}\"]').attr('title');");
     };
     this.clickFilterWrapperCancelByName = function (attrName) {
         that.findFilterWrapperByName(attrName).$('a.filter-link-cancel').click();
@@ -536,6 +534,10 @@ var recordPage = function() {
     this.getConfirmDeleteButton = function () {
         return element(by.id("delete-confirmation"));
     }
+
+    this.getShowAllRelatedEntitiesButton = function() {
+        return element(by.id("show-all-related-tables"));
+    };
 
     this.getPermalinkButton = function() {
         return element(by.id('permalink'));

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -342,6 +342,10 @@ var recordEditPage = function() {
         return browser.executeScript("return $(arguments[0]).find('.select2-chosen:not(\".ng-hide\")').text().trim();", el);
     };
 
+    this.getCreateBtns = function() {
+        return element.all(by.css(".create-record-btn"));
+    };
+
     this.getDateInputForAColumn = function(name, index) {
         index = index || 0;
         return element(by.model('form.recordEditModel.rows[' + index + ']["' + name + '"]'));


### PR DESCRIPTION
PR for #658 
- Add a CREATE button to out-bound foreign key columns in recordedit
- Click on the button to open recordedit in a new tab
- Added test cases
