### PR TITLE
Record app related table refresh

### DIFF
--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -99,7 +99,7 @@
             // 1. Pluck required values from the ref into cookie obj by getting the values of the keys that form this FK relationship
             var cookie = {
                 rowname: $rootScope.recordDisplayname,
-                constraintName: ref.origFKR.constraint_names[0].join(':'),
+                constraintName: ref.origFKR.constraint_names[0].join(':')
             };
             var newRef = ref.contextualize.entryCreate;
             var mapping = newRef.origFKR.mapping;

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -218,6 +218,17 @@
                 $rootScope.reference.create(model.submissionRows).then(function success(page) {
                     vm.readyToSubmit = false; // form data has already been submitted to ERMrest
                     if (vm.prefillCookie) {
+
+                        // only do this if came from record->relatedTable->add
+                        // We can tell from having prefill
+                        var cookie = $cookies.getObject(vm.prefillCookie.originUri);
+                        if (!cookie)
+                            cookie = {};
+                        cookie[vm.prefillCookie.objectUri] = model.submissionRows.length;
+                        $cookies.putObject(vm.prefillCookie.originUri, cookie, {
+                            expires: new Date(Date.now() + (60 * 60 * 24 * 1000))
+                        });
+
                         $cookies.remove(context.prefill);
                     }
                     vm.redirectAfterSubmission(page);

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -219,17 +219,16 @@
                     vm.readyToSubmit = false; // form data has already been submitted to ERMrest
                     if (vm.prefillCookie) {
 
-                        // only do this if came from record->relatedTable->add
-                        // We can tell from having prefill
-                        var cookie = $cookies.getObject(vm.prefillCookie.originUri);
-                        if (!cookie)
-                            cookie = {};
-                        cookie[vm.prefillCookie.objectUri] = model.submissionRows.length;
-                        $cookies.putObject(vm.prefillCookie.originUri, cookie, {
-                            expires: new Date(Date.now() + (60 * 60 * 24 * 1000))
-                        });
-
                         $cookies.remove(context.prefill);
+
+                        // cookie indicating record added
+                        // only do this if came from record->relatedTable->add, We can tell from having prefill
+                        // use the prefill id as cookie name
+                        $cookies.put(context.prefill, model.submissionRows.length,
+                            {
+                                expires: new Date(Date.now() + (60 * 60 * 24 * 1000))
+                            }
+                        );
                     }
                     vm.redirectAfterSubmission(page);
                 }, function error(response) {

--- a/test/e2e/data_setup/config/related-table-link.dev.json
+++ b/test/e2e/data_setup/config/related-table-link.dev.json
@@ -25,6 +25,9 @@
     "cleanup" : true,
     "tests" : {
         "params": {
+            "schemaName" : "product-unordered-related-tables",
+            "price" : "247.00",
+            "booking_date": "2/10/2016, 12:00:00 AM",
             "tuples" : [{
                 "table_name" : "accommodation",
                 "related_table_name_with_more_results" : "booking",

--- a/test/e2e/specs/record/related-table/03-record.related-table-link.spec.js
+++ b/test/e2e/specs/record/related-table/03-record.related-table-link.spec.js
@@ -26,7 +26,7 @@ describe('View existing record,', function() {
 
                 describe("Show the related entity tables,", function() {
 					var params = recordHelpers.relatedTablesDefaultOrder(tupleParams);
-					var params = recordHelpers.relatedTableLinks(tupleParams);
+					var params = recordHelpers.relatedTableLinks(testParams, tupleParams);
 				});
 
     		});


### PR DESCRIPTION
PR for #817 

When an add related table entry operation originating from the record page, a cookie is created with a unique id. When the new recordedit tab has finished creating new entries, it modifies the cookie's value. When the record tab regains focus, it checks its cookie and update the appropriate related tables with new entries.