### PR TITLE
More Less issue in tables when paginated or searched

### DIFF
--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -67,7 +67,14 @@
                             }
                         };      
 
-                        resizeRow();
+                        scope.$watchCollection('rowValues', function (v) {
+                            $timeout(function() {
+                                timerCount = 0;
+                                containsOverflow = false, oldHeights = [];
+                                resizeRow();
+                            }, 10);
+                           
+                        });
                     }
                 }
             };

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -535,7 +535,6 @@ tbody{
 .hideContent {
     overflow: hidden;
     line-height: 20px;
-    max-height: 100px;
 }
 
 .showContent {

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -1,6 +1,6 @@
 <td ng-repeat="val in rowValues track by $index">
     <div ng-switch="val.isHTML">
-        <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" ng-style="maxHeightStyle">
+        <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" ng-style="overflow[$index] && maxHeightStyle">
             <span ng-switch-when="true" class="markdown-container" bind-html-unsafe="val.value"></span>
             <span ng-switch-default ng-bind="val.value"></span>
         </div>


### PR DESCRIPTION
This PR fixes issue issue #899. The problem was with the ellipsis directive which was not registering to listen to rowvalue changes.

Whenever the table content was updated, the ellipsis code had to be rerun which wasn't being done.

Now there is an explicit watcher on the row-values, which is triggered on change in values.

Can be checked [here](https://dev.isrd.isi.edu/~chirag/chaise/recordset/#1/legacy:dataset@sort(id)?limit=15)