### PR TITLE
Fixed issue 271 in ermrestjs

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -116,7 +116,12 @@
                     }
                 };
 
-                scope.rowClickAction = function(index) {
+                scope.rowClickAction = function(event, index) {
+                    var el = event.target || event.srcElement;
+                    if (el.nodeName.toLowerCase() === 'a' || el.nodeName.toLowerCase() === 'button') {
+                        return false;
+                    }
+
                     var args = {"tuple": scope.vm.page.tuples[index]};
                     if (scope.defaultRowLinking !== undefined && scope.defaultRowLinking === true) {
                         scope.gotoRowLink(index);

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -14,9 +14,9 @@
 
         <!-- rows -->
         <tbody>
-            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="rowClickAction($index)" ng-style="{'cursor': 'pointer'}">
+            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="rowClickAction($event, $index)" ng-style="{'cursor': 'pointer'}">
                 <td ng-repeat="val in row track by $index" ng-switch="val.isHTML">
-                    <span ng-switch-when="true" ng-bind-html="val.value" ng-click="$event.stopPropagation()" ng-style="{'cursor': 'auto'}"></span>
+                    <div ng-switch-when="true" ng-bind-html="val.value" ng-style="{'cursor': 'pointer'}"></div>
                     <span ng-switch-default>{{val.value}}</span>
                 </td>
             </tr>


### PR DESCRIPTION
This PR fixes issue [Search modal has area that is not clickable](https://github.com/informatics-isi-edu/ermrestjs/issues/271) in ermrestjs. 

 The problem was that the span which contained the markdowndidn't allow to bubble the click actions to the row above it.

I have enabled it and I am explicitly checking for if the target is an anchor or button tag don't bubble up or else propagate it as a row click event.

You can test he functionality for search modal [here](https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/experiments:sample) and recordset over [here](https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/experiments:sample)