### PR TITLE
Tuple.displayname is now HTML. Use html binding where it's used. #769

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -37,7 +37,7 @@
             <alerts alerts="ctrl.alerts"></alerts>
 
             <div ng-if="reference">
-                <div id="entity-title">{{ recordDisplayname }}</div>
+                <div id="entity-title" ng-bind-html="recordDisplayname"></div>
                 <div id="entity-subtitle">{{ reference.displayname }}</div>
             </div>
 

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -38,7 +38,7 @@
                     <div class="col-xs-12">
                         <div class="row">
                             <div class="col-xs-7">
-                                <div id="entity-title"><span ng-if="::!form.editMode">Create</span><span ng-if="::form.editMode">Edit</span> {{displayname}} Record<span ng-show="form.recordEditModel.rows.length > 1">s</span></div>
+                                <div id="entity-title"><span ng-if="::!form.editMode">Create</span><span ng-if="::form.editMode">Edit</span> <span ng-bind-html="displayname"></span> Record<span ng-show="form.recordEditModel.rows.length > 1">s</span></div>
                                 <span class="text-danger">*</span> indicates required field
                             </div>
                             <div class="col-xs-5 padding-top-10">


### PR DESCRIPTION
PR for issue #769 (requires https://github.com/informatics-isi-edu/ermrestjs/pull/286 to be merged)
Show entity displayname (tuple.displayname) as HTML.

Before:
https://cirm-dev.isrd.isi.edu/chaise/record/#1/Microscopy:Experiment/ID=20160914-H%26ENone-JAM-0

After:
https://cirm-dev.isrd.isi.edu/~jchen/chaise/record/#1/Microscopy:Experiment/ID=20160914-H%26ENone-JAM-0