### PR TITLE
Toggle Markdown related tables to between markdown and tabular views

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -54,21 +54,22 @@
                     </uib-accordion-heading>
 
                     <!-- for different elements inside the accordion -->
-                    <div ng-switch on="relatedRef.display.type">
-
-                        <div class="pull-right" style="margin-top:-25px;">
-                            <span ng-if="relatedRef.canCreate && ctrl.modifyRecord"><a class="add-records-link" ng-click="ctrl.addRelatedRecord(relatedRef)">Add</a> |</span>
-                            <a class="more-results-link pull-right" ng-click="ctrl.toRecordSet(relatedRef)">View More</a>
-                        </div>
-                        <div class="row">
-                            <div class="col-xs-12">
-                                <div ng-switch-when="markdown">
-                                    <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
-                                </div>
-                                <!-- ng-switch-when="table" is also the default case -->
-                                <div ng-switch-default>
-                                    <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]" default-row-linking="true"></record-table>
-                                </div>
+                    <div class="pull-right" style="margin-top:-25px;">
+                        <span ng-if="::relatedRef.display.type == 'markdown'">
+                            <a class="toggle-display-link" ng-click="ctrl.toggleRelatedTableDisplayType($index)">
+                                <span ng-show="tableModels[$index].displayType == 'markdown'">Table</span>
+                                <span ng-show="tableModels[$index].displayType != 'markdown'">Revert</span>
+                            Display</a>&nbsp;|</span>
+                        <span ng-if="relatedRef.canCreate && ctrl.modifyRecord"><a class="add-records-link" ng-click="ctrl.addRelatedRecord(relatedRef)">Add</a>&nbsp;|</span>
+                        <span><a class="more-results-link" ng-click="ctrl.toRecordSet(relatedRef)">View More</a></span>
+                    </div>
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <div ng-show="tableModels[$index].displayType == 'markdown'">
+                                <span class="markdown-container" bind-html-unsafe="tableModels[$index].page.content"></span>
+                            </div>
+                            <div ng-show="tableModels[$index].displayType != 'markdown'">
+                                <record-table class="related-table" id="rt-{{relatedRef.displayname}}" vm="tableModels[$index]" default-row-linking="true"></record-table>
                             </div>
                         </div>
                     </div>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -61,7 +61,6 @@
                     $log.info("Reference: ", $rootScope.reference);
 
                     $rootScope.relatedReferences = $rootScope.reference.related;
-                    console.log('Related refs', $rootScope.relatedReferences);
                     // There should only ever be one entity related to this reference
                     return $rootScope.reference.read(1);
                 }, function error(exception) {

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -61,6 +61,7 @@
                     $log.info("Reference: ", $rootScope.reference);
 
                     $rootScope.relatedReferences = $rootScope.reference.related;
+                    console.log('Related refs', $rootScope.relatedReferences);
                     // There should only ever be one entity related to this reference
                     return $rootScope.reference.read(1);
                 }, function error(exception) {
@@ -109,7 +110,8 @@
                                     sortby: null,               // column name, user selected or null
                                     sortOrder: null,            // asc (default) or desc
                                     rowValues: [],              // array of rows values
-                                    search: null                // search term
+                                    search: null,                // search term
+                                    displayType: $rootScope.relatedReferences[i].display.type
                                 };
                                 model.rowValues = DataUtils.getRowValuesFromPage(page);
                                 $rootScope.tableModels[i] = model;

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -88,6 +88,14 @@
             }
         };
 
+        vm.toggleRelatedTableDisplayType = function(i) {
+            console.log($rootScope.tableModels[i]);
+            if ($rootScope.tableModels[i].displayType == 'markdown') {
+                $rootScope.tableModels[i].displayType = 'table';
+            } else {
+                $rootScope.tableModels[i].displayType = 'markdown';
+            }
+        };
 
         vm.toggleRelatedTables = function() {
             vm.showEmptyRelatedTables = !vm.showEmptyRelatedTables;

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -89,7 +89,6 @@
         };
 
         vm.toggleRelatedTableDisplayType = function(i) {
-            console.log($rootScope.tableModels[i]);
             if ($rootScope.tableModels[i].displayType == 'markdown') {
                 $rootScope.tableModels[i].displayType = 'table';
             } else {

--- a/test/e2e/data_setup/config/related-table-link.dev.json
+++ b/test/e2e/data_setup/config/related-table-link.dev.json
@@ -30,6 +30,7 @@
                 "related_table_name_with_more_results" : "booking",
                 "related_table_name_with_link_in_table" : "accommodation_image",
                 "related_table_name_with_page_size_annotation" : "accommodation_image",
+                "related_table_name_with_row_markdown_pattern" : "media",
                 "keys" : [{ "name": "id", "value": "2004", "operator": "=" }],
                 "tables_order" : [ "accommodation_image (2+)", "booking (6)", "media (1)" ],
                 "booking_count" : 6,

--- a/test/e2e/data_setup/schema/product-unordered-related-tables.json
+++ b/test/e2e/data_setup/schema/product-unordered-related-tables.json
@@ -817,6 +817,11 @@
         ],
         "description": {
           "display": "Media"
+        },
+        "tag:isrd.isi.edu,2016:table-display": {
+            "compact/brief": {
+                "row_markdown_pattern": "{{{accommodation_id}}}"
+            }
         }
       }
     }

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -330,6 +330,33 @@ exports.relatedTableLinks = function (tableParams) {
         });
     });
 
+    it('should have a link to toggle between markdown and tabular views for markdown tables', function() {
+        var EC = protractor.ExpectedConditions,
+        markdownRelatedTable = tableParams.related_table_name_with_row_markdown_pattern, // "media"
+        markdownToggleLink = chaisePage.recordPage.getToggleDisplayLink(markdownRelatedTable);
+
+        browser.wait(EC.elementToBeClickable(markdownToggleLink), 10000);
+
+        // expect the markdown table to display this link
+        expect(markdownToggleLink.isDisplayed()).toBeTruthy();
+
+        // Expect initial display to be markdown by searching for a .markdown-container
+        var initialMarkdownDisplay = element(by.id('rt-heading-' + markdownRelatedTable)).element(by.css('.markdown-container'));
+        expect(initialMarkdownDisplay.isDisplayed()).toBeTruthy();
+
+        markdownToggleLink.click().then(function() {
+            // After clicking toggle link, the table should now be displayed as a regular table (which would have an id of "rt-media")
+            var tableDisplay = element(by.id('rt-' + markdownRelatedTable));
+            expect(tableDisplay.isDisplayed()).toBeTruthy();
+            return markdownToggleLink.click();
+        }).then(function() {
+            // After clicking the toggle link once more, expect the related table to revert to its markdown display
+            expect(initialMarkdownDisplay.isDisplayed()).toBeTruthy();
+        }).catch(function(error) {
+            console.log(error);
+        });
+    });
+
     it('should have an Add link for a related table that redirects to that related table in recordedit with a prefill query parameter.', function() {
         var EC = protractor.ExpectedConditions,
             relatedTableName = tableParams.related_table_name_with_more_results,

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -584,6 +584,11 @@ var recordPage = function() {
         return element(by.id("rt-heading-" + displayName)).element(by.css(".add-records-link"));
     };
 
+    this.getToggleDisplayLink = function(displayName) {
+        // the link is not a child of the table, rather one of the accordion group
+        return element(by.id("rt-heading-" + displayName)).element(by.css(".toggle-display-link"));
+    };
+
     this.getRelatedTableRowValues = function(displayName) {
         return that.getRelatedTableRows(displayName).all(by.tagName("td"));
     };


### PR DESCRIPTION
This PR addresses #823.

It adds a "Table Display" link to each Markdown related table, which allows the user to toggle that table between Markdown and tabular display.

I replaced the `ng-switch` logic in favor of `ng-show` because I didn't want Angular to remove and re-insert elements in the DOM every time the user toggled the display, which would cause a delay for the user.

Requesting a review from to @jrchudy and tagging @shinyichen as well. Also assigning this PR to @jrchudy because ZenHub doesn't allow filtering by Reviewer yet. :(