### PR TITLE
Handle no session properly

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -3,8 +3,14 @@
 
     angular.module('chaise.errors', ['chaise.alerts', 'chaise.authen', 'chaise.modal', 'chaise.utils'])
 
+    .constant('errorNames', {
+        unauthorized: "Unauthorized",
+        forbidden: "Forbidden",
+        notFound: "Not Found"
+    })
+
     // Factory for each error type
-    .factory('ErrorService', ['AlertsService', 'Session', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, Session, $log, $rootScope, $uibModal, $window) {
+    .factory('ErrorService', ['AlertsService', 'errorNames', 'Session', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, errorNames, Session, $log, $rootScope, $uibModal, $window) {
 
         function errorPopup(message, errorCode, pageName, redirectLink) {
             var providedLink = true;
@@ -32,7 +38,7 @@
             });
 
             modalInstance.result.then(function () {
-                if (errorCode == "Unauthorized" && !providedLink) {
+                if (errorCode == errorNames.unauthorized && !providedLink) {
                     Session.login($window.location.href);
                 } else {
                     $window.location.replace(redirectLink);
@@ -44,7 +50,7 @@
         function catchAll(exception) {
             $log.info(exception);
 
-            if (exception instanceof ERMrest.UnauthorizedError || exception.code == "Unauthorized") {
+            if (exception instanceof ERMrest.UnauthorizedError || exception.code == errorNames.unauthorized) {
                 Session.login($window.location.href);
             } else {
                 AlertsService.addAlert({type:'error', message:exception.message});

--- a/common/errors.js
+++ b/common/errors.js
@@ -32,7 +32,7 @@
             });
 
             modalInstance.result.then(function () {
-                if (errorCode == "401 Unauthorized" && !providedLink) {
+                if (errorCode == "Unauthorized" && !providedLink) {
                     Session.login($window.location.href);
                 } else {
                     $window.location.replace(redirectLink);
@@ -44,7 +44,7 @@
         function catchAll(exception) {
             $log.info(exception);
 
-            if (exception instanceof ERMrest.UnauthorizedError || exception.code == "401 Unauthorized") {
+            if (exception instanceof ERMrest.UnauthorizedError || exception.code == "Unauthorized") {
                 Session.login($window.location.href);
             } else {
                 AlertsService.addAlert({type:'error', message:exception.message});

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -59,11 +59,8 @@
 
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }, function sessionFailed() {
-                var noSessionMessage = "There is no current session.";
-                var noSessionError = new Error(noSessionMessage);
-                noSessionError.code = "401 Unauthorized";
-
-                throw noSessionError;
+                // do nothing but return without a session
+                return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }).then(function getReference(reference) {
                 $rootScope.reference = (context.filter ? reference.contextualize.entryEdit : reference.contextualize.entryCreate);
                 $rootScope.reference.session = session;

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -96,7 +96,7 @@
                                 var filter = context.filter;
                                 var noDataMessage = "No entity exists with " + filter.column + filter.operator + filter.value;
                                 var noDataError = new Error(noDataMessage);
-                                noDataError.code = "404 Not Found";
+                                noDataError.code = "Not Found";
 
                                 throw noDataError;
                             }
@@ -155,21 +155,35 @@
                         }).catch(function readCatch(exception) {
                             ErrorService.errorPopup(exception.message, exception.code, "home page");
                         });
+                    } else if (session) {
+                        var notAuthorizedMessage = "You are not authorized to Update entities.";
+                        var notAuthorizedError = new Error(notAuthorizedMessage);
+                        notAuthorizedError.code = "Fordbidden";
+
+                        throw notAuthorizedError;
                     } else {
                         var notAuthorizedMessage = "You are not authorized to Update entities.";
                         var notAuthorizedError = new Error(notAuthorizedMessage);
-                        notAuthorizedError.code = "403 Fordbidden";
+
+                        notAuthorizedError.code = "Unauthorized";
 
                         throw notAuthorizedError;
                     }
                 } else {
                     if ($rootScope.reference.canCreate) {
                         $rootScope.displayname = $rootScope.reference.displayname;
+                    } else if (session) {
+                        var forbiddenMessage = "You are not authorized to Create entities.";
+                        var forbiddenError = new Error(forbiddenMessage);
+
+                        forbiddenError.code = "Forbidden";
+
+                        throw forbiddenError;
                     } else {
                         var notAuthorizedMessage = "You are not authorized to Create entities.";
                         var notAuthorizedError = new Error(notAuthorizedMessage);
 
-                        notAuthorizedError.code = "403 Fordbidden";
+                        notAuthorizedError.code = "Unauthorized";
 
                         throw notAuthorizedError;
                     }
@@ -178,9 +192,9 @@
                 $log.warn(response);
                 throw response;
             }).catch(function genericCatch(exception) {
-                if (exception instanceof ERMrest.UnauthorizedError || exception.code == "401 Unauthorized") {
+                if (exception instanceof ERMrest.UnauthorizedError || exception.code == "Unauthorized") {
                     ErrorService.catchAll(exception);
-                } else if (exception.code == "403 Forbidden") {
+                } else if (exception.code == "Forbidden") {
                     ErrorService.errorPopup(exception.message, exception.code, "previous page", $window.document.referrer);
                 } else {
                     ErrorService.errorPopup(exception.message, exception.code, "home page");

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -27,9 +27,12 @@
         $cookiesProvider.defaults.secure = true;
     }])
 
-    .run(['ERMrest', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies', function runRecordEditApp(ERMrest, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
+    .run(['ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
+        function runRecordEditApp(ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
+
         var session,
             context = { booleanValues: ['', true, false] };
+            
         UriUtils.setOrigin();
         headInjector.addTitle();
         headInjector.addCustomCSS();
@@ -96,7 +99,7 @@
                                 var filter = context.filter;
                                 var noDataMessage = "No entity exists with " + filter.column + filter.operator + filter.value;
                                 var noDataError = new Error(noDataMessage);
-                                noDataError.code = "Not Found";
+                                noDataError.code = errorNames.notFound;
 
                                 throw noDataError;
                             }
@@ -158,14 +161,14 @@
                     } else if (session) {
                         var notAuthorizedMessage = "You are not authorized to Update entities.";
                         var notAuthorizedError = new Error(notAuthorizedMessage);
-                        notAuthorizedError.code = "Fordbidden";
+                        notAuthorizedError.code = errorNames.forbidden;
 
                         throw notAuthorizedError;
                     } else {
                         var notAuthorizedMessage = "You are not authorized to Update entities.";
                         var notAuthorizedError = new Error(notAuthorizedMessage);
 
-                        notAuthorizedError.code = "Unauthorized";
+                        notAuthorizedError.code = errorNames.unauthorized;
 
                         throw notAuthorizedError;
                     }
@@ -176,14 +179,14 @@
                         var forbiddenMessage = "You are not authorized to Create entities.";
                         var forbiddenError = new Error(forbiddenMessage);
 
-                        forbiddenError.code = "Forbidden";
+                        forbiddenError.code = errorNames.forbidden;
 
                         throw forbiddenError;
                     } else {
                         var notAuthorizedMessage = "You are not authorized to Create entities.";
                         var notAuthorizedError = new Error(notAuthorizedMessage);
 
-                        notAuthorizedError.code = "Unauthorized";
+                        notAuthorizedError.code = errorNames.unauthorized;
 
                         throw notAuthorizedError;
                     }
@@ -192,9 +195,9 @@
                 $log.warn(response);
                 throw response;
             }).catch(function genericCatch(exception) {
-                if (exception instanceof ERMrest.UnauthorizedError || exception.code == "Unauthorized") {
+                if (exception instanceof ERMrest.UnauthorizedError || exception.code == errorNames.unauthorized) {
                     ErrorService.catchAll(exception);
-                } else if (exception.code == "Forbidden") {
+                } else if (exception.code == errorNames.forbidden) {
                     ErrorService.errorPopup(exception.message, exception.code, "previous page", $window.document.referrer);
                 } else {
                     ErrorService.errorPopup(exception.message, exception.code, "home page");

--- a/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/data-dependent/00-navbar.spec.js
@@ -8,7 +8,6 @@ describe('Navbar ', function() {
         menu = element(by.id('navbar-menu'));
         browser.executeScript('return chaiseConfig').then(function(config) {
             chaiseConfig = config;
-            console.log(chaiseConfig);
             return browser.wait(EC.presenceOf(navbar), 5000);
         }).then(function() {
             done();

--- a/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
+++ b/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
@@ -26,7 +26,6 @@ describe('View existing record,', function() {
 
                 it('should load document title defined in chaise-config.js and have showDeleteButton=true', function(done) {
                     browser.executeScript("return chaiseConfig;").then(function(chaiseConfig) {
-                        console.log(chaiseConfig);
                         expect(chaiseConfig.showDeleteButton).toBe(true);
                         if (chaiseConfig.headTitle) {
                             browser.getTitle().then(function(title) {


### PR DESCRIPTION
This PR addresses issue #722. When no session is find in `recordedit` it continues on rather than throwing a not found error. This will now properly error out when checking the ACLs for the returned reference.

I also removed the error code numbers from the error messages that show up in the modal.