### PR TITLE
Fix related table headings count

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -48,7 +48,7 @@
 
             <uib-accordion close-others="false">
                 <div uib-accordion-group class="related-table-heading" id="rt-heading-{{relatedRef.displayname}}" ng-repeat="relatedRef in relatedReferences track by $index" ng-if="ctrl.showRelatedTable($index)"
-                    heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}})" is-open="tableModels[$index].open">
+                    heading="{{tableModels[$index].open ? '-' : '+'}} {{relatedRef.displayname}} ({{tableModels[$index].rowValues.length}}{{tableModels[$index].hasNext ? '+' : ''}})" is-open="tableModels[$index].open">
                     <!-- for different elements inside the accordion -->
                     <div ng-switch on="relatedRef.display.type">
                         <div class="row">

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -98,7 +98,6 @@
 
                         (function(i) {
                             $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
-
                                 var model = {
                                     reference: $rootScope.relatedReferences[i],
                                     columns: $rootScope.relatedReferences[i].columns,
@@ -117,13 +116,11 @@
                             }, function readFail() {
                                 var model = {
                                     hasLoaded: true
-                                }
-
+                                };
                                 $rootScope.tableModels[i] = model;
                             });
                         })(i);
                     }
-
                 }, function error(response) {
                     $log.warn(response);
                     throw response;

--- a/test/e2e/data_setup/config/record.dev.json
+++ b/test/e2e/data_setup/config/record.dev.json
@@ -31,7 +31,7 @@
                 "deleteKeys": [{ "name": "id", "value": "4004", "operator": "="}],
                 "title": "Sherathon Hotel",
                 "subTitle" : "Accommodations",
-                "tables_order" : ["- booking (2)", "- accommodation_image (2)"],
+                "tables_order" : ["- booking (2)", "- accommodation_image (2+)"],
                 "related_table_name_with_page_size_annotation" : "accommodation_image",
                 "page_size" : 2,
                 "related_tables" : [

--- a/test/e2e/data_setup/config/related-table-link.dev.json
+++ b/test/e2e/data_setup/config/related-table-link.dev.json
@@ -31,7 +31,7 @@
                 "related_table_name_with_link_in_table" : "accommodation_image",
                 "related_table_name_with_page_size_annotation" : "accommodation_image",
                 "keys" : [{ "name": "id", "value": "2004", "operator": "=" }],
-                "tables_order" : [ "- accommodation_image (2)", "- booking (6)", "- media (1)" ],
+                "tables_order" : [ "- accommodation_image (2+)", "- booking (6)", "- media (1)" ],
                 "booking_count" : 6,
                 "page_size" : 2
             }]

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -167,7 +167,12 @@ exports.testPresentation = function (tableParams) {
                     // verify all rows are present
                     chaisePage.recordPage.getRelatedTableRows(displayName).count().then(function(rowCount) {
                         expect(rowCount).toBe(relatedTables[i].data.length);
-                        expect(headings[i]).toBe("- " + displayName + " (" + rowCount + ")");
+                        // The annotation_image table has more rows than the page_size, so its heading will have a + after the row count
+                        if (displayName == tableParams.related_table_name_with_page_size_annotation) {
+                            expect(headings[i]).toBe("- " + displayName + " (" + rowCount + "+)");
+                        } else {
+                            expect(headings[i]).toBe("- " + displayName + " (" + rowCount + ")");
+                        }
                     });
                 })(i, displayName);
             }
@@ -344,7 +349,8 @@ exports.relatedTableLinks = function (tableParams) {
             // ... and then get the url from this new tab...
             return browser.driver.getCurrentUrl();
         }).then(function(url) {
-            // ... before switching back to the original Record app's tab so that the next it spec can run properly
+            // ... before closing this new tab and switching back to the original Record app's tab so that the next it spec can run properly
+            browser.close();
             browser.switchTo().window(allWindows[0]);
             expect(url.indexOf('recordedit')).toBeGreaterThan(-1);
             expect(url.indexOf(relatedTableName)).toBeGreaterThan(-1);

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -167,10 +167,13 @@ exports.testPresentation = function (tableParams) {
                     // verify all rows are present
                     chaisePage.recordPage.getRelatedTableRows(displayName).count().then(function(rowCount) {
                         expect(rowCount).toBe(relatedTables[i].data.length);
-                        // The annotation_image table has more rows than the page_size, so its heading will have a + after the row count
+
+                        // Because this spec is reused in multiple recordedit tests, this if-else branching just ensures the correct expectation is used depending on which table is encountered
                         if (displayName == tableParams.related_table_name_with_page_size_annotation) {
+                        // The annotation_image table has more rows than the page_size, so its heading will have a + after the row count
                             expect(headings[i]).toBe("- " + displayName + " (" + rowCount + "+)");
                         } else {
+                        // All other tables should not have the + at the end its heading
                             expect(headings[i]).toBe("- " + displayName + " (" + rowCount + ")");
                         }
                     });


### PR DESCRIPTION
This PR addresses #776. It adds a "+" to related table headings if that table has more rows than the page size.