### PR TITLE
Loading... message shows properly

### DIFF
--- a/record/record.app.js
+++ b/record/record.app.js
@@ -77,7 +77,7 @@
                     $rootScope.tableModels = [];
                     $rootScope.lastRendered = null;
 
-                    if ($rootScope.relatedReferences.length > 0) $rootScope.loading = true;
+                    $rootScope.loading = ($rootScope.relatedReferences.length > 0);
                     for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
                         $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
 

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -69,10 +69,11 @@
                     prevTableHasLoaded = $rootScope.tableModels[i-1].hasLoaded;
                     if ($rootScope.lastRendered == (i-1)) {
                         $rootScope.lastRendered = i;
-                        if ($rootScope.lastRendered == $rootScope.relatedReferences.length-1) {
-                            $rootScope.loading = false;
-                        }
                     }
+                }
+                
+                if ($rootScope.lastRendered == $rootScope.relatedReferences.length-1) {
+                    $rootScope.loading = false;
                 }
 
                 if (vm.showEmptyRelatedTables) {


### PR DESCRIPTION
This PR addresses the loading message appearing when there is 1 related table. I tested this in situations where there are multiple tables, 1 table, 0 tables, as well as entities with hidden tables to begin with.