### PR TITLE
Add new record from Record to RecordEdit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ RECORD_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(JS)/vendor/angular.js \
 	$(JS)/vendor/angular-messages.min.js \
 	$(JS)/vendor/angular-sanitize.js \
+	$(COMMON)/vendor/angular-cookies.min.js \
 	$(COMMON)/alerts.js \
 	$(COMMON)/authen.js \
 	$(COMMON)/delete-link.js \
@@ -249,13 +250,14 @@ VIEWER_SHARED_CSS_DEPS=$(CSS)/vendor/bootstrap.min.css \
 
 VIEWER_CSS_SOURCE=$(VIEWER_ASSETS)/viewer.css
 
-# JavaScript and CSS source for Data Entry app
+# JavaScript and CSS source for RecordEdit app
 RE_ASSETS=recordedit
 
 RE_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(JS)/vendor/angular.js \
 	$(JS)/vendor/angular-sanitize.js \
 	$(JS)/vendor/angular-messages.min.js \
+	$(COMMON)/vendor/angular-cookies.min.js \
 	$(COMMON)/vendor/mask.min.js \
 	$(COMMON)/vendor/moment.min.js \
 	$(COMMON)/alerts.js \

--- a/common/authen.js
+++ b/common/authen.js
@@ -6,9 +6,9 @@
     .factory('Session', ['$http', '$q', '$window', 'UriUtils', function ($http, $q, $window, UriUtils) {
 
         function NotFoundError(status, message) {
-                this.code = 404;
-                this.status = status;
-                this.message = message;
+            this.code = 404;
+            this.status = status;
+            this.message = message;
         }
 
         NotFoundError.prototype = Object.create(Error.prototype);

--- a/common/utils.js
+++ b/common/utils.js
@@ -37,6 +37,16 @@
                 ermrestUri = {},
                 catalogId;
 
+            // If hash has ?prefill or &prefill parameter, remove it
+            if (hash.indexOf('prefill=') !== -1) {
+                var startIndex = hash.indexOf('prefill=');
+                var stopIndex = hash.indexOf('&', startIndex);
+                if (stopIndex !== -1) {
+                    hash = hash.substring(0, startIndex) + hash.substring(stopIndex + 1);
+                } else {
+                    hash = hash.substring(0, startIndex - 1);
+                }
+            }
 
             // If the hash is empty, check for defaults
             if (hash == '' || hash === undefined || hash.length == 1) {
@@ -87,7 +97,6 @@
 
             var baseUri = chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : location.origin + '/ermrest';
             var path = '/catalog/' + fixedEncodeURIComponent(catalogId) + '/entity' + hash;
-
             return baseUri + path;
         }
 
@@ -153,8 +162,8 @@
                 return context;
             }
 
-            // parse out modifiers, expects in order of sort, paging and limit
-            var modifiers = ["@sort(", "@before(", "@after", "?limit="];
+            // parse out modifiers, expects in order of sort, paging, limit, and prefill
+            var modifiers = ["@sort(", "@before(", "@after", "?limit=", "?prefill=", "&prefill="];
             for (i = 0; i < modifiers.length; i++) {
                 if (hash.indexOf(modifiers[i]) !== -1) {
                     hash = hash.split(modifiers[i])[0]; // remove modifiers from uri
@@ -222,6 +231,20 @@
                 if (modifierPath.indexOf("?limit=") !== -1) {
                     context.limit = parseInt(modifierPath.match(/\?limit=([0-9]*)/)[1]);
                 }
+
+                // extract ?prefill or &prefill
+                var prefills = ['?prefill=', '&prefill='];
+                prefills.forEach(function(query) {
+                    if (modifierPath.indexOf(query) !== -1) {
+                        var startIndex = modifierPath.indexOf(query) + query.length;
+                        var stopIndex = modifierPath.indexOf('&', startIndex);
+                        if (stopIndex !== -1) {
+                            context.prefill = modifierPath.substring(startIndex, stopIndex);
+                        } else {
+                            context.prefill = modifierPath.substring(startIndex);
+                        }
+                    }
+                });
             }
 
             // TODO With Reference API, we don't need the code below?
@@ -407,7 +430,7 @@
         }
 
         /**
-         * 
+         *
          * This code handles address bar changes
          * Normally when user changes the url in the address bar,
          * nothing happens.
@@ -513,11 +536,11 @@
             getRowValuesFromPage: getRowValuesFromPage
         }
     }])
-    
+
     .factory("UiUtils", [function() {
         /**
          *
-         * To allow the dropdown button to open at the top/bottom depending on the space available 
+         * To allow the dropdown button to open at the top/bottom depending on the space available
          */
         function setBootstrapDropdownButtonBehavior() {
             $(document).on("shown.bs.dropdown", ".btn-group", function () {
@@ -562,7 +585,7 @@
             getValueFromContext: getValueFromContext
         }
     }])
-    
+
 
     // if a view value is empty string (''), change it to null before submitting to the database
     .directive('emptyToNull', function () {

--- a/common/vendor/angular-cookies.min.js
+++ b/common/vendor/angular-cookies.min.js
@@ -1,0 +1,9 @@
+/*
+ AngularJS v1.5.5
+ (c) 2010-2016 Google, Inc. http://angularjs.org
+ License: MIT
+*/
+(function(n,c){'use strict';function l(b,a,g){var d=g.baseHref(),k=b[0];return function(b,e,f){var g,h;f=f||{};h=f.expires;g=c.isDefined(f.path)?f.path:d;c.isUndefined(e)&&(h="Thu, 01 Jan 1970 00:00:00 GMT",e="");c.isString(h)&&(h=new Date(h));e=encodeURIComponent(b)+"="+encodeURIComponent(e);e=e+(g?";path="+g:"")+(f.domain?";domain="+f.domain:"");e+=h?";expires="+h.toUTCString():"";e+=f.secure?";secure":"";f=e.length+1;4096<f&&a.warn("Cookie '"+b+"' possibly not set or overflowed because it was too large ("+
+f+" > 4096 bytes)!");k.cookie=e}}c.module("ngCookies",["ng"]).provider("$cookies",[function(){var b=this.defaults={};this.$get=["$$cookieReader","$$cookieWriter",function(a,g){return{get:function(d){return a()[d]},getObject:function(d){return(d=this.get(d))?c.fromJson(d):d},getAll:function(){return a()},put:function(d,a,m){g(d,a,m?c.extend({},b,m):b)},putObject:function(d,b,a){this.put(d,c.toJson(b),a)},remove:function(a,k){g(a,void 0,k?c.extend({},b,k):b)}}}]}]);c.module("ngCookies").factory("$cookieStore",
+["$cookies",function(b){return{get:function(a){return b.getObject(a)},put:function(a,c){b.putObject(a,c)},remove:function(a){b.remove(a)}}}]);l.$inject=["$document","$log","$browser"];c.module("ngCookies").provider("$$cookieWriter",function(){this.$get=l})})(window,window.angular);
+//# sourceMappingURL=angular-cookies.min.js.map

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -8,53 +8,61 @@
 <body>
     <navbar></navbar>
 
-    <div class="container-fluid">
+    <div id="main-content" class="container-fluid">
         <div ng-controller="RecordController as ctrl">
+            <div id="record-bookmark-container" class="col-xs-12 meta-icons">
+                <a id="create-record" ng-if="reference && reference.canCreate && ctrl.modifyRecord" title="Click here to create a record" ng-click="::ctrl.createRecord()">
+                    <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
+                </a>&nbsp;&nbsp;
+                <a id="edit-record" ng-if="reference && reference.canUpdate && ctrl.modifyRecord" title="Click here to edit this record" ng-click="::ctrl.editRecord()">
+                    <span class="glyphicon glyphicon-pencil"></span> <strong>Edit Record</strong>
+                </a>&nbsp;&nbsp;
+                <a id="show-all-related-tables" ng-click="ctrl.showEmptyRelatedTables = true">
+                    <span class="glyphicon glyphicon-resize-vertical"></span> <strong>Show All Related Entities</strong>
+                </a>&nbsp;&nbsp;
+                <a id="permalink" title="This link stores your search criteria as a URL. Right click and save." ng-href="{{ctrl.permalink()}}">
+                    <span class="glyphicon glyphicon-bookmark"></span> <strong>Permalink</strong>
+                </a>
+            </div>
+
             <alerts alerts="ctrl.alerts"></alerts>
-        </div>
 
-        <div id="record-bookmark-container" class="col-xs-12 meta-icons" ng-controller="RecordController as ctrl">
-            <a id="create-record" class="coltooltip" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord">
-                <span class="glyphicon glyphicon-plus"></span> <strong> Create Record</strong>
-                <span class="coltooltiptext">Click here to create a record</span>
-            </a>&nbsp;&nbsp;
-            <a id="edit-record" class="coltooltip" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
-                <span class="glyphicon glyphicon-pencil"></span><strong> Edit Record</strong>
-                <span class="coltooltiptext">Click here to edit this record</span>
-            </a>&nbsp;&nbsp;
-            <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord" label="Delete Record" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
-            <a id="permalink" class="coltooltip" ng-href="{{ctrl.permalink()}}">
-                <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
-                <span class="coltooltiptext">This link stores your search criteria as a URL. Right click and save.</span>
-            </a>
-        </div>
+            <div ng-if="reference">
+                <div id="entity-title">{{ recordDisplayname }}</div>
+                <div id="entity-subtitle">{{ reference.displayname }}</div>
+            </div>
 
-        <div ng-if="reference">
-            <div id="entity-title">{{ recordDisplayname }}</div>
-            <div id="entity-subtitle">{{ reference.displayname }}</div>
-        </div>
+            <!-- defined on $rootScope in run function -->
+            <div ng-if="recordValues && columns">
+                <record-display columns="columns" values="recordValues"></record-display>
+            </div>
 
-        <!-- defined on $rootScope in run function -->
-        <div ng-if="recordValues && columns">
-            <record-display columns="columns" values="recordValues"></record-display>
-        </div>
-
-        <uib-accordion close-others="false">
-            <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
-                ng-if="($index === 0 || tableModels[$index-1].hasLoaded) && tableModels[$index].rowValues.length > 0"
-                heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
-                <!-- for different elements inside the accordion -->
-                <div ng-switch on="relatedRef.display.type">
-                    <a class="more-results-link text-right" ng-controller="RecordController as ctrl" ng-click="ctrl.toRecordSet(relatedRef)">View All Records</a>
-                    <div ng-switch-when="markdown">
-                        <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
-                    </div>
-                    <!-- ng-switch-when="table" is also the default case -->
-                    <div ng-switch-default>
-                        <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+            <uib-accordion close-others="false">
+                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index"
+                    ng-if="ctrl.showRelatedTable($index)"
+                    heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
+                    <!-- for different elements inside the accordion -->
+                    <div ng-switch on="relatedRef.display.type">
+                        <div class="row">
+                            <div class="col-xs-12 text-right">
+                                <span ng-if="relatedRef.canCreate && ctrl.modifyRecord"><a class="add-records-link" ng-click="ctrl.addRelatedRecord(relatedRef)">Add Record</a> |</span>
+                                <a class="more-results-link" ng-click="ctrl.toRecordSet(relatedRef)">View All Records</a>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div ng-switch-when="markdown">
+                                    <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
+                                </div>
+                                <!-- ng-switch-when="table" is also the default case -->
+                                <div ng-switch-default>
+                                    <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]"></record-table>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </uib-accordion>
+            </uib-accordion>
+        </div>
     </div>
 </body>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -12,19 +12,20 @@
         <div ng-controller="RecordController as ctrl">
             <div id="record-bookmark-container" class="col-xs-12 meta-icons">
                 <a id="create-record" class="coltooltip" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord">
-                    <span class="glyphicon glyphicon-plus"></span> <strong> Create Record</strong>
+                    <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
                     <span class="coltooltiptext">Click here to create a record</span>
                 </a>&nbsp;&nbsp;
                 <a id="edit-record" class="coltooltip" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
-                    <span class="glyphicon glyphicon-pencil"></span><strong> Edit Record</strong>
+                    <span class="glyphicon glyphicon-pencil"></span> <strong>Edit Record</strong>
                     <span class="coltooltiptext">Click here to edit this record</span>
                 </a>&nbsp;&nbsp;
                 <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord" label="Delete Record" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
-                <a id="show-all-related-tables" ng-click="ctrl.showEmptyRelatedTables = true">
+                <a id="show-all-related-tables" class="coltooltip" ng-click="ctrl.showEmptyRelatedTables = true">
                     <span class="glyphicon glyphicon-resize-vertical"></span> <strong>Show All Related Entities</strong>
+                    <span class="coltooltiptext">Click here to show empty related entities too.</span>
                 </a>&nbsp;&nbsp;
                 <a id="permalink" class="coltooltip" ng-href="{{ctrl.permalink()}}">
-                    <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
+                    <span class="glyphicon glyphicon-bookmark"></span> <strong>Permalink</strong>
                     <span class="coltooltiptext">This link stores your search criteria as a URL. Right click and save.</span>
                 </a>
             </div>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -11,17 +11,21 @@
     <div id="main-content" class="container-fluid">
         <div ng-controller="RecordController as ctrl">
             <div id="record-bookmark-container" class="col-xs-12 meta-icons">
-                <a id="create-record" ng-if="reference && reference.canCreate && ctrl.modifyRecord" title="Click here to create a record" ng-click="::ctrl.createRecord()">
-                    <span class="glyphicon glyphicon-plus"></span> <strong>Create Record</strong>
+                <a id="create-record" class="coltooltip" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord">
+                    <span class="glyphicon glyphicon-plus"></span> <strong> Create Record</strong>
+                    <span class="coltooltiptext">Click here to create a record</span>
                 </a>&nbsp;&nbsp;
-                <a id="edit-record" ng-if="reference && reference.canUpdate && ctrl.modifyRecord" title="Click here to edit this record" ng-click="::ctrl.editRecord()">
-                    <span class="glyphicon glyphicon-pencil"></span> <strong>Edit Record</strong>
+                <a id="edit-record" class="coltooltip" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
+                    <span class="glyphicon glyphicon-pencil"></span><strong> Edit Record</strong>
+                    <span class="coltooltiptext">Click here to edit this record</span>
                 </a>&nbsp;&nbsp;
+                <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord" label="Delete Record" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
                 <a id="show-all-related-tables" ng-click="ctrl.showEmptyRelatedTables = true">
                     <span class="glyphicon glyphicon-resize-vertical"></span> <strong>Show All Related Entities</strong>
                 </a>&nbsp;&nbsp;
-                <a id="permalink" title="This link stores your search criteria as a URL. Right click and save." ng-href="{{ctrl.permalink()}}">
-                    <span class="glyphicon glyphicon-bookmark"></span> <strong>Permalink</strong>
+                <a id="permalink" class="coltooltip" ng-href="{{ctrl.permalink()}}">
+                    <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
+                    <span class="coltooltiptext">This link stores your search criteria as a URL. Right click and save.</span>
                 </a>
             </div>
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -3,6 +3,7 @@
 
     angular.module('chaise.record', [
         'ngSanitize',
+        'ngCookies',
         'chaise.delete',
         'chaise.errors',
         'chaise.modal',
@@ -23,6 +24,11 @@
             nextButtonDisabled: true,
             defaultPageLimit: 25
         };
+    }])
+
+    .config(['$cookiesProvider', function($cookiesProvider) {
+        $cookiesProvider.defaults.path = '/';
+        $cookiesProvider.defaults.secure = true;
     }])
 
     .run(['DataUtils', 'headInjector', 'ERMrest', 'UriUtils', 'ErrorService', 'pageInfo', '$log', '$rootScope', '$window', 'UiUtils', function runApp(DataUtils, headInjector, ERMrest, UriUtils, ErrorService, pageInfo, $log, $rootScope, $window, UiUtils) {
@@ -55,7 +61,7 @@
                 }, function error(exception) {
                     throw exception;
                 }).then(function getPage(page) {
-                    var tuple = page.tuples[0];
+                    var tuple = $rootScope.tuple = page.tuples[0];
                     // Used directly in the record-display directive
                     $rootScope.recordDisplayname = tuple.displayname;
 

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.record')
 
-    .controller('RecordController', ['$window', '$rootScope', 'AlertsService', '$cookies', 'pageInfo', 'DataUtils', 'UriUtils', function RecordController($window, $rootScope, AlertsService, $cookies, pageInfo, DataUtils, UriUtils) {
+    .controller('RecordController', ['AlertsService', '$cookies', '$log', 'UriUtils', '$rootScope', '$window', function RecordController(AlertsService, $cookies, $log, UriUtils, $rootScope, $window) {
         var vm = this;
 
         vm.alerts = AlertsService.alerts;
@@ -30,6 +30,16 @@
             else {
                 $window.location.href = appURL;
             }
+        };
+
+        vm.deleteRecord = function() {
+            $rootScope.reference.delete().then(function deleteSuccess() {
+                //success, go to databrowser or home
+                $window.location.href = (chaiseConfig.dataBrowser ? chaiseConfig.dataBrowser : $window.location.origin);
+            }, function deleteFail(error) {
+                AlertsService.addAlert({type: 'error', message: error.message});
+                $log.warn(response);
+            });
         };
 
         vm.permalink = function getPermalink() {

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -3,11 +3,12 @@
 
     angular.module('chaise.record')
 
-    .controller('RecordController', ['AlertsService', '$log', '$rootScope', '$window', function RecordController(AlertsService, $log, $rootScope, $window) {
+    .controller('RecordController', ['$window', '$rootScope', 'AlertsService', '$cookies', 'pageInfo', 'DataUtils', 'UriUtils', function RecordController($window, $rootScope, AlertsService, $cookies, pageInfo, DataUtils, UriUtils) {
         var vm = this;
 
         vm.alerts = AlertsService.alerts;
         vm.modifyRecord = chaiseConfig.editRecord === false ? false : true;
+        vm.showEmptyRelatedTables = false;
 
         vm.createRecord = function() {
             var newRef = $rootScope.reference.contextualize.entryCreate;
@@ -31,16 +32,6 @@
             }
         };
 
-        vm.deleteRecord = function() {
-            $rootScope.reference.delete().then(function deleteSuccess() {
-                //success, go to databrowser or home
-                $window.location.href = (chaiseConfig.dataBrowser ? chaiseConfig.dataBrowser : $window.location.origin);
-            }, function deleteFail(error) {
-                AlertsService.addAlert({type: 'error', message: error.message});
-                $log.warn(response);
-            });
-        }
-
         vm.permalink = function getPermalink() {
             if (!$rootScope.reference) {
                 return $window.location.href;
@@ -51,11 +42,69 @@
         vm.toRecordSet = function(ref) {
             var appURL = ref.appLink;
             if (!appURL) {
-                AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + ref.compactPath});
+                return AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + ref.compactPath});
             }
-            else {
-                $window.location.href = appURL;
+            return $window.location.href = appURL;
+        };
+
+        vm.showRelatedTable = function(i) {
+            var isFirst = false, prevTableHasLoaded = false;
+            if ($rootScope.tableModels && $rootScope.tableModels[i]) {
+                if (i === 0) {
+                    isFirst = true;
+                } else if ($rootScope.tableModels[i-1]) {
+                    prevTableHasLoaded = $rootScope.tableModels[i-1].hasLoaded;
+                }
+
+                if (vm.showEmptyRelatedTables) {
+                    return isFirst || prevTableHasLoaded;
+                }
+                return (isFirst || prevTableHasLoaded) && $rootScope.tableModels[i].rowValues.length > 0;
             }
         };
+
+        // Send user to RecordEdit to create a new row in this related table
+        vm.addRelatedRecord = function(ref) {
+            // 1. Pluck required values from the ref into cookie obj by getting the values of the keys that form this FK relationship
+            var cookie = {
+                rowname: $rootScope.recordDisplayname,
+                constraintName: ref.origFKR.constraint_names[0].join(':')
+            };
+            var newRef = ref.contextualize.entryCreate;
+            var mapping = newRef.origFKR.mapping;
+
+            // Get the column pair that form this FKR between this related table and the main entity
+            cookie.keys = {};
+            mapping._from.forEach(function(fromColumn, i) {
+                var toColumn = mapping._to[i];
+                // Assign the column value into cookie
+                cookie.keys[fromColumn.name] = $rootScope.tuple.data[toColumn.name];
+            });
+            console.log('Cookie', cookie);
+            // 2. Generate a unique for a coookie, set to expire after 24hrs, set it on browser.
+            var COOKIE_NAME = 'recordedit-' + getRandomInt(0, Number.MAX_SAFE_INTEGER);
+            $cookies.putObject(COOKIE_NAME, cookie, {
+                expires: new Date(Date.now() + (60 * 60 * 24 * 1000))
+            });
+            // 3. Get appLink, append ?prefill=[COOKIE_NAME]
+            var appLink = newRef.appLink + '?prefill=' + UriUtils.fixedEncodeURIComponent(COOKIE_NAME);
+            console.log(appLink);
+            // 4. Redirect to the url in a new tab
+            var window = $window.open(appLink, '_blank');
+            if (window) {
+                // Browser allowed the window to be opened, switch to it.
+                window.focus();
+            } else {
+                // Browser blocked the popup/new window/new tab. TODO: Just redirect in same window?
+                $window.location.href = appLink;
+            }
+        };
+
+        // TODO: Refactor this out to common/
+        function getRandomInt(min, max) {
+          min = Math.ceil(min);
+          max = Math.floor(max);
+          return Math.floor(Math.random() * (max - min)) + min;
+        }
     }]);
 })();

--- a/record/record.css
+++ b/record/record.css
@@ -1,15 +1,20 @@
 .container-fluid {
+    /* If changing paddings here, change the padding in #record-bookmark-container */
     padding-right: 50px;
     padding-left: 50px;
 }
 
-#record-bookmark-container {
-    text-align: right;
-    top: 0;
+#main-content {
+    margin-top: 120px;
 }
 
-.more-results-link {
-    display: block;
-    width: inherit;
-    max-width: inherit;
+#record-bookmark-container {
+    text-align: right;
+    position: fixed;
+    top: 50px;
+    right: 0;
+    padding: 15px 50px 15px 50px; /* padding-left and padding-right sides are to equal the left and right paddings of .container-fluid */
+    background-color: #f1f1f1;
+    box-shadow: 0 4px 2px -2px rgba(0,0,0,0.4);
+    z-index: 1;
 }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.recordEdit')
 
-    .controller('FormController', ['AlertsService', 'recordEditModel', 'UriUtils', '$log', '$rootScope', '$uibModal', '$window', function FormController(AlertsService, recordEditModel, UriUtils, $log, $rootScope, $uibModal, $window) {
+    .controller('FormController', ['AlertsService', 'recordEditModel', 'UriUtils', '$log', '$rootScope', '$uibModal', '$window', '$cookies', function FormController(AlertsService, recordEditModel, UriUtils, $log, $rootScope, $uibModal, $window, $cookies) {
         var vm = this;
         var context = $rootScope.context;
         vm.recordEditModel = recordEditModel;
@@ -57,6 +57,7 @@
                 clearOnBlur: false
             }
         };
+        vm.prefillCookie = $cookies.getObject(context.prefill);
 
         // Takes a page object and uses the uri generated for the reference to construct a chaise uri
         function redirectAfterSubmission(page) {
@@ -161,6 +162,9 @@
             } else {
                 $rootScope.reference.create(model.rows).then(function success(page) {
                     vm.readyToSubmit = false; // form data has already been submitted to ERMrest
+                    if (vm.prefillCookie) {
+                        $cookies.remove(context.prefill);
+                    }
                     vm.redirectAfterSubmission(page);
                 }, function error(response) {
                     vm.showSubmissionError(response);
@@ -275,11 +279,13 @@
             return displayType;
         }
 
-        // Returns with true or an object if input should be disabled
+        // Returns true if column.getInputDisabled returns truthy OR if column was prefilled via cookie
         function isDisabled(column) {
             try {
                 if (column.getInputDisabled(context.appContext)) {
                     return true;
+                } else if (vm.prefillCookie) {
+                    return vm.prefillCookie.hasOwnProperty(column.name);
                 }
                 return false;
             } catch (e) {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -285,7 +285,7 @@
                 if (column.getInputDisabled(context.appContext)) {
                     return true;
                 } else if (vm.prefillCookie) {
-                    return vm.prefillCookie.hasOwnProperty(column.name);
+                    return vm.prefillCookie.constraintName == column.name;
                 }
                 return false;
             } catch (e) {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -239,7 +239,7 @@
             var type = column.type.name;
             var displayType;
             if (isForeignKey(column)) {
-                displayType = 'dropdown';
+                displayType = 'popup-select';
             } else {
                 switch (type) {
                     case 'timestamp':
@@ -294,7 +294,7 @@
         }
 
         function isForeignKey(column) {
-            return column.memberOfForeignKeys.length > 0
+            return column.memberOfForeignKeys.length > 0 || column.isPseudo;
         }
 
         // Returns true if a column type is found in the given array of types

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -104,13 +104,11 @@
                                                 </div>
                                             </div>
                                             <!-- dropdown select input -->
-                                            <div ng-switch-when="dropdown">
-                                                <ui-select ng-model="form.recordEditModel.rows[rowIndex][column.name]" theme="select2" ng-disabled="::form.isDisabled(column);">
-                                                    <ui-select-match name="{{::column.name}}" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">{{$select.selected.display}}</ui-select-match>
-                                                    <ui-select-choices repeat="domainValue.key as domainValue in form.recordEditModel.domainValues[column.name] | filter: $select.search" >
-                                                        <div ng-bind-html="domainValue.display | highlight: $select.search"></div>
-                                                    </ui-select-choices>
-                                                </ui-select>
+                                            <div ng-switch-when="popup-select">
+                                                <span ng-bind="form.recordEditModel.rows[rowIndex][column.name]"></span>
+                                                <button ng-click="form.searchPopup(rowIndex, column)" class="pull-right">
+                                                    <span class="glyphicon glyphicon-search"></span>
+                                                </button>
                                             </div>
                                             <!-- int2 input -->
                                             <input ng-switch-when="integer2" ng-model="form.recordEditModel.rows[rowIndex][column.name]"

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -105,7 +105,7 @@
                                             </div>
                                             <!-- dropdown select input -->
                                             <div ng-switch-when="popup-select">
-                                                <span ng-bind="form.recordEditModel.rows[rowIndex][column.name]"></span>
+                                                <span class="popup-select-value" ng-bind="form.recordEditModel.rows[rowIndex][column.name]"></span>
                                                 <button ng-click="form.searchPopup(rowIndex, column)" class="pull-right">
                                                     <span class="glyphicon glyphicon-search"></span>
                                                 </button>

--- a/recordedit/model.js
+++ b/recordedit/model.js
@@ -7,7 +7,8 @@
     .value('recordEditModel', {
         table: {},
         rows: [{}], // rows of data in the form, not the table from ERMrest
-        domainValues: {}
+        domainValues: {},
+        submissionRows: [{}]
         // , filterUri: ''
     });
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -62,9 +62,6 @@
                     // get the cookie with the prefill value
                     var cookie = $cookies.getObject(context.prefill);
                     if (cookie) {
-                        console.log('Cookie', cookie);
-                        // assign those values into the model
-
                         // Update view model
                         recordEditModel.rows[recordEditModel.rows.length - 1][cookie.constraintName] = cookie.rowname;
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -21,7 +21,7 @@
         'ui.select'
     ])
 
-    .config(['$cookiesProvider', '$windowProvider', function($cookiesProvider, $windowProvider) {
+    .config(['$cookiesProvider', function($cookiesProvider) {
         $cookiesProvider.defaults.path = '/';
         $cookiesProvider.defaults.secure = true;
     }])
@@ -57,58 +57,25 @@
 
                 $log.info("Reference: ", $rootScope.reference);
 
-                // Case for creating an entity with prefilled values
+                // Case for creating an entity, with prefilled values
                 if (context.prefill) {
                     // get the cookie with the prefill value
                     var cookie = $cookies.getObject(context.prefill);
                     if (cookie) {
+                        console.log('Cookie', cookie);
                         // assign those values into the model
-                        Object.keys(cookie).forEach(function(key) {
-                            // TODO: Should refactor this switch statement out into its function after GPCR decodeURIComponent
-                            // It's nearly identical to the switch statement in the if (context.filter) {} case
-                            var colName = key; var colValue = cookie[key]; var colType;
-                            $rootScope.reference.columns.some(function(column) {
-                                if (column.name === colName) {
-                                    colType = column.type.name;
-                                    return true;
-                                }
-                            });
-                            switch (colType) {
-                                case "timestamp":
-                                case "timestamptz":
-                                    if (colValue) {
-                                        // Cannot ensure that all timestamp values are formatted in ISO 8601
-                                        // TODO: Fix pretty print fn in ermrestjs to return ISO 8601 format instead of toLocaleString?
-                                        var ts = moment(colValue);
-                                        value = {
-                                            date: ts.format('YYYY-MM-DD'),
-                                            time: ts.format('hh:mm:ss'),
-                                            meridiem: ts.format('A')
-                                        };
-                                    } else {
-                                        value = {
-                                            date: null,
-                                            time: null,
-                                            meridiem: null
-                                        };
-                                    }
-                                    break;
-                                case "int2":
-                                case "int4":
-                                case "int8":
-                                    colValue = (colValue ? parseInt(colValue, 10) : '');
-                                    break;
-                                case "float4":
-                                case "float8":
-                                case "numeric":
-                                    colValue = (colValue ? parseFloat(colValue) : '');
-                                    break;
-                                default:
-                                    break;
-                            }
-                            recordEditModel.rows[recordEditModel.rows.length - 1][colName] = colValue;
+
+                        // Update view model
+                        recordEditModel.rows[recordEditModel.rows.length - 1][cookie.constraintName] = cookie.rowname;
+
+                        // Update submission model
+                        var columnNames = Object.keys(cookie.keys);
+                        columnNames.forEach(function(colName) {
+                            var colValue = cookie.keys[colName];
+                            recordEditModel.submissionRows[recordEditModel.submissionRows.length - 1][colName] = colValue;
                         });
                     }
+                    console.log('Model', recordEditModel);
                 }
 
                 // Case for editing an entity

--- a/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
@@ -54,14 +54,14 @@ describe('Navbar ', function() {
         });
     });
 
-    // These tests are xit'd because we don't handle tests logging in via Globus/other services just yet
+    // TODO: These tests are xit'd because we don't handle tests logging in via Globus/other services just yet
     // e.g. On Travis, the user is logged in. On local machines, you must log in manually, which changes the desired order of specs.
     xit('should have a "Log In" link', function() {
         var actualLink = element(by.id('login-link'));
         browser.wait(EC.elementToBeClickable(actualLink), 10000).then(function() {
             expect(actualLink.isDisplayed()).toBeTruthy();
         });
-    });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
 
     xit('should have a "Sign Up" link with the right href from chaiseConfig', function(done) {
         if (chaiseConfig.signUpURL) {
@@ -75,7 +75,7 @@ describe('Navbar ', function() {
             expect(element(by.id('signup-link')).isPresent()).toBeFalsy();
             done();
         }
-    });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
 
     xit('should display a "Log Out" link', function(done) {
         var logOutLink = element(by.id('logout-link'));
@@ -84,7 +84,7 @@ describe('Navbar ', function() {
             expect(logOutLink.isDisplayed()).toBeTruthy();
             done();
         });
-    });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
 
     xit('should link to the profile URL from chaiseConfig, if specified', function() {
         var actual = element.all(by.css('.username'));
@@ -94,5 +94,5 @@ describe('Navbar ', function() {
         } else {
             expect(actual.getAttribute('href')).toBeFalsy();
         }
-    });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
 });

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -303,13 +303,17 @@ exports.relatedTableLinks = function (tableParams) {
 
         var allWindows;
         addRelatedRecordLink.click().then(function() {
+            // This Add link opens in a new tab so we have to track the windows in the browser...
             return browser.getAllWindowHandles();
         }).then(function(handles) {
             allWindows = handles;
+            // ... and switch to the new tab here...
             return browser.switchTo().window(allWindows[1]);
         }).then(function() {
+            // ... and then get the url from this new tab...
             return browser.driver.getCurrentUrl();
         }).then(function(url) {
+            // ... before switching back to the original Record app's tab so that the next it spec can run properly
             browser.switchTo().window(allWindows[0]);
             expect(url.indexOf('recordedit')).toBeGreaterThan(-1);
             expect(url.indexOf(relatedTableName)).toBeGreaterThan(-1);

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -291,6 +291,32 @@ exports.relatedTableLinks = function (tableParams) {
         });
     });
 
+    it('should have a Add link for a related table that redirects to that related table in recordedit with a prefill query parameter.', function() {
+        var EC = protractor.ExpectedConditions,
+            relatedTableName = tableParams.related_table_name_with_more_results,
+            addRelatedRecordLink = chaisePage.recordPage.getAddRecordLink(relatedTableName);
+
+        // Should make sure user is logged in
+        browser.wait(EC.elementToBeClickable(addRelatedRecordLink), 10000);
+
+        expect(addRelatedRecordLink.isDisplayed()).toBeTruthy();
+
+        var allWindows;
+        addRelatedRecordLink.click().then(function() {
+            return browser.getAllWindowHandles();
+        }).then(function(handles) {
+            allWindows = handles;
+            return browser.switchTo().window(allWindows[1]);
+        }).then(function() {
+            return browser.driver.getCurrentUrl();
+        }).then(function(url) {
+            browser.switchTo().window(allWindows[0]);
+            expect(url.indexOf('recordedit')).toBeGreaterThan(-1);
+            expect(url.indexOf(relatedTableName)).toBeGreaterThan(-1);
+            expect(url.indexOf('?prefill=')).toBeGreaterThan(-1);
+        });
+    });
+
     it("should have a View All link for a related table that redirects to recordset.", function() {
         var EC = protractor.ExpectedConditions,
             relatedTableName = tableParams.related_table_name_with_more_results,

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -121,6 +121,10 @@ describe('Record Add', function() {
     describe('When url has a prefill query string param set, ', function() {
         var testCookie = {};
         beforeAll(function() {
+            // Refresh the page
+            browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+            browser.sleep(3000);
+
             // Write a dummy cookie for creating a record in Accommodation table
             testCookie = {
                 constraintName: 'product:accommodation_category_fkey1', // A FK that Accommodation table has with Category table

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -121,9 +121,6 @@ describe('Record Add', function() {
     describe('When url has a prefill query string param set, ', function() {
         var testCookie = {};
         beforeAll(function() {
-            browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
-            browser.sleep(3000);
-
             // Write a dummy cookie for creating a record in Accommodation table
             testCookie = {
                 constraintName: 'product:accommodation_category_fkey1', // A FK that Accommodation table has with Category table

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -146,7 +146,7 @@ describe('Record Add', function() {
         });
 
         afterAll(function() {
-            browser.manage().deleteCookieNamed('test');
+            browser.manage().deleteCookie('test');
         });
     });
 

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -1,5 +1,5 @@
 var chaisePage = require('../../../../utils/chaise.page.js'), IGNORE = "tag:isrd.isi.edu,2016:ignore", HIDDEN = "tag:misd.isi.edu,2015:hidden";
-var recordEditHelpers = require('../../helpers.js');
+var recordEditHelpers = require('../../helpers.js'), chance = require('chance').Chance();
 
 describe('Record Add', function() {
 
@@ -100,6 +100,38 @@ describe('Record Add', function() {
 					}).pend("Postpone test until foreign key UI is updated for the new reference apis");
 
 				});
+
+                it('should pre-fill fields from cookie if prefill query param is set', function() {
+                    if (tableParams.table_name.toLowerCase() == 'Accommodation'.toLowerCase()) {
+                        // Write a dummy cookie for creating a record in Accommodation table
+                        var testCookie = {
+                            title: chance.sentence(),
+                            rating: chance.floating({min: 0, max: 100})
+                        };
+                        browser.manage().addCookie('test', JSON.stringify(testCookie));
+
+                        // Reload the page with prefill query param in url
+                        browser.get(browser.params.url + ":" + tableParams.table_name + '?prefill=test');
+                        browser.sleep(3000);
+
+                        browser.manage().getCookie('test').then(function(cookie) {
+                            if (cookie) {
+                                // Check if those fields have the values
+                                Object.keys(testCookie).forEach(function(cookieKey) {
+                                    chaisePage.recordEditPage.getInputForAColumn(cookieKey).then(function(input) {
+                                        var inputValue = input.getAttribute('value');
+                                        var expectedValue = testCookie[cookieKey];
+                                        expect(inputValue).toBe(inputValue);
+                                    });
+                                });
+                            } else {
+                                expect('Cookie did not load').toEqual('but cookie should have loaded');
+                            }
+                            browser.get(browser.params.url + ":" + tableParams.table_name);
+                            browser.sleep(3000);
+                        });
+                    }
+                });
 
     		});
 

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -20,11 +20,11 @@ describe('Record Add', function() {
 					browser.sleep(3000);
 			    });
 
-				describe("Presentation and validation,", function() {
+				xdescribe("Presentation and validation,", function() {
 					var params = recordEditHelpers.testPresentationAndBasicValidation(tableParams);
 				});
 
-				describe("delete record, ", function() {
+				xdescribe("delete record, ", function() {
 
 					if (tableParams.records > 1) {
 
@@ -65,7 +65,7 @@ describe('Record Add', function() {
 					}
 				});
 
-				describe("Submit " + tableParams.records + " records", function() {
+				xdescribe("Submit " + tableParams.records + " records", function() {
 					beforeAll(function() {
 						// Submit the form
 						chaisePage.recordEditPage.submitForm();
@@ -100,44 +100,43 @@ describe('Record Add', function() {
 					}).pend("Postpone test until foreign key UI is updated for the new reference apis");
 
 				});
-
-                it('should pre-fill fields from cookie if prefill query param is set', function() {
-                    if (tableParams.table_name.toLowerCase() == 'Accommodation'.toLowerCase()) {
-                        // Write a dummy cookie for creating a record in Accommodation table
-                        var testCookie = {
-                            title: chance.sentence(),
-                            rating: chance.floating({min: 0, max: 100})
-                        };
-                        browser.manage().addCookie('test', JSON.stringify(testCookie));
-
-                        // Reload the page with prefill query param in url
-                        browser.get(browser.params.url + ":" + tableParams.table_name + '?prefill=test');
-                        browser.sleep(3000);
-
-                        browser.manage().getCookie('test').then(function(cookie) {
-                            if (cookie) {
-                                // Check if those fields have the values
-                                Object.keys(testCookie).forEach(function(cookieKey) {
-                                    chaisePage.recordEditPage.getInputForAColumn(cookieKey).then(function(input) {
-                                        var inputValue = input.getAttribute('value');
-                                        var expectedValue = testCookie[cookieKey];
-                                        expect(inputValue).toBe(inputValue);
-                                    });
-                                });
-                            } else {
-                                expect('Cookie did not load').toEqual('but cookie should have loaded');
-                            }
-                            browser.get(browser.params.url + ":" + tableParams.table_name);
-                            browser.sleep(3000);
-                        });
-                    }
-                });
-
     		});
 
     	})(testParams.tables[i], i);
 
     }
+
+    describe('When url has a prefill query string param set, ', function() {
+        var testCookie = {};
+        beforeAll(function() {
+            // Write a dummy cookie for creating a record in Accommodation table
+            testCookie = {
+                constraintName: 'product:accommodation_category_fkey1', // A FK that Accommodation table has with Category table
+                rowname: chance.sentence(),
+                keys: {id: 1}
+            };
+            browser.manage().addCookie('test', JSON.stringify(testCookie));
+
+            // Reload the page with prefill query param in url
+            browser.get(browser.params.url + ":" + testParams.tables[0].table_name + '?prefill=test');
+            browser.sleep(3000);
+        });
+
+        it('should pre-fill fields from the prefill cookie', function() {
+            browser.manage().getCookie('test').then(function(cookie) {
+                if (cookie) {
+                    var input = element.all(by.css('.popup-select-value')).first();
+                    expect(input.getText()).toBe(testCookie.rowname);
+                } else {
+                    expect('Cookie did not load').toEqual('but cookie should have loaded');
+                }
+            });
+        });
+
+        afterAll(function() {
+            browser.manage().deleteCookieNamed('test');
+        });
+    });
 
     it('should load custom CSS and document title defined in chaise-config.js', function() {
         var chaiseConfig = browser.executeScript('return chaiseConfig');

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -20,11 +20,11 @@ describe('Record Add', function() {
 					browser.sleep(3000);
 			    });
 
-				xdescribe("Presentation and validation,", function() {
+				describe("Presentation and validation,", function() {
 					var params = recordEditHelpers.testPresentationAndBasicValidation(tableParams);
 				});
 
-				xdescribe("delete record, ", function() {
+				describe("delete record, ", function() {
 
 					if (tableParams.records > 1) {
 
@@ -65,7 +65,7 @@ describe('Record Add', function() {
 					}
 				});
 
-				xdescribe("Submit " + tableParams.records + " records", function() {
+				describe("Submit " + tableParams.records + " records", function() {
 					beforeAll(function() {
 						// Submit the form
 						chaisePage.recordEditPage.submitForm();
@@ -106,9 +106,24 @@ describe('Record Add', function() {
 
     }
 
+    it('should load custom CSS and document title defined in chaise-config.js', function() {
+        var chaiseConfig = browser.executeScript('return chaiseConfig');
+        if (chaiseConfig.customCSS) {
+            expect($("link[href='" + chaiseConfig.customCSS + "']").length).toBeTruthy();
+        }
+        if (chaiseConfig.headTitle) {
+            browser.getTitle().then(function(title) {
+                expect(title).toEqual(chaiseConfig.headTitle);
+            });
+        }
+    });
+
     describe('When url has a prefill query string param set, ', function() {
         var testCookie = {};
         beforeAll(function() {
+            browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+            browser.sleep(3000);
+
             // Write a dummy cookie for creating a record in Accommodation table
             testCookie = {
                 constraintName: 'product:accommodation_category_fkey1', // A FK that Accommodation table has with Category table
@@ -136,18 +151,6 @@ describe('Record Add', function() {
         afterAll(function() {
             browser.manage().deleteCookieNamed('test');
         });
-    });
-
-    it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig = browser.executeScript('return chaiseConfig');
-        if (chaiseConfig.customCSS) {
-            expect($("link[href='" + chaiseConfig.customCSS + "']").length).toBeTruthy();
-        }
-        if (chaiseConfig.headTitle) {
-            browser.getTitle().then(function(title) {
-                expect(title).toEqual(chaiseConfig.headTitle);
-            });
-        }
     });
 
 });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -509,6 +509,11 @@ var recordPage = function() {
         return element(by.id("rt-heading-" + displayName)).element(by.css(".more-results-link"));
     };
 
+    this.getAddRecordLink = function(displayName) {
+        // the link is not a child of the table, rather one of the accordion group
+        return element(by.id("rt-heading-" + displayName)).element(by.css(".add-records-link"));
+    };
+
     this.getRelatedTableRowValues = function(displayName) {
         return that.getRelatedTableRows(displayName).all(by.tagName("td"));
     };


### PR DESCRIPTION
This PR addresses #667 and #669. These 2 issues combine to describe a workflow in which:

- A user goes to a Record page and clicks an Add Record link on one of the related tables.
- The link takes the user to the RecordEdit page, where the foreign key relationship between the the main entity on the Record page and the clicked related table is pre-filled.

To test:
1. Go to [this record](https://dev.isrd.isi.edu/~jessie/chaise/record/#1/legacy:dataset/id=4894) on Record app.
2. Click the `Add Record` link for the External Reference related table (at the bottom)
3.  The browser open the RecordEdit app in a new tab, and the url in the new tab should have a `?prefill=` query parameter in the url.
4.  The `id` column on the RecordEdit tab should have the rowname of the main entity from Record page as its pre-filled value.