### PR TITLE
Fixed issue #761, sort-icon not showing up in modal for recordset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,7 @@ DETAILED_JS_SOURCE= $(JS)/respond.js \
 
 DETAILED_SHARED_CSS_DEPS=$(CSS)/vendor/bootstrap.min.css \
 	$(CSS)/material-design/css/material-design-iconic-font.min.css \
+	$(CSS)/font-awesome/css/font-awesome.min.css \
 	$(COMMON)/styles/appheader.css
 
 DETAILED_CSS_DEPS=$(DETAILED_ASSETS)/lib/slippry/slippry.css \
@@ -288,6 +289,7 @@ RE_JS_SOURCE=$(RE_ASSETS)/recordEdit.app.js \
 
 RE_SHARED_CSS_DEPS=$(CSS)/vendor/bootstrap.min.css \
 	$(CSS)/material-design/css/material-design-iconic-font.min.css \
+	$(CSS)/font-awesome/css/font-awesome.min.css \
 	$(CSS)/vendor/select.css \
 	$(CSS)/vendor/select2.css \
 	$(CSS)/vendor/angular-datepicker.css \


### PR DESCRIPTION
This PR fixes issue #761 . 

The reason the icon wasn't loaded was because recordedit page didn't had font-awesome.css included. The icons are dependent on that css.

This can be tested here https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/gpcr_browser:construct_gui/