### PR TITLE
Change tooltips to use UIB tooltips

### DIFF
--- a/common/delete-link.js
+++ b/common/delete-link.js
@@ -16,9 +16,7 @@
 * @param {String} label - If defined, this is the text to display on the UI control.
 * @param {String} button-size - Customize with 'xs', 'sm', or 'lg'. If undefined, the
 * default is the regular Bootstrap button size.
-* @param {String} tooltip - If defined, the UI control will display this tooltip
-* text when the user hovers over the control.
-* @example <delete-link button-size="sm" tooltip="Click to delete." icon="true" display="button" callback="ctrl.removeItem(item);"></delete-link>
+* @example <delete-link button-size="sm" icon="true" display="button" callback="ctrl.removeItem(item);"></delete-link>
 */
 
 (function() {
@@ -44,7 +42,6 @@
                 label: '@',
                 display: '@',
                 callback: '&',
-                tooltip: '@',
                 buttonSize: '@'
             },
             link: function(scope) {

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -45,6 +45,11 @@ a:hover, a:focus{
 button .glyphicon-trash {
     color: #fff;
 }
+
+span[uib-tooltip] {
+    border-bottom: 1px dotted black;
+}
+
 /****************** HEADER ******************/
 
 #header{
@@ -65,37 +70,6 @@ button .glyphicon-trash {
     font-size: 14px;
     margin: 0px 0 12px 0;
 }
-
-/****************** Entity Table ******************/
-
-.coltooltiplabel {
-    border-bottom: 1px dotted black;
-}
-
-.coltooltip .coltooltiptext {
-    display: none;
-    width: 100px;
-    background-color: #454545;
-    color: #f0f0f0;
-    text-align: center;
-    padding: 5px 5px;
-    border-radius: 6px;
-    font-size: 11px;
-    position: absolute;
-    z-index: 3;
-    text-transform: none;
-    white-space: normal;
-}
-
-.coltooltip .paragraph{
-    width: 200px;
-    text-align: left;
-}
-
-.coltooltip:hover .coltooltiptext {
-    display: inline-block;
-}
-
 
 /****************** ACCORDION ******************/
 

--- a/common/templates/delete-link/delete-btn.html
+++ b/common/templates/delete-link/delete-btn.html
@@ -1,7 +1,4 @@
-<div ng-class="{'coltooltip': tooltip}">
-    <button ng-click="deleteFn();" class="btn btn-primary" ng-class="{'btn-lg': buttonSize == 'lg', 'btn-sm': buttonSize == 'sm', 'btn-xs': buttonSize == 'xs'}">
-        <span ng-if="icon" class="glyphicon glyphicon-trash"></span>
-        <span ng-if="label">{{label}}</span>
-    </button>
-    <span ng-if="tooltip" class="coltooltiptext">{{tooltip}}</span>
-</div>
+<button ng-click="deleteFn();" class="btn btn-primary" ng-class="{'btn-lg': buttonSize == 'lg', 'btn-sm': buttonSize == 'sm', 'btn-xs': buttonSize == 'xs'}" ng-attr-uib-tooltip="{{(false) ? tooltip : undefined}}" ng-attr-tooltip-placement="{{(false) ? 'top' : undefined}}">
+    <span ng-if="icon" class="glyphicon glyphicon-trash"></span>
+    <span ng-if="label">{{label}}</span>
+</button>

--- a/common/templates/delete-link/delete-btn.html
+++ b/common/templates/delete-link/delete-btn.html
@@ -1,4 +1,4 @@
-<button ng-click="deleteFn();" class="btn btn-primary" ng-class="{'btn-lg': buttonSize == 'lg', 'btn-sm': buttonSize == 'sm', 'btn-xs': buttonSize == 'xs'}" ng-attr-uib-tooltip="{{(false) ? tooltip : undefined}}" ng-attr-tooltip-placement="{{(false) ? 'top' : undefined}}">
+<button ng-click="deleteFn();" class="btn btn-primary" ng-class="{'btn-lg': buttonSize == 'lg', 'btn-sm': buttonSize == 'sm', 'btn-xs': buttonSize == 'xs'}">
     <span ng-if="icon" class="glyphicon glyphicon-trash"></span>
     <span ng-if="label">{{label}}</span>
 </button>

--- a/common/templates/delete-link/delete-link.html
+++ b/common/templates/delete-link/delete-link.html
@@ -1,7 +1,4 @@
-<div ng-class="{'coltooltip': tooltip}">
-    <a ng-click="deleteFn();">
-        <span ng-if="icon" class="glyphicon glyphicon-trash"></span>
-        <strong ng-if="label"> {{label}}</strong>
-    </a>
-    <span ng-if="tooltip" class="coltooltiptext">{{tooltip}}</span>
-</div>
+<a ng-click="deleteFn();">
+    <span ng-if="icon" class="glyphicon glyphicon-trash"></span>
+    <strong ng-if="label"> {{label}}</strong>
+</a>

--- a/common/templates/record.html
+++ b/common/templates/record.html
@@ -1,8 +1,7 @@
 <table class="table">
     <tr ng-repeat="column in columns" ng-if="::values[$index].value != null" id="{{'row-' + column.name}}">
-        <td class="entity-key col-xs-2" ng-class="{'coltooltip': column.comment}">
-            <span ng-class="{'coltooltiplabel': column.comment}">{{::column.displayname}}</span>
-            <span ng-if="column.comment" class="coltooltiptext">{{::column.comment}}</span>
+        <td class="entity-key col-xs-2">
+            <span ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}">{{::column.displayname}}</span>
         </td>
         <td class="entity-value col-xs-10" ng-switch="::values[$index].isHTML">
             <span ng-switch-when="true" class="markdown-container" bind-html-unsafe="::values[$index].value"></span>

--- a/common/templates/record.html
+++ b/common/templates/record.html
@@ -1,7 +1,7 @@
 <table class="table">
     <tr ng-repeat="column in columns" ng-if="::values[$index].value != null" id="{{'row-' + column.name}}">
         <td class="entity-key col-xs-2">
-            <span ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}">{{::column.displayname}}</span>
+            <span class="column-displayname" ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}">{{::column.displayname}}</span>
         </td>
         <td class="entity-value col-xs-10" ng-switch="::values[$index].isHTML">
             <span ng-switch-when="true" class="markdown-container" bind-html-unsafe="::values[$index].value"></span>

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -13,9 +13,9 @@
                     <button id="search-submit" class="btn btn-primary" ng-click="search(vm.search)" role="button">
                         &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
                     </button>
-                    <button type="button" tabIndex="-1" class="btn btn-primary btn-no-focus coltooltip">
+                    <button type="button" tabIndex="-1" class="btn btn-primary btn-no-focus" tooltip-placement="bottom"
+                    uib-tooltip-html="'<p>Use space to separate between conjunctive terms, | (no spaces) to separate disjunctive terms and quotations for exact phrases.</p><p>For example, <i><b>usc 1234</b></i> returns all records containing &ldquo;usc&rdquo; and &ldquo;1234&rdquo;.</p><p><i><b>usc|1234</b></i> returns all records containing &ldquo;usc&rdquo; or &ldquo;1234&rdquo;.</b></i></p><p><i><b>usc 1234</b></i> returns all records containing &ldquo;usc 1234&rdquo;.</p>'">
                         <span class="glyphicon glyphicon-question-sign"></span>
-                        <span class="coltooltiptext paragraph"><p>Use space to separate between conjunctive terms, | (no spaces) to separate disjunctive terms and quotations for exact phrases.</p><p>For example, <i><b>usc 1234</b></i> returns all records containing "usc" and "1234".</p><p><i><b>usc|1234</b></i> returns all records containing "usc" or "1234".</b></i></p><p><i><b>"usc 1234"</b></i> returns all records containing "usc 1234".</span>
                     </button>
                     <button id="search-clear" class="btn btn-primary" ng-disabled="!vm.reference.location.searchTerm" ng-click="clearSearch()" type="button">Reset</button>
                 </span>
@@ -40,7 +40,7 @@
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 pull-right" align="right">
         <!-- add record -->
-        <button id="add-record-btn" type="button" class="btn btn-primary" ng-click="addRecord()"  tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Create new record">
+        <button id="add-record-btn" type="button" class="btn btn-primary" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
             <span class="glyphicon glyphicon-plus"></span>
         </button>
     </div>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -4,7 +4,7 @@
         <thead class="table-heading">
             <tr>
                 <th nowrap ng-repeat="col in vm.columns track by $index">
-                    <span class="table-column-displayname" ng-class="{'coltooltiplabel': col.comment}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby(col.name)">{{::col.displayname}}</span>
+                    <span class="table-column-displayname" ng-attr-uib-tooltip="{{(col.comment) ? col.comment : undefined}}" ng-attr-tooltip-placement="{{(col.comment) ? 'top' : undefined}}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby(col.name)">{{::col.displayname}}</span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='asc'" ng-click="toggleSortOrder()" class="glyphicon glyphicon-sort-by-attributes" ng-style="{'cursor': 'pointer'}"></span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='desc'" ng-click="toggleSortOrder()" class="glyphicon glyphicon-sort-by-attributes-alt" ng-style="{'cursor': 'pointer'}"></span>
                     <span ng-show="!col.isPseudo && vm.sortby!==col.name" class="glyphicon glyphicon-sort" ng-click="sortby(col.name)" ng-style="{'cursor': 'pointer'}"></span>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -4,7 +4,7 @@
         <thead class="table-heading">
             <tr>
                 <th nowrap ng-repeat="col in vm.columns track by $index">
-                    <span class="table-column-displayname" ng-attr-uib-tooltip="{{(col.comment) ? col.comment : undefined}}" ng-attr-tooltip-placement="{{(col.comment) ? 'top' : undefined}}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby(col.name)">{{::col.displayname}}</span>
+                    <span class="table-column-displayname" ng-attr-uib-tooltip="{{::(col.comment) ? col.comment : undefined}}" ng-attr-tooltip-placement="{{::(col.comment) ? 'top' : undefined}}" title="{{col.comment}}" ng-click="!col.isPseudo && sortby(col.name)">{{::col.displayname}}</span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='asc'" ng-click="toggleSortOrder()" class="glyphicon glyphicon-sort-by-attributes" ng-style="{'cursor': 'pointer'}"></span>
                     <span ng-show="!col.isPseudo && vm.sortby==col.name && vm.sortOrder=='desc'" ng-click="toggleSortOrder()" class="glyphicon glyphicon-sort-by-attributes-alt" ng-style="{'cursor': 'pointer'}"></span>
                     <span ng-show="!col.isPseudo && vm.sortby!==col.name" class="glyphicon glyphicon-sort" ng-click="sortby(col.name)" ng-style="{'cursor': 'pointer'}"></span>

--- a/detailed/assets/javascripts/app.js
+++ b/detailed/assets/javascripts/app.js
@@ -2,6 +2,13 @@
 
 var chaiseRecordApp = angular.module("chaiseRecordApp", ['ngResource', 'ngRoute', 'ui.bootstrap','ui.grid', 'ui.grid.resizeColumns', 'ui.grid.pinning', 'ui.grid.selection', 'ui.grid.moveColumns', 'ui.grid.exporter', 'ui.grid.grouping', 'ui.grid.infiniteScroll', 'ngCookies', 'ngSanitize', 'chaise.utils', 'chaise.navbar']);
 
+// Configure all tooltips to be attached to the body by default. To attach a
+// tooltip on the element instead, set the `tooltip-append-to-body` attribute
+// to `false` on the element.
+chaiseRecordApp.config(['$tooltipProvider', function($tooltipProvider) {
+    $tooltipProvider.options({appendToBody: true});
+}]);
+
 // Refreshes page when fragment identifier changes
 setTimeout(function(){
 

--- a/detailed/assets/views/detailed.html
+++ b/detailed/assets/views/detailed.html
@@ -26,11 +26,7 @@
             <table class="table">
                 <tr ng-repeat="(key, value) in entity | filteredEntity">
                     <td class="col-xs-2">
-                        <div ng-if="entity.colTooltips[key]" class="coltooltip">
-                            <span class="entity-key" style="text-transform: capitalize;">{{ key | removeUnderScores }}</span>
-                            <span class="coltooltiptext">{{ entity.colTooltips[key] }}</span>
-                        </div>
-                        <span ng-if="!entity.colTooltips[key]" class="entity-key" style="text-transform: capitalize;">{{ key | removeUnderScores }}</span>
+                        <span class="entity-key" style="text-transform: capitalize;" ng-attr-tooltip="{{::(entity.colTooltips[key]) ? entity.colTooltips[key] : undefined}}" ng-attr-tooltip-placement="{{::(entity.colTooltips[key]) ? 'right' : undefined}}">{{ key | removeUnderScores }}</span>
                     </td>
                     <td class="entity-value col-xs-10">
                         <a ng-if="entity[key + '_link'] && value !== null" ng-href="{{entity[key + '_link']}}" ng-click="isExternalUrl(reference[key + '_link']) || reloadPage()"

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -11,30 +11,26 @@
     <div id="main-content" class="container-fluid">
         <div ng-controller="RecordController as ctrl">
             <div id="record-bookmark-container" class="col-xs-12 meta-icons">
-                <a id="create-record" class="coltooltip" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord">
+                <a id="create-record" ng-click="::ctrl.createRecord()" ng-if="reference && reference.canCreate && ctrl.modifyRecord" uib-tooltip="Click here to create a record." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-plus"></span> <strong>Create</strong>
-                    <span class="coltooltiptext">Click here to create a record</span>
                 </a>&nbsp;&nbsp;
-                <a id="edit-record" class="coltooltip" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
+                <a id="edit-record" ng-click="::ctrl.editRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord" uib-tooltip="Click here to edit this record." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-pencil"></span> <strong>Edit</strong>
-                    <span class="coltooltiptext">Click here to edit this record</span>
                 </a>&nbsp;&nbsp;
-                <a id="copy-record" ng-click="::ctrl.copyRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord">
+                <a id="copy-record" ng-click="::ctrl.copyRecord()" ng-if="reference && reference.canUpdate && ctrl.modifyRecord" uib-tooltip="Click here to create a copy of this record." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-copy"></span> <strong>Copy</strong>
                 </a>&nbsp;&nbsp;
-                <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord && ctrl.showDeleteButton" label="Delete" tooltip="Click here to delete this record" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
-                <a id="show-all-related-tables" class="coltooltip" ng-click="ctrl.toggleRelatedTables();">
+                <delete-link id="delete-record" ng-if="reference && reference.canDelete && ctrl.modifyRecord && ctrl.showDeleteButton" label="Delete" uib-tooltip="Click here to delete this record." tooltip-placement="bottom" icon="true" callback="ctrl.deleteRecord()"></delete-link>&nbsp;&nbsp;
+                <a id="show-all-related-tables" ng-click="ctrl.toggleRelatedTables();" uib-tooltip="{{'Click here to ' + ((ctrl.showEmptyRelatedTables) ? 'show empty related entities too.' : 'hide empty related entities.')}}" tooltip-placement="bottom">
                     <span class="glyphicon" ng-class="{'glyphicon-resize-full': !ctrl.showEmptyRelatedTables, 'glyphicon-resize-small': ctrl.showEmptyRelatedTables}"></span>
                     <strong>
                         <span ng-show="!ctrl.showEmptyRelatedTables">Show All</span>
                         <span ng-show="ctrl.showEmptyRelatedTables">Hide Empty</span>
                          Related Records
                     </strong>
-                    <span class="coltooltiptext">Click here to show empty related entities too.</span>
                 </a>&nbsp;&nbsp;
-                <a id="permalink" class="coltooltip" ng-href="{{ctrl.permalink()}}">
+                <a id="permalink" ng-href="{{ctrl.permalink()}}" uib-tooltip="This link stores your search criteria as a URL. Right click and save." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
-                    <span class="coltooltiptext">This link stores your search criteria as a URL. Right click and save.</span>
                 </a>
             </div>
             <alerts alerts="ctrl.alerts"></alerts>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -27,6 +27,13 @@
         $cookiesProvider.defaults.secure = true;
     }])
 
+    // Configure all tooltips to be attached to the body by default. To attach a
+    // tooltip on the element instead, set the `tooltip-append-to-body` attribute
+    // to `false` on the element.
+    .config(['$uibTooltipProvider', function($uibTooltipProvider) {
+        $uibTooltipProvider.options({appendToBody: true});
+    }])
+
     .run(['constants', 'DataUtils', 'ERMrest', 'ErrorService', 'headInjector', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window',
         function runApp(constants, DataUtils, ERMrest, ErrorService, headInjector, Session, UiUtils, UriUtils, $log, $rootScope, $window) {
 

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -504,11 +504,11 @@
 
         /*------------------------code below is for fixing the column names when scrolling -----------*/
 
-        var captionColumWidth = 130;
-        var marginLeft = captionColumWidth + 10;
+        var captionColumnWidth = 130;
+        var marginLeft = captionColumnWidth + 10;
 
         // Sets a fixed width for the columns, as they're positioned absolute
-        vm.captionColumWidth = { 'width' : captionColumWidth + "px" };
+        vm.captionColumnWidth = { 'width' : captionColumnWidth + "px" };
 
         // Sets margin-left for the formedit div as the first columns are positioned absolute
         // to avoid overlap between them
@@ -521,7 +521,7 @@
         // Adds height and width to the first empty heading of the first row
         // to make it uniform
         vm.firstHeaderStyle = {
-            'width' : captionColumWidth + "px",
+            'width' : captionColumnWidth + "px",
             'height' : headerHeight + "px"
         };
 
@@ -542,7 +542,7 @@
         // so that it doesn't scrolls due to the margin-left applied before extra padding
         function onResize(doNotInvokeEvent) {
             var elemWidth = formContainerEl.outerWidth();
-            vm.formEditDivMarginLeft.width = elemWidth - captionColumWidth - 30;
+            vm.formEditDivMarginLeft.width = elemWidth - captionColumnWidth - 30;
 
             if (!editMode) {
                 vm.formEditDivMarginLeft.width = vm.formEditDivMarginLeft.width -30 -5

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -51,11 +51,11 @@
                         <div class="row padding-right-15" ng-show="!form.editMode">
                             <div class="btn-group pull-right">
                                 <button id="copy-record-btn" class="btn btn-primary center-block" ng-click="form.copyFormRow();" ng-if="!form.editMode" type="button"
-                                    tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Click to add 1 record.">
+                                    tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
                                     <span class="glyphicon glyphicon-plus"></span>
                                 </button>
                                 <button id="copy-x-rows-btn" class="btn btn-primary center-block" ng-click="form.showMultiInsert = !form.showMultiInsert" type="button"
-                                    tooltip-placement="bottom-right" tooltip-append-to-body="true" uib-tooltip="Click to add a maximum of {{form.MAX_ROWS_TO_ADD-1}} records.">
+                                    tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{form.MAX_ROWS_TO_ADD-1}} records.">
                                     <span class="glyphicon glyphicon-chevron-down"></span>
                                 </button>
                             </div>
@@ -66,7 +66,7 @@
                                     <input id="copy-rows-input" type="number" class="form-control " ng-model="form.numberRowsToAdd">
                                     <span class="input-group-btn">
                                         <button id="copy-rows-submit" class="btn btn-sm btn-primary center-block" ng-click="form.copyFormRow()" type="button"
-                                            tooltip-placement="bottom" tooltip-append-to-body="true" uib-tooltip="Submit">
+                                            tooltip-placement="bottom" uib-tooltip="Submit">
                                             <span class="glyphicon glyphicon-ok"></span>
                                         </button>
                                     </span>
@@ -82,15 +82,15 @@
                                             <div class="row">
                                                 <div class="col-xs-12">
                                                     <div class="pull-left" ng-bind="rowIndex + 1"></div>
-                                                    <delete-link class="pull-right" ng-show="form.recordEditModel.rows.length > 1" button-size="sm"  tooltip-placement="bottom" tooltip-append-to-body=true uib-tooltip="Click to remove this record from the form." icon="true" display="button" callback="form.removeFormRow(rowIndex);"></delete-link>
+                                                    <delete-link class="pull-right" ng-show="form.recordEditModel.rows.length > 1" button-size="sm"  tooltip-placement="bottom" uib-tooltip="Click to remove this record from the form." icon="true" display="button" callback="form.removeFormRow(rowIndex);"></delete-link>
                                                 </div>
                                             </div>
                                         </td>
                                     </tr>
                                     <tr class="entity" ng-form="form.formContainer.row[rowIndex]" ng-repeat="column in reference.columns">
-                                        <td ng-style="form.captionColumWidth" class="entity-key col-xs-1" ng-class="{'coltooltip': column.comment}">
+                                        <td ng-style="form.captionColumWidth" class="entity-key col-xs-1">
                                             <span ng-if="::form.isRequired(column);" class="text-danger">*</span>
-                                            <span ng-class="{'coltooltiplabel': column.comment}" tooltip-placement="right" tooltip-append-to-body=true uib-tooltip="{{::column.comment}}">{{::column.displayname}}</span>
+                                            <span ng-class="{'coltooltiplabel': column.comment}" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}" ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}">{{::column.displayname}}</span>
                                         </td>
                                         <td class="entity-value" ng-form="form.formContainer.row[rowIndex][column.name]" ng-repeat="(rowIndex, row) in form.recordEditModel.rows track by $index" ng-switch="form.columnToDisplayType(column);">
                                             <!-- date input-->
@@ -145,10 +145,10 @@
                                                 <div contenteditable="false" ng-disabled="::form.isDisabled(column);" class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
                                                     ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                 <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px'}">
-                                                    <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)" tooltip-append-to-body=true tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+                                                    <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
                                                 </div>
                                                 <span class="input-group-addon" ng-show="::!form.isDisabled(column);">
-                                                    <button ng-focus="form.blurElement($event);" class="btn btn-default coltooltip modal-popup-btn" type="button" ng-click="form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);" tooltip-placement="bottom" tooltip-append-to-body=true uib-tooltip="Choose from an existing value">
+                                                    <button ng-focus="form.blurElement($event);" class="btn btn-default coltooltip modal-popup-btn" type="button" ng-click="form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);" tooltip-placement="bottom" uib-tooltip="Choose from an existing value.">
                                                         <span class="glyphicon glyphicon-chevron-down"></span>
                                                     </button>
                                                 </span>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -91,7 +91,7 @@
                                     <tr class="entity" ng-form="form.formContainer.row[rowIndex]" ng-repeat="column in reference.columns">
                                         <td ng-style="form.captionColumWidth" class="entity-key col-xs-1">
                                             <span ng-if="::form.isRequired(column);" class="text-danger">*</span>
-                                            <span ng-class="{'coltooltiplabel': column.comment}" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}" ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}">{{::column.displayname}}</span>
+                                            <span class="column-displayname" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}" ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}">{{::column.displayname}}</span>
                                         </td>
                                         <td class="entity-value" ng-form="form.formContainer.row[rowIndex][column.name]" ng-repeat="(rowIndex, row) in form.recordEditModel.rows track by $index" ng-switch="form.columnToDisplayType(column);">
                                             <!-- date input-->
@@ -146,10 +146,10 @@
                                                 <div contenteditable="false" ng-disabled="::form.isDisabled(column);" class="form-control popup-select-value" ng-style="form.isDisabled(column)? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="form.searchPopup(rowIndex, column)"
                                                     ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                 <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px', 'pointer-events': 'all'}">
-                                                    <span class="glyphicon glyphicon-remove foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+                                                    <span class="glyphicon glyphicon-remove coltooltiptext foreignkey-remove" ng-click="form.clearForeignKey(rowIndex, column)" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
                                                 </div>
                                                 <span class="input-group-addon" ng-show="::!form.isDisabled(column);">
-                                                    <button ng-focus="form.blurElement($event);" class="btn btn-default coltooltip modal-popup-btn" type="button" ng-click="form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);" tooltip-placement="bottom" uib-tooltip="Choose from an existing value.">
+                                                    <button ng-focus="form.blurElement($event);" class="btn btn-default modal-popup-btn" type="button" ng-click="form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);" tooltip-placement="bottom" uib-tooltip="Choose from an existing value.">
                                                         <span class="glyphicon glyphicon-chevron-down"></span>
                                                     </button>
                                                 </span>

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -28,6 +28,13 @@
         $cookiesProvider.defaults.secure = true;
     }])
 
+    // Configure all tooltips to be attached to the body by default. To attach a
+    // tooltip on the element instead, set the `tooltip-append-to-body` attribute
+    // to `false` on the element.
+    .config(['$uibTooltipProvider', function($uibTooltipProvider) {
+        $uibTooltipProvider.options({appendToBody: true});
+    }])
+
     .run(['ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
         function runRecordEditApp(ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
 

--- a/recordedit/recordEdit.css
+++ b/recordedit/recordEdit.css
@@ -62,6 +62,10 @@ input[type=number]::-webkit-outer-spin-button {
     padding: 0;
 }
 
+.form-control-feedback > span.foreignkey-remove {
+    border-bottom: none;
+}
+
 /*******Bootstrap  Modal styling *********/
 
 /*When the modal fills the screen it has an even 2.5% on top and bottom*/

--- a/recordedit/recordEdit.css
+++ b/recordedit/recordEdit.css
@@ -58,10 +58,6 @@ input[type=number]::-webkit-outer-spin-button {
     min-width: 112px;
 }
 
-.form-control-feedback.coltooltip > .coltooltiptext{
-    padding: 0;
-}
-
 .form-control-feedback > span.foreignkey-remove {
     border-bottom: none;
 }

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -40,7 +40,12 @@
         chaiseBaseURL: null
     })
 
-
+    // Configure all tooltips to be attached to the body by default. To attach a
+    // tooltip on the element instead, set the `tooltip-append-to-body` attribute
+    // to `false` on the element.
+    .config(['$uibTooltipProvider', function($uibTooltipProvider) {
+        $uibTooltipProvider.options({appendToBody: true});
+    }])
 
     // Register the 'recordsetModel' object, which can be accessed by other
     // services, but cannot be access by providers (and config, apparently).

--- a/test/e2e/data_setup/config/recordset.dev.json
+++ b/test/e2e/data_setup/config/recordset.dev.json
@@ -32,7 +32,14 @@
         "title" : "Accommodations",
         "keys" : [{ "name": "id", "value": "2001", "operator" : "::gt::"}],
         "sortby" : "no_of_rooms",
-        "columns" : ["Name of Accommodation", "Website", "User Rating", "Summary", "Operational Since", "Is Luxurious"],
+        "columns" : [
+            { "title" : "Name of Accommodation", "value": "Sherathon Hotel", "type": "text"},
+            { "title" : "Website", "value": "<p class=\"ng-scope\"><a href=\"http://www.starwoodhotels.com/sheraton/index.html\">Link to Website</a></p>", "type": "text", "comment" : "A valid url of the accommodation"},
+            { "title" : "User Rating", "value": "4.3000", "type": "float4"},
+            { "title" : "Summary", "value": "Sherathon Hotels is an international hotel company with more than 990 locations in 73 countries. The first Radisson Hotel was built in 1909 in Minneapolis, Minnesota, US. It is named after the 17th-century French explorer Pierre-Esprit Radisson.", "type": "longtext"},
+            { "title" : "Operational Since", "value": "12/9/2008, 12:00:00 AM", "type": "timestamptz" },
+            { "title" : "Is Luxurious", "value": "true", "type": "boolean" }
+        ],
         "data" : [
           {
             "id": 2003,

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -88,7 +88,7 @@ exports.testPresentation = function (tableParams) {
 					expect(exists).toBeDefined();
 
 					// Check comment is same
-					expect(actualComment.getInnerHtml()).toBe(comment);
+                    expect(actualComment).toBe(comment);
 				});
 			});
 		});

--- a/test/e2e/specs/recordset/helpers.js
+++ b/test/e2e/specs/recordset/helpers.js
@@ -40,7 +40,7 @@ exports.testPresentation = function (tableParams) {
 	it("should show " + tableParams.columns.length + " columns", function() {
 		chaisePage.recordsetPage.getColumns().getInnerHtml().then(function(columnNames) {
 			for (var j = 0; j < columnNames.length; j++) {
-				expect(columnNames[j]).toBe(tableParams.columns[j]);
+				expect(columnNames[j]).toBe(tableParams.columns[j].title);
 
 			}
 		});
@@ -59,8 +59,8 @@ exports.testPresentation = function (tableParams) {
 					var exists = actualComment ? true : undefined;
 					expect(exists).toBeDefined();
 
-					// Check comment is same
-					expect(actualComment.getInnerHtml()).toBe(comment);
+                    // Check comment is same
+                    expect(actualComment).toBe(comment);
 				});
 			});
 		});

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -268,11 +268,11 @@ var recordEditPage = function() {
     };
 
     this.getAllColumnCaptions = function() {
-        return browser.executeScript("return $('td.entity-key').find('span[ng-class=\"{\\'coltooltiplabel\\': column.comment}\"]');");
+        return browser.executeScript("return $('td.entity-key > span.column-displayname')");
     };
 
     this.getColumnsWithUnderline = function() {
-        return browser.executeScript("return $('td.entity-key').find('span[ng-class=\"{\\'coltooltiplabel\\': column.comment}\"].coltooltiplabel');");
+        return browser.executeScript("return $('td.entity-key > span.column-displayname[uib-tooltip]')");
     };
 
     this.getColumnWithAsterisk = function(el) {
@@ -280,7 +280,7 @@ var recordEditPage = function() {
     };
 
     this.getColumnComment = function(el) {
-        return browser.executeScript("return $(arguments[0]).next('.coltooltiptext')[0];", el);
+        return el.getAttribute('uib-tooltip');
     };
 
     this.getInputForAPageColumn = function(el, index) {
@@ -527,11 +527,11 @@ var recordPage = function() {
     };
 
     this.getAllColumnCaptions = function() {
-        return browser.executeScript("return $('td.entity-key').find('span[ng-class=\"{\\'coltooltiplabel\\': column.comment}\"]');");
+        return browser.executeScript("return $('td.entity-key > span.column-displayname')");
     };
 
     this.getColumnsWithUnderline = function() {
-        return browser.executeScript("return $('td.entity-key').find('span[ng-class=\"{\\'coltooltiplabel\\': column.comment}\"].coltooltiplabel');");
+        return browser.executeScript("return $('td.entity-key > span.column-displayname[uib-tooltip]')");
     };
 
     this.getColumnWithAsterisk = function(el) {
@@ -539,7 +539,7 @@ var recordPage = function() {
     };
 
     this.getColumnComment = function(el) {
-        return browser.executeScript("return $(arguments[0]).next('.coltooltiptext')[0];", el);
+        return el.getAttribute('uib-tooltip');
     };
 
     this.getColumnValueElements = function() {
@@ -652,11 +652,11 @@ var recordsetPage = function() {
     };
 
     this.getColumnsWithUnderline = function() {
-        return browser.executeScript("return $('td.entity-key').find('span[ng-class=\"{\\'coltooltiplabel\\': column.comment}\"].coltooltiplabel');");
+        return browser.executeScript("return $('span.table-column-displayname[uib-tooltip]')");
     };
 
     this.getColumnComment = function(el) {
-        return browser.executeScript("return $(arguments[0]).next('.coltooltiptext')[0];", el);
+        return el.getAttribute('uib-tooltip');
     };
 
     this.getSearchBox = function() {

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -39,6 +39,13 @@
         // TODO: Check if context has everything it needs before proceeding. If not, Bad Request
     }])
 
+    // Configure all tooltips to be attached to the body by default. To attach a
+    // tooltip on the element instead, set the `tooltip-append-to-body` attribute
+    // to `false` on the element.
+    .config(['$uibTooltipProvider', function($uibTooltipProvider) {
+        $uibTooltipProvider.options({appendToBody: true});
+    }])
+
     // Get a client connection to ERMrest
     // Note: Only Providers and Constants can be dependencies in .config blocks. So
     // if you want to use a factory or service (e.g. $window or your custom one)


### PR DESCRIPTION
This PR addresses #816. It converts our existing CSS-based tooltips to the more flexible [tooltip tool from Angular UI](http://angular-ui.github.io/bootstrap/versioned-docs/1.3.2/#/tooltip).

 - The `tooltip` attribute in the `deleteLinks` directive has been removed in favor of applying UIB tooltips directly to the directive instead (and thus allow for customization on placement, `append-to-body` or not, etc.).

- Tooltips are appended to the `<body>` by default in each app (set via `.config` blocks) to avoid potential clashes with styles on the tooltips' parent elements. This can be reversed by setting `append-to-body` to `false` on a per-tooltip basis.

