### PR TITLE
Fix non-deterministic tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,7 @@ distclean: clean
 # Rule to run tests
 .PHONY: test
 test:
-	$(BIN)/protractor $(E2EnavbarNoHeadTitle) && $(BIN)/protractor $(E2EnavbarNoLogo) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
+	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
 
 # Rule to run karma
 .PHONY: karma

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ E2EDrecordRelatedTable=test/e2e/specs/record/related-table/protractor.conf.js
 E2EDrecordset=test/e2e/specs/recordset/data-dependent/protractor.conf.js
 E2EDviewer=test/e2e/specs/viewer/data-dependent/protractor.conf.js
 E2Elogin=test/e2e/specs/login/protractor.conf.js
-E2Enavbar=test/e2e/specs/navbar/data-dependent/protractor.conf.js
+E2Enavbar=test/e2e/specs/navbar/base-config/protractor.conf.js
+E2EnavbarHeadTitle=test/e2e/specs/navbar/no-logo-no-brandtext/protractor.conf.js
 
 # Rule to determine MD5 utility
 ifeq ($(shell which md5 2>/dev/null),)
@@ -420,7 +421,7 @@ distclean: clean
 # Rule to run tests
 .PHONY: test
 test:
-	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
+	$(BIN)/protractor $(E2EnavbarNoHeadTitle) && $(BIN)/protractor $(E2EnavbarNoLogo) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
 
 # Rule to run karma
 .PHONY: karma
@@ -431,7 +432,13 @@ karma:
 .PHONY: testall
 testall:
 	$(BIN)/karma start
-	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable)  && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch)  && $(BIN)/protractor $(E2Elogin)
+	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable)  && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch)  && $(BIN)/protractor $(E2Elogin)
+
+
+#Rule to run navbar tests
+.PHONY: testnavbar
+testnavbar:
+	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle)
 
 #Rule to run search app tests
 .PHONY: testsearch

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -10,6 +10,8 @@
                 </button>
                 <a class="navbar-brand" ng-href="{{brandURL || '/' }}">
                     <img id="brand-image" ng-if="brandImage" ng-src="{{brandImage}}">
+                </a>
+                <a class="navbar-brand" ng-href="{{brandURL || '/' }}">
                     <span id="brand-text" ng-bind="brandText || 'Chaise'"></span>
                 </a>
             </div>

--- a/test/e2e/specs/navbar/base-config/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/base-config/00-navbar.spec.js
@@ -77,7 +77,7 @@ describe('Navbar ', function() {
         });
     }).pend("Pending until we handle tests logging in via Globus/other services");
 
-    xit('should link to the profile URL from chaiseConfig, if specified', function() {
+    xit('should link to the profile URL from chaiseConfig', function() {
         var actual = element.all(by.css('.username'));
         expect(actual.count()).toEqual(1);
         expect(actual.getAttribute('href')).toEqual(chaiseConfig.profileURL);

--- a/test/e2e/specs/navbar/base-config/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/base-config/00-navbar.spec.js
@@ -20,19 +20,15 @@ describe('Navbar ', function() {
 
     it('should display the right title from chaiseConfig', function() {
         var actualTitle = element(by.id('brand-text'));
-        var expectedTitle = chaiseConfig.navbarBrandText || chaiseConfig.headTitle || 'Chaise';
+        var expectedTitle = chaiseConfig.navbarBrandText;
         expect(actualTitle.getText()).toEqual(expectedTitle);
     });
 
-    it('should use the image specified in chaiseConfig', function() {
-        if (!chaiseConfig.navbarBrandImage) {
-            expect(element(by.id('brand-image')).isPresent()).toBeFalsy();
-        } else {
-            var actualLogo = element(by.id('brand-image'));
-            var expectedLogo = chaiseConfig.navbarBrandImage;
-            expect(actualLogo.isDisplayed()).toBeTruthy();
-            expect(actualLogo.getAttribute('src')).toMatch(expectedLogo);
-        }
+    it('should use the brand image/logo specified in chaiseConfig', function() {
+        var actualLogo = element(by.id('brand-image'));
+        var expectedLogo = chaiseConfig.navbarBrandImage;
+        expect(actualLogo.isDisplayed()).toBeTruthy();
+        expect(actualLogo.getAttribute('src')).toMatch(expectedLogo);
     });
 
     it('for the menu, should generate the correct # of list items', function() {
@@ -64,17 +60,12 @@ describe('Navbar ', function() {
     }).pend("Pending until we handle tests logging in via Globus/other services");
 
     xit('should have a "Sign Up" link with the right href from chaiseConfig', function(done) {
-        if (chaiseConfig.signUpURL) {
-            var actualLink = element(by.id('signup-link'));
-            browser.wait(EC.elementToBeClickable(actualLink), 10000).then(function() {
-                expect(actualLink.isDisplayed()).toBeTruthy();
-                expect(actualLink.getAttribute('href')).toMatch(chaiseConfig.signUpURL);
-                done();
-            });
-        } else {
-            expect(element(by.id('signup-link')).isPresent()).toBeFalsy();
+        var actualLink = element(by.id('signup-link'));
+        browser.wait(EC.elementToBeClickable(actualLink), 10000).then(function() {
+            expect(actualLink.isDisplayed()).toBeTruthy();
+            expect(actualLink.getAttribute('href')).toMatch(chaiseConfig.signUpURL);
             done();
-        }
+        });
     }).pend("Pending until we handle tests logging in via Globus/other services");
 
     xit('should display a "Log Out" link', function(done) {
@@ -89,10 +80,6 @@ describe('Navbar ', function() {
     xit('should link to the profile URL from chaiseConfig, if specified', function() {
         var actual = element.all(by.css('.username'));
         expect(actual.count()).toEqual(1);
-        if (chaiseConfig.profileURL) {
-            expect(actual.getAttribute('href')).toEqual(chaiseConfig.profileURL);
-        } else {
-            expect(actual.getAttribute('href')).toBeFalsy();
-        }
+        expect(actual.getAttribute('href')).toEqual(chaiseConfig.profileURL);
     }).pend("Pending until we handle tests logging in via Globus/other services");
 });

--- a/test/e2e/specs/navbar/base-config/chaise-config.js
+++ b/test/e2e/specs/navbar/base-config/chaise-config.js
@@ -1,16 +1,22 @@
-// Configure deployment-specific data here
+/* This config tests navbar functionalities with:
+ - No headTitle
+ - navbarBrandImage
+ - navbarBrandText
+ - signUpURL
+ - profileURL
+*/
 
 var chaiseConfig = {
     name: "navebar",
     layout: 'list',
     confirmDelete: true,
-    headTitle: 'test123',
     customCSS: '/assets/css/chaise.css',
     navbarBrand: 'test123',
-    navbarBrandImage: 'test123',
+    navbarBrandImage: 'test123.jpg',
     navbarBrandText: 'test123',
+    headTitle: 'this one should be ignored in favor of navbarBrandText',
     logoutURL: 'test123',
-    profileURL: 'test123',
+    profileURL: 'test123l;akjdf;lakdsjf',
     dataBrowser: '/',
     maxColumns: 6,
     showUnfilteredResults: false,
@@ -32,7 +38,7 @@ var chaiseConfig = {
       chosenAttribute: "Data Type",
       chosenValue: "Expression microarray - gene"
    },
-   signUpURL: 'test123',
+   signUpURL: 'test123.coma;lksjf;laksj',
    navbarMenu: {
        newTab: true,
        children: [

--- a/test/e2e/specs/navbar/base-config/protractor.conf.js
+++ b/test/e2e/specs/navbar/base-config/protractor.conf.js
@@ -1,0 +1,23 @@
+var pConfig = require('./../../../utils/protractor.configuration.js');
+
+var config = pConfig.getConfig({
+  // Change this to your desired filed name and Comment below testConfiguration object declaration
+    configFileName: 'navbar.dev.json',
+
+  /* Just in case if you plan on not giving a file for configuration, you can always specify a testConfiguration object
+   * Comment above 2 lines
+   * Empty configuration will run test cases against catalog 1 and default schema
+   */
+
+    // testConfiguration: {},
+    page: 'search',
+    setBaseUrl: function(browser, data) {
+      browser.params.url = process.env.CHAISE_BASE_URL + "/search";
+      return browser.params.url;
+    },
+
+	// Specify chaiseConfigPath
+    chaiseConfigFilePath: 'test/e2e/specs/navbar/base-config/chaise-config.js'
+});
+config.rootElement = '#main-content';
+exports.config = config;

--- a/test/e2e/specs/navbar/no-logo-no-brandtext/00-navbar.spec.js
+++ b/test/e2e/specs/navbar/no-logo-no-brandtext/00-navbar.spec.js
@@ -1,0 +1,77 @@
+describe('Navbar ', function() {
+    var navbar, menu, chaiseConfig, EC = protractor.ExpectedConditions;
+
+    beforeAll(function (done) {
+        browser.ignoreSynchronization=true;
+        browser.get(browser.params.url || "");
+        navbar = element(by.id('mainnav'));
+        menu = element(by.id('navbar-menu'));
+        browser.executeScript('return chaiseConfig').then(function(config) {
+            chaiseConfig = config;
+            return browser.wait(EC.presenceOf(navbar), 5000);
+        }).then(function() {
+            done();
+        });
+    });
+
+    it('should be visible', function() {
+        expect(navbar.isDisplayed()).toBeTruthy();
+    });
+
+    it('should display the right title from chaiseConfig', function() {
+        var actualTitle = element(by.id('brand-text'));
+        var expectedTitle = chaiseConfig.headTitle;
+        expect(actualTitle.getText()).toEqual(expectedTitle);
+    });
+
+    it('should not display a brand image/logo', function() {
+        expect(element(by.id('brand-image')).isPresent()).toBeFalsy();
+    });
+
+    it('for the menu, should generate the correct # of list items', function() {
+        var nodesInDOM = menu.all(by.tagName('li'));
+        var counter = 0;
+        function countNodes(array) {
+            array.forEach(function(element) {
+                counter++;
+                if (element.children) {
+                    countNodes(element.children);
+                }
+            });
+            return counter;
+        }
+        countNodes(chaiseConfig.navbarMenu.children);
+
+        nodesInDOM.count().then(function(count) {
+            expect(count).toEqual(counter);
+        });
+    });
+
+    // TODO: These tests are xit'd because we don't handle tests logging in via Globus/other services just yet
+    // e.g. On Travis, the user is logged in. On local machines, you must log in manually, which changes the desired order of specs.
+    xit('should have a "Log In" link', function() {
+        var actualLink = element(by.id('login-link'));
+        browser.wait(EC.elementToBeClickable(actualLink), 10000).then(function() {
+            expect(actualLink.isDisplayed()).toBeTruthy();
+        });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
+
+    xit('should not display a "Sign Up" link', function(done) {
+        expect(element(by.id('signup-link')).isPresent()).toBeFalsy();
+    }).pend("Pending until we handle tests logging in via Globus/other services");
+
+    xit('should display a "Log Out" link', function(done) {
+        var logOutLink = element(by.id('logout-link'));
+        browser.wait(EC.elementToBeClickable(logOutLink), 10000).then(function() {
+            browser.ignoreSynchronization = true;
+            expect(logOutLink.isDisplayed()).toBeTruthy();
+            done();
+        });
+    }).pend("Pending until we handle tests logging in via Globus/other services");
+
+    xit('should not link to a profile URL on the username', function() {
+        var actual = element.all(by.css('.username'));
+        expect(actual.count()).toEqual(1);
+        expect(actual.getAttribute('href')).toBeFalsy();
+    }).pend("Pending until we handle tests logging in via Globus/other services");
+});

--- a/test/e2e/specs/navbar/no-logo-no-brandtext/chaise-config.js
+++ b/test/e2e/specs/navbar/no-logo-no-brandtext/chaise-config.js
@@ -1,0 +1,69 @@
+/* This config tests navbar functionalities with:
+ - No navbarBrandImage
+ - No navbarBrandText
+ - No profileURL
+ - No signUpURL
+ - A specified headTitle
+*/
+
+
+var chaiseConfig = {
+    name: "navebar",
+    layout: 'list',
+    confirmDelete: true,
+    customCSS: '/assets/css/chaise.css',
+    navbarBrand: 'test123',
+    headTitle: 'show me on the navbar!',
+    logoutURL: 'test123',
+    dataBrowser: '/',
+    maxColumns: 6,
+    showUnfilteredResults: false,
+    defaultAnnotationColor: 'red',
+    feedbackURL: 'http://goo.gl/forms/f30sfheh4H',
+    helpURL: '/help/using-the-data-browser/',
+    showBadgeCounts: false,
+    recordUiGridEnabled: false,
+    recordUiGridExportCSVEnabled: true,
+    recordUiGridExportPDFEnabled: true,
+    editRecord: true,
+    showDeleteButton: true,
+    tour: {
+      pickRandom: false,
+      searchInputAttribute: "Data",
+      searchChosenAttribute: "Data Type",
+      searchInputValue: "micro",
+      extraAttribute: "Mouse Anatomic Source",
+      chosenAttribute: "Data Type",
+      chosenValue: "Expression microarray - gene"
+   },
+   navbarMenu: {
+       newTab: true,
+       children: [
+           {
+               name: "Search",
+               url: "/chaise/search/#1/legacy:dataset",
+               newTab: false
+           },
+           {
+               name: "RecordEdit",
+               children: [
+                   {
+                       name: "Add Records",
+                       children: [
+                           {
+                               name: "Edit Existing Record",
+                               url: "/chaise/recordedit/#1/legacy:dataset/id=5776",
+                               newTab: true
+                           }
+                       ]
+                   }
+               ],
+               newTab: true
+           }
+       ]
+   }
+};
+
+if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    exports.config = chaiseConfig;
+}

--- a/test/e2e/specs/navbar/no-logo-no-brandtext/protractor.conf.js
+++ b/test/e2e/specs/navbar/no-logo-no-brandtext/protractor.conf.js
@@ -17,7 +17,7 @@ var config = pConfig.getConfig({
     },
 
 	// Specify chaiseConfigPath
-    chaiseConfigFilePath: 'test/e2e/specs/navbar/data-dependent/chaise-config.js'
+    chaiseConfigFilePath: 'test/e2e/specs/navbar/no-logo-no-brandtext/chaise-config.js'
 });
 config.rootElement = '#main-content';
 exports.config = config;

--- a/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
+++ b/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
@@ -45,7 +45,10 @@ describe('View existing record,', function() {
     }
 
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig;
+        var chaiseConfig, tupleParams = testParams.tuples[0], keys = [];
+        tupleParams.keys.forEach(function(key) {
+            keys.push(key.name + key.operator + key.value);
+        });
         browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
         browser.sleep(3000);
         browser.executeScript('return chaiseConfig').then(function(config) {

--- a/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
+++ b/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
@@ -43,4 +43,19 @@ describe('View existing record,', function() {
 
     	})(testParams.tuples[i], i);
     }
+
+    it('should load custom CSS and document title defined in chaise-config.js', function() {
+        var chaiseConfig;
+        browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
+        browser.sleep(3000);
+        browser.executeScript('return chaiseConfig').then(function(config) {
+            chaiseConfig = config;
+            return browser.executeScript('return $("link[href=\'' + chaiseConfig.customCSS + '\']")');
+        }).then(function(elemArray) {
+            expect(elemArray.length).toBeTruthy();
+            return browser.getTitle();
+        }).then(function(title) {
+            expect(title).toEqual(chaiseConfig.headTitle);
+        });
+    });
 });

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -106,15 +106,18 @@ describe('Record Add', function() {
     }
 
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig = browser.executeScript('return chaiseConfig');
-        if (chaiseConfig.customCSS) {
-            expect($("link[href='" + chaiseConfig.customCSS + "']").length).toBeTruthy();
-        }
-        if (chaiseConfig.headTitle) {
-            browser.getTitle().then(function(title) {
-                expect(title).toEqual(chaiseConfig.headTitle);
-            });
-        }
+        var chaiseConfig;
+        browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+        browser.sleep(3000);
+        browser.executeScript('return chaiseConfig').then(function(config) {
+            chaiseConfig = config;
+            return browser.executeScript('return $("link[href=\'' + chaiseConfig.customCSS + '\']")');
+        }).then(function(elemArray) {
+            expect(elemArray.length).toBeTruthy();
+            return browser.getTitle();
+        }).then(function(title) {
+            expect(title).toEqual(chaiseConfig.headTitle);
+        });
     });
 
     describe('When url has a prefill query string param set, ', function() {
@@ -143,6 +146,7 @@ describe('Record Add', function() {
                     var field = element.all(by.css('.popup-select-value')).first();
                     expect(field.getText()).toBe(testCookie.rowname);
                 } else {
+                    // Fail the test
                     expect('Cookie did not load').toEqual('but cookie should have loaded');
                 }
             });

--- a/test/e2e/specs/recordedit/data-independent/add/chaise-config.js
+++ b/test/e2e/specs/recordedit/data-independent/add/chaise-config.js
@@ -1,0 +1,70 @@
+/* This config tests functionalities with:
+ - headTitle
+ - customCSS
+*/
+
+var chaiseConfig = {
+    name: "Sample",
+    layout: 'list',
+    confirmDelete: true,
+    navbarBrandText: 'Something.jpg',
+    navbarBrand: '/',
+    navbarBrandImage: 'something.jpg',
+    logoutURL: '/image-annotation',
+    headTitle: 'some sample title 23423lkj42;l31j4',
+    customCSS: '/path/to/custom/css',
+    dataBrowser: '',
+    maxColumns: 6,
+    showUnfilteredResults: false,
+    defaultAnnotationColor: 'red',
+    feedbackURL: 'http://goo.gl/forms/f30sfheh4H',
+    helpURL: '/help/using-the-data-browser/',
+    showBadgeCounts: false,
+    recordUiGridEnabled: false,
+    recordUiGridExportCSVEnabled: true,
+    recordUiGridExportPDFEnabled: true,
+    editRecord: true,
+    showDeleteButton: true,
+    tour: {
+      pickRandom: false,
+      searchInputAttribute: "Data",
+      searchChosenAttribute: "Data Type",
+      searchInputValue: "micro",
+      extraAttribute: "Mouse Anatomic Source",
+      chosenAttribute: "Data Type",
+      chosenValue: "Expression microarray - gene"
+    },
+    navbarMenu: {
+        newTab: true,
+        children: [
+            {
+                // This "Search" menu item has 2 nested dropdowns.
+                // Use the "name" key to label a menu item.
+                // Use the "children" key to specify dropdowns; you can nest as many dropdowns as you need.
+                name: "Search",
+                children: [
+                    {
+                        name: "Search 1",
+                        children: [
+                            {
+                                name: "Search 1.1",
+                                url: "/chaise/search/#1/YOUR_CATALOG:YOUR_SCHEMA"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                // This "Create" menu item doesn't have any dropdowns.
+                // Use the "url" key to specify this menu item's url and to signal that it doesn't have any children.
+                // URLs can be absolute or relative to the document root.
+                name: "Create",
+                url: "/chaise/recordedit/#1/YOUR_CATALOG:YOUR_SCHEMA"
+            }
+        ]
+    }
+};
+
+if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    exports.config = chaiseConfig;
+}

--- a/test/e2e/specs/recordedit/data-independent/add/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/add/protractor.conf.js
@@ -13,6 +13,7 @@ var config = pConfig.getConfig({
     },
   */
 
+    chaiseConfigFilePath: 'test/e2e/specs/recordedit/data-independent/add/chaise-config.js',
     page: 'recordedit',
     setBaseUrl: function(browser, data) {
       browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId + "/" + data.schema.name;

--- a/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
@@ -18,10 +18,6 @@ var config = pConfig.getConfig({
       browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId  + "/" + data.schema.name;;
       return browser.params.url;
     }
-    // ,
-    //
-    // // Specify chaiseConfigPath
-    // chaiseConfigFilePath: 'test/e2e/specs/recordedit/data-independent/edit/chaise-config.js'
 });
 
 exports.config = config;

--- a/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
+++ b/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
@@ -32,15 +32,18 @@ describe('View recordset,', function() {
     }
 
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig = browser.executeScript('return chaiseConfig');
-        if (chaiseConfig.customCSS) {
-            expect($("link[href='" + chaiseConfig.customCSS + "']").length).toBeTruthy();
-        }
-        if (chaiseConfig.headTitle) {
-            browser.getTitle().then(function(title) {
-                expect(title).toEqual(chaiseConfig.headTitle);
-            });
-        }
+        var chaiseConfig;
+        browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+        browser.sleep(3000);
+        browser.executeScript('return chaiseConfig').then(function(config) {
+            chaiseConfig = config;
+            return browser.executeScript('return $("link[href=\'' + chaiseConfig.customCSS + '\']")');
+        }).then(function(elemArray) {
+            expect(elemArray.length).toBeTruthy();
+            return browser.getTitle();
+        }).then(function(title) {
+            expect(title).toEqual(chaiseConfig.headTitle);
+        });
     });
 
 });

--- a/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
+++ b/test/e2e/specs/recordset/data-dependent/00-recordset.presentation.spec.js
@@ -32,8 +32,11 @@ describe('View recordset,', function() {
     }
 
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig;
-        browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+        var chaiseConfig, tupleParams = testParams.tuples[0], keys = [];
+        tupleParams.keys.forEach(function(key) {
+            keys.push(key.name + key.operator + key.value);
+        });
+        browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&") + "@sort(" + tupleParams.sortby + ")");
         browser.sleep(3000);
         browser.executeScript('return chaiseConfig').then(function(config) {
             chaiseConfig = config;

--- a/test/e2e/specs/recordset/data-dependent/chaise-config.js
+++ b/test/e2e/specs/recordset/data-dependent/chaise-config.js
@@ -1,0 +1,70 @@
+/* This config tests functionalities with:
+ - headTitle
+ - customCSS
+*/
+
+var chaiseConfig = {
+    name: "Sample",
+    layout: 'list',
+    confirmDelete: true,
+    navbarBrandText: 'Something.jpg',
+    navbarBrand: '/',
+    navbarBrandImage: 'something.jpg',
+    logoutURL: '/image-annotation',
+    headTitle: 'some sample title 23423lkj42;l31j4',
+    customCSS: '/path/to/custom/css',
+    dataBrowser: '',
+    maxColumns: 6,
+    showUnfilteredResults: false,
+    defaultAnnotationColor: 'red',
+    feedbackURL: 'http://goo.gl/forms/f30sfheh4H',
+    helpURL: '/help/using-the-data-browser/',
+    showBadgeCounts: false,
+    recordUiGridEnabled: false,
+    recordUiGridExportCSVEnabled: true,
+    recordUiGridExportPDFEnabled: true,
+    editRecord: true,
+    showDeleteButton: true,
+    tour: {
+      pickRandom: false,
+      searchInputAttribute: "Data",
+      searchChosenAttribute: "Data Type",
+      searchInputValue: "micro",
+      extraAttribute: "Mouse Anatomic Source",
+      chosenAttribute: "Data Type",
+      chosenValue: "Expression microarray - gene"
+    },
+    navbarMenu: {
+        newTab: true,
+        children: [
+            {
+                // This "Search" menu item has 2 nested dropdowns.
+                // Use the "name" key to label a menu item.
+                // Use the "children" key to specify dropdowns; you can nest as many dropdowns as you need.
+                name: "Search",
+                children: [
+                    {
+                        name: "Search 1",
+                        children: [
+                            {
+                                name: "Search 1.1",
+                                url: "/chaise/search/#1/YOUR_CATALOG:YOUR_SCHEMA"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                // This "Create" menu item doesn't have any dropdowns.
+                // Use the "url" key to specify this menu item's url and to signal that it doesn't have any children.
+                // URLs can be absolute or relative to the document root.
+                name: "Create",
+                url: "/chaise/recordedit/#1/YOUR_CATALOG:YOUR_SCHEMA"
+            }
+        ]
+    }
+};
+
+if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    exports.config = chaiseConfig;
+}

--- a/test/e2e/specs/recordset/data-dependent/protractor.conf.js
+++ b/test/e2e/specs/recordset/data-dependent/protractor.conf.js
@@ -19,7 +19,7 @@ var config = pConfig.getConfig({
      */
     page: '/recordset',
 
-
+    chaiseConfigFilePath: 'test/e2e/specs/recordset/data-dependent/chaise-config.js',
     setBaseUrl: function(browser, data) {
         browser.params.url = process.env.CHAISE_BASE_URL + "/recordset" + "/#" + data.catalogId + "/" + data.schema.name;
         return browser.params.url;

--- a/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
+++ b/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
@@ -35,10 +35,14 @@ describe('Viewer app', function() {
 
 
     }
-    
+
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig;
-        browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+        var chaiseConfig, tupleParams = testParams.tuples[0], keys = [];
+        browser.ignoreSynchronization = true;
+        tupleParams.keys.forEach(function(key) {
+            keys.push(key.name + key.operator + key.value);
+        });
+        browser.get(browser.params.url + ":" + tupleParams.table_name + "/" + keys.join("&"));
         browser.sleep(3000);
         browser.executeScript('return chaiseConfig').then(function(config) {
             chaiseConfig = config;

--- a/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
+++ b/test/e2e/specs/viewer/data-dependent/00-viewer.presentation.spec.js
@@ -35,15 +35,19 @@ describe('Viewer app', function() {
 
 
     }
+    
     it('should load custom CSS and document title defined in chaise-config.js', function() {
-        var chaiseConfig = browser.executeScript('return chaiseConfig');
-        if (chaiseConfig.customCSS) {
-            expect($("link[href='" + chaiseConfig.customCSS + "']").length).toBeTruthy();
-        }
-        if (chaiseConfig.headTitle) {
-            browser.getTitle().then(function(title) {
-                expect(title).toEqual(chaiseConfig.headTitle);
-            });
-        }
+        var chaiseConfig;
+        browser.get(browser.params.url + ":" + testParams.tables[0].table_name);
+        browser.sleep(3000);
+        browser.executeScript('return chaiseConfig').then(function(config) {
+            chaiseConfig = config;
+            return browser.executeScript('return $("link[href=\'' + chaiseConfig.customCSS + '\']")');
+        }).then(function(elemArray) {
+            expect(elemArray.length).toBeTruthy();
+            return browser.getTitle();
+        }).then(function(title) {
+            expect(title).toEqual(chaiseConfig.headTitle);
+        });
     });
 });

--- a/test/e2e/specs/viewer/data-dependent/chaise-config.js
+++ b/test/e2e/specs/viewer/data-dependent/chaise-config.js
@@ -1,0 +1,70 @@
+/* This config tests functionalities with:
+ - headTitle
+ - customCSS
+*/
+
+var chaiseConfig = {
+    name: "Sample",
+    layout: 'list',
+    confirmDelete: true,
+    navbarBrandText: 'Something.jpg',
+    navbarBrand: '/',
+    navbarBrandImage: 'something.jpg',
+    logoutURL: '/image-annotation',
+    headTitle: 'some sample title 23423lkj42;l31j4',
+    customCSS: '/path/to/custom/css',
+    dataBrowser: '',
+    maxColumns: 6,
+    showUnfilteredResults: false,
+    defaultAnnotationColor: 'red',
+    feedbackURL: 'http://goo.gl/forms/f30sfheh4H',
+    helpURL: '/help/using-the-data-browser/',
+    showBadgeCounts: false,
+    recordUiGridEnabled: false,
+    recordUiGridExportCSVEnabled: true,
+    recordUiGridExportPDFEnabled: true,
+    editRecord: true,
+    showDeleteButton: true,
+    tour: {
+      pickRandom: false,
+      searchInputAttribute: "Data",
+      searchChosenAttribute: "Data Type",
+      searchInputValue: "micro",
+      extraAttribute: "Mouse Anatomic Source",
+      chosenAttribute: "Data Type",
+      chosenValue: "Expression microarray - gene"
+    },
+    navbarMenu: {
+        newTab: true,
+        children: [
+            {
+                // This "Search" menu item has 2 nested dropdowns.
+                // Use the "name" key to label a menu item.
+                // Use the "children" key to specify dropdowns; you can nest as many dropdowns as you need.
+                name: "Search",
+                children: [
+                    {
+                        name: "Search 1",
+                        children: [
+                            {
+                                name: "Search 1.1",
+                                url: "/chaise/search/#1/YOUR_CATALOG:YOUR_SCHEMA"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                // This "Create" menu item doesn't have any dropdowns.
+                // Use the "url" key to specify this menu item's url and to signal that it doesn't have any children.
+                // URLs can be absolute or relative to the document root.
+                name: "Create",
+                url: "/chaise/recordedit/#1/YOUR_CATALOG:YOUR_SCHEMA"
+            }
+        ]
+    }
+};
+
+if (typeof module === 'object' && module.exports && typeof require === 'function') {
+    exports.config = chaiseConfig;
+}

--- a/test/e2e/specs/viewer/data-dependent/protractor.conf.js
+++ b/test/e2e/specs/viewer/data-dependent/protractor.conf.js
@@ -17,7 +17,7 @@ var config = pConfig.getConfig({
      */
     page: '/viewer',
 
-
+    chaiseConfigFilePath: 'test/e2e/specs/viewer/data-dependent/chaise-config.js',
     setBaseUrl: function(browser, data) {
         browser.params.url = process.env.CHAISE_BASE_URL + "/viewer" + "/#" + data.catalogId + "/" + data.schema.name;
         return browser.params.url;


### PR DESCRIPTION
This partially addresses #766 by fixing the tests for navbar and the `headInjector` service.

**headInjector tests**: These deal with the specs that say `"should load custom CSS and document title in chaise-config.js"`
- Added this spec to Record app tests
- Modified the existing specs in Viewer, RecordEdit, and RecordSet apps to directly test the `customCSS` and `headTitle` properties of `chaise-config.js` instead of only testing _if_ these properties existed in `chaiseConfig`

**Navbar tests**:
- There are now 2 `chaise-config.js`s to test the navbar's functionalities by setting or not setting various `chaiseConfig` properties. The specific set of properties is listed at the top of these configs.

Assigning to @jrchudy, tagging @shinyichen if she'd like to take a look as well.