### PR TITLE
RecordEdit: Redirect properly when submitting form with no changes

### DIFF
--- a/recordedit/model.js
+++ b/recordedit/model.js
@@ -7,6 +7,7 @@
     .value('recordEditModel', {
         table: {},
         rows: [{}], // rows of data in the form, not the table from ERMrest
+        oldRows: [{}], // Keep a copy of the initial rows data so that we can see if user has made any changes later
         submissionRows: [{}] // rows of data converted to raw data for submission
     });
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -85,7 +85,10 @@
                             recordEditModel.submissionRows[recordEditModel.submissionRows.length - 1][colName] = colValue;
                         });
                     }
-                    console.log('Model', recordEditModel);
+                    $log.info('Model: ', recordEditModel);
+                    // Keep a copy of the initial rows data so that we can see if user has made any changes later
+                    recordEditModel.oldRows = angular.copy(recordEditModel.rows);
+                    $log.info('Old model.rows:', recordEditModel.oldRows);
                 }
 
                 // Case for editing an entity
@@ -152,6 +155,8 @@
                                 recordEditModel.rows[recordEditModel.rows.length - 1][column.name] = value;
                             }
                             $log.info('Model: ', recordEditModel);
+                            // Keep a copy of the initial rows data so that we can see if user has made any changes later
+                            recordEditModel.oldRows = angular.copy(recordEditModel.rows);
                         }, function error(response) {
                             $log.warn(response);
                             throw response;

--- a/test/e2e/specs/recordedit/data-independent/edit/01-recordedit.edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/01-recordedit.edit.spec.js
@@ -41,7 +41,7 @@ describe('Edit existing record,', function() {
                     var params = recordEditHelpers.testPresentationAndBasicValidation(tableParams);
 				});
 
-				describe("Submit existing record", function() {
+				describe("Submitting an existing record", function() {
 					beforeAll(function() {
 						// Submit the form
 						chaisePage.recordEditPage.submitForm();
@@ -68,14 +68,31 @@ describe('Edit existing record,', function() {
 						    });
 						}
 					});
-
 				});
 
     		});
 
     	})(testParams.tables[i], i);
-
-
     }
+    describe('and submitting the form without making any changes', function() {
+        var keys = [], tableParams = testParams.tables[0];
+        beforeAll(function() {
+            tableParams.keys.forEach(function(key) {
+                keys.push(key.name + key.operator + key.value);
+            });
+            browser.ignoreSynchronization=true;
+            browser.get(browser.params.url + ":" + tableParams.table_name + "/" + keys.join("&"));
+            browser.sleep(3000);
+            chaisePage.recordEditPage.submitForm();
+            browser.sleep(3000);
+        });
 
+        it('should also redirect to the correct Record page', function() {
+            browser.driver.getCurrentUrl().then(function(url) {
+                var redirectUrl = browser.params.url.replace('/recordedit/', '/record/');
+                redirectUrl += ':' + tableParams.table_name + '/' + keys.join('&');
+                expect(url).toBe(redirectUrl);
+            });
+        });
+    });
 });

--- a/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
@@ -15,7 +15,7 @@ var config = pConfig.getConfig({
     chaiseConfigFilePath: 'test/e2e/specs/recordedit/data-independent/edit/chaise-config.js',
     page: 'recordedit',
     setBaseUrl: function(browser, data) {
-      browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId  + "/" + data.schema.name;;
+      browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId  + "/" + data.schema.name;
       return browser.params.url;
     }
     // ,


### PR DESCRIPTION
This PR addresses #795. 

Upon submitting in edit mode, if the app sees no difference between `recordEditModel.rows` and `recordEditModel.oldRows` (new property created to store initial state of `recordEditModel.rows`), then the app does not perform the operation to update that row in ERMrest. Instead, it just redirects to the appropriate Record page.