### PR TITLE
Included bindHTMLUnsafe on recordedit page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,7 @@ RE_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(COMMON)/errorDialog.controller.js \
 	$(COMMON)/modal.js \
 	$(COMMON)/delete-link.js \
+	$(COMMON)/bindHtmlUnsafe.js \
 	$(JS)/vendor/bootstrap.js \
 	$(JS)/vendor/ui-bootstrap-tpls.js \
 	$(JS)/vendor/select.js \

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -13,6 +13,7 @@
         'chaise.record.table',
         'chaise.utils',
         'chaise.validators',
+        'chaise.html',
         'ermrestjs',
         'ngCookies',
         'ngMessages',


### PR DESCRIPTION
This **PR** fixes issue #859 .Recordedit app didn't include `bindHtmlUnsafe.js`, due to which some html columns were not being rendered in the modal.

Can be tested here https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/experiments:sample