### PR TITLE
Foreign Key X button not clickable

### DIFF
--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -144,7 +144,7 @@
                                                 <label class="sr-only"></label>
                                                 <div contenteditable="false" ng-disabled="::form.isDisabled(column);" class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
                                                     ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
-                                                <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px'}">
+                                                <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px', 'pointer-events': 'all'}">
                                                     <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)" tooltip-append-to-body=true tooltip-placement="bottom" uib-tooltip="Clear field"></span>
                                                 </div>
                                                 <span class="input-group-addon" ng-show="::!form.isDisabled(column);">


### PR DESCRIPTION
This PR fixes issue #848 where you couldn't click on x button when you have selected a foreign key from modal on recordedit page.

The issue was with the class `form-control-feedback` which added a `pointer-events:none` css style. This property disables the element from firing any input events.

https://dev.isrd.isi.edu/~chirag/chaise/recordedit/#1/legacy:dataset