### PR TITLE
Ellipses Fix #787 & #801

### DIFF
--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -7,38 +7,39 @@
         .directive('ellipses', ['$sce', '$timeout', function($sce, $timeout) {
 
             return {
-                restrict: 'E',
+                restrict: 'AE',
                 templateUrl: '../common/templates/ellipses.html',
                 scope: {
-                    content: '=',
-                    isHtml: "="
+                    rowValues: '='
                 },
                 link: function (scope, element) {
+                    scope.overflow = []; // for each cell in the row
 
-                    scope.overflow = false;
+                    scope.hideContent = false;
                     scope.linkText = "more";
 
                     // 1em = 14px
                     // 7.25em = 101.5px
                     scope.maxHeight = "7.25em";
-                    scope.showMore = false;
 
-                    scope.readmore = function() {
-                        if (scope.overflow) {
-                            scope.overflow = false;
+                    scope.readmore = function(index) {
+                        if (scope.hideContent) {
+                            scope.hideContent = false;
                             scope.linkText = "less";
                         } else {
-                            scope.overflow = true;
+                            scope.hideContent = true;
                             scope.linkText = "more";
                         }
-                    }
+                    };
 
                     $timeout(function() {
-                        if (element.children().first().prop('offsetHeight') > 100) {
-                            scope.overflow = true;
-                            scope.showMore = true;
-                        } else {
-                            scope.overflow = false;
+                        for (var i = 0; i < element[0].children.length; i++) {
+                            if (element[0].children[i].children[0].offsetHeight > 100) {
+                                scope.overflow[i] = true;
+                                scope.hideContent = true;
+                            } else {
+                                scope.overflow[i] = false;
+                            }
                         }
                     }, 0);
 

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -1,6 +1,6 @@
 <td ng-repeat="val in rowValues track by $index">
     <div ng-switch="val.isHTML">
-        <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" >
+        <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}">
             <span ng-switch-when="true" class="markdown-container" ng-bind-html="val.value"></span>
             <span ng-switch-default ng-bind="val.value"></span>
         </div>

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -2,7 +2,7 @@
     <div ng-switch="val.isHTML">
         <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" >
             <span ng-switch-when="true" class="markdown-container" ng-bind-html="val.value"></span>
-            <span ng-switch-default>{{val.value}}</span>
+            <span ng-switch-default ng-bind="val.value"></span>
         </div>
         <div ng-if="overflow[$index]" style="display:inline;">
             ...

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -1,10 +1,12 @@
-<div ng-switch="isHtml">
-    <div ng-class="{'hideContent': overflow == true, 'showContent': overflow == false}" >
-	    <span ng-switch-when="true" class="markdown-container" ng-bind-html="content"></span>
-	    <span ng-switch-default>{{content}}</span>
+<td ng-repeat="val in rowValues track by $index">
+    <div ng-switch="val.isHTML">
+        <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" >
+            <span ng-switch-when="true" class="markdown-container" ng-bind-html="val.value"></span>
+            <span ng-switch-default>{{val.value}}</span>
+        </div>
+        <div ng-if="overflow[$index]" style="display:inline;">
+            ...
+            <span style="display:inline-block; text-decoration: underline" class="text-primary readmore" ng-click="readmore($index)">{{linkText}}</span>
+        </div>
     </div>
-    <div ng-show="showMore" style="display:inline;">
-        ...
-        <span style="display:inline-block; text-decoration: underline" class="text-primary readmore" ng-click="readmore()">{{linkText}}</span>
-    </div>
-</div>
+</td>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -14,10 +14,7 @@
 
         <!-- rows -->
         <tbody>
-            <tr class="table-row" ng-repeat="row in vm.rowValues track by $index" ng-click="rowClickAction($event, $index)" ng-style="{'cursor': 'pointer'}">
-                <td ng-repeat="val in row track by $index">
-                    <ellipses content="val.value" is-html="val.isHTML"></ellipses>
-                </td>
+            <tr class="table-row" ellipses ng-repeat="row in vm.rowValues track by $index" row-values="row" ng-click="rowClickAction($event, $index)" ng-style="{'cursor': 'pointer'}">
             </tr>
         </tbody>
     </table>

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -21,7 +21,10 @@
             <div style="margin-top: 15px;">Loading...</div>
         </div>
 
-        <recordset vm="vm" default-row-linking="true"></recordset>
+        <div ng-show="vm.hasLoaded">
+            <recordset vm="vm" default-row-linking="true"></recordset>
+        </div>
+
     </div>
 
 </div>

--- a/test/e2e/specs/recordset/helpers.js
+++ b/test/e2e/specs/recordset/helpers.js
@@ -100,6 +100,7 @@ exports.testPresentation = function (tableParams) {
 	});
 
 	it("click on row should redirect to record app", function() {
+        browser.sleep(1000);
 		chaisePage.recordsetPage.getRows().then(function(rows) {
 			rows[0].click().then(function() {
                 browser.driver.sleep(1000);


### PR DESCRIPTION
The ellipses directive was table cell based. This caused two problems 1) loading the table is slow because the ellipse code has to run for each cell in the table, which caused the problem addressed in #787, table appears blank when page initializes, and 2) clicking on the more/less link only expands/collapses content of one cell, but should expand/collapse the row #801.

This PR made ellipses directive row based, which addresses both issues. 