### PR TITLE
Make sure the FK popup modal only appears for pseudocolumns

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -396,7 +396,7 @@
         }
 
         function isForeignKey(column) {
-            return (column.memberOfForeignKeys.length > 0 || column.isPseudo);
+            return column.isPseudo;
         }
 
         // Returns true if a column type is found in the given array of types

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -107,7 +107,7 @@
                                             <!-- modal popup input -->
                                             <div ng-switch-when="popup-select" class="form-group has-feedback input-group modal-popup">
                                                 <label class="sr-only"></label>
-                                                <div class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
+                                                <div contenteditable="false" class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
                                                     ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                 <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '80px'}">
                                                     <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)"></span>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -107,7 +107,7 @@
                                             <!-- modal popup input -->
                                             <div ng-switch-when="popup-select" class="form-group has-feedback input-group modal-popup">
                                                 <label class="sr-only"></label>
-                                                <div class="form-control popup-select-value" type="text" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);"
+                                                <div class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
                                                     ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                 <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '80px'}">
                                                     <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)"></span>

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -307,6 +307,17 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 					});
 				});
 
+                it('should show an uneditable field for each foreign key column', function() {
+                    var expectedNumOfPopupFields = columns.length * (recordIndex + 1);
+                    var popupFields = element.all(by.css('.popup-select-value'));
+                    expect(popupFields.count()).toBe(expectedNumOfPopupFields);
+                    // Ensure each field is an uneditable div element (not an input)
+                    popupFields.map(function(field) {
+                        expect(field.getTagName()).toBe('div');
+                        expect(field.getAttribute('contenteditable')).toBe('false');
+                    });
+                });
+
                 // in the edit case
                 if (!tableParams.records) {
 


### PR DESCRIPTION
This PR fixes #706. To help avoid an "editable" field for these FK fields in the future, I added `contenteditable=false` to the `div` for these FK fields and a test case that checks it's an uneditable `div` (instead of an unforeseen `input` field that would allow editing).