### PR TITLE
Split make testall into multiple jobs to avoid travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,18 @@ before_script:
   - sudo -H -u webauthn webauthn2-manage addattr admin
   - sudo -H -u webauthn webauthn2-manage assign test1 admin
 
+
+script: 
+  - make build
+  - make testnavbar
+  - make testrecord 
+  - make testrecordset 
+  - make testrecordadd 
+  - make testrecordedit 
+  - make testviewer 
+  - make testsearch 
+  - make testlogin
+
 after_failure:
   - sudo ls -lR /etc/apache2
   - sudo ls -lR /var/run/apache2

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ testrecord:
 #Rule to run record add app tests
 .PHONY: testrecordadd
 testrecordadd:
-	$(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor E2EDIrecordMultiAdd
+	$(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordMultiAdd)
 
 #Rule to run recordset app tests
 .PHONY: testrecordset

--- a/Makefile
+++ b/Makefile
@@ -462,27 +462,31 @@ testdetailed:
 #Rule to run record app tests
 .PHONY: testrecord
 testrecord:
-	$(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordRelatedTable)
+	$(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2EDrecordCopy)
 
 #Rule to run record add app tests
 .PHONY: testrecordadd
 testrecordadd:
-	$(BIN)/protractor $(E2EDIrecordAdd)
+	$(BIN)/protractor $(E2EDIrecordAdd) && E2EDIrecordMultiAdd
 
 #Rule to run recordset app tests
 .PHONY: testrecordset
 testrecordset:
 	$(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd)
 
-
 .PHONY: testrecordedit
 testrecordedit:
-	$(BIN)/protractor $(E2EDIrecordEdit)
+	$(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled)
 
 #Rule to run viewer app tests
 .PHONY: testviewer
 testviewer:
 	$(BIN)/protractor $(E2EDviewer)
+
+#Rule to run detailed app tests
+.PHONY: testlogin
+testdetailed:
+	$(BIN)/protractor $(E2Elogin)
 
 # Rule to make html
 .PHONY: html

--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ testrecord:
 #Rule to run record add app tests
 .PHONY: testrecordadd
 testrecordadd:
-	$(BIN)/protractor $(E2EDIrecordAdd) && E2EDIrecordMultiAdd
+	$(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor E2EDIrecordMultiAdd
 
 #Rule to run recordset app tests
 .PHONY: testrecordset

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "make build",
     "pretest": "make build",
-    "test": "make testall",
+    "test": "make testnavbar && make testrecord && make testrecordset && make testrecordadd && make testrecordedit && make testviewer && make testsearch && make testlogin",
     "docs": "make doc"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "build": "make build",
     "pretest": "make build",
-    "test": "make testnavbar && make testrecord && make testrecordset && make testrecordadd && make testrecordedit && make testviewer && make testsearch && make testlogin",
     "docs": "make doc"
   },
   "repository": {


### PR DESCRIPTION
This PR fixes issue #886. We had to split `make testall` into separate smaller jobs because Travis has a time limit of 50 minutes per job.