### PR TITLE
Recordset table image overflow

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -548,6 +548,10 @@ tbody{
     margin-bottom: 0px;
 }
 
+.recordset-table td .markdown-container img {
+    overflow-x: hidden;
+}
+
 /************* custom buttons **************/
 .btn-no-focus:focus {
     outline: none;

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -1,4 +1,4 @@
-<div class="outer-table">
+<div class="outer-table recordset-table">
     <table class="table table-striped table-bordered table-hover">
         <!-- sortable column header -->
         <thead class="table-heading">


### PR DESCRIPTION
This PR fixes issue #861. Img tags inside a td cannot overflow and get clipped according to the aspect ratio.