### PR TITLE
RecordEdit: In edit mode, set default meridiem if null timestamp column value

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -510,10 +510,6 @@
             if (!vm.recordEditModel.rows[modelIndex][columnName]) {
                 vm.recordEditModel.rows[modelIndex][columnName] = {meridiem: 'AM'};
             }
-            // If timestamp model object exists, but meridiem prop doesn't, assign a default meridiem
-            if (!vm.recordEditModel.rows[modelIndex][columnName].meridiem) {
-                vm.recordEditModel.rows[modelIndex][columnName].meridiem = 'AM';
-            }
             // Do the toggling
             var meridiem = vm.recordEditModel.rows[modelIndex][columnName].meridiem;
             if (meridiem.charAt(0).toLowerCase() === 'a') {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -506,9 +506,15 @@
 
         // Toggle between AM/PM for a time input's model
         function toggleMeridiem(modelIndex, columnName) {
+            // If the entire timestamp model doesn't exist, initialize it with a default meridiem
             if (!vm.recordEditModel.rows[modelIndex][columnName]) {
                 vm.recordEditModel.rows[modelIndex][columnName] = {meridiem: 'AM'};
             }
+            // If timestamp model object exists, but meridiem prop doesn't, assign a default meridiem
+            if (!vm.recordEditModel.rows[modelIndex][columnName].meridiem) {
+                vm.recordEditModel.rows[modelIndex][columnName].meridiem = 'AM';
+            }
+            // Do the toggling
             var meridiem = vm.recordEditModel.rows[modelIndex][columnName].meridiem;
             if (meridiem.charAt(0).toLowerCase() === 'a') {
                 return vm.recordEditModel.rows[modelIndex][columnName].meridiem = 'PM';

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -141,7 +141,7 @@
                                             value = {
                                                 date: null,
                                                 time: null,
-                                                meridiem: null
+                                                meridiem: 'AM'
                                             };
                                         }
                                         break;

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -133,10 +133,10 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                     disabledCols[annotationKey].forEach(function(column) {
                         if (column.type.typename == 'timestamp' || column.type.typename == 'timestamptz') {
                             var timeInputs = chaisePage.recordEditPage.getTimestampInputsForAColumn(column.name, recordIndex);
-                            var dateInput = timeInputs.date, timeInput = timeInputs.time, meridiemInput = timeInputs.meridiem;
+                            var dateInput = timeInputs.date, timeInput = timeInputs.time, meridiemBtn = timeInputs.meridiem;
                             expect(dateInput.isEnabled()).toBe(false);
                             expect(timeInput.isEnabled()).toBe(false);
-                            expect(meridiemInput.isEnabled()).toBe(false);
+                            expect(meridiemBtn.isEnabled()).toBe(false);
                         } else {
                             chaisePage.recordEditPage.getInputForAColumn(column.name, recordIndex).then(function(input) {
                                 expect(input.isEnabled()).toBe(false);
@@ -513,11 +513,36 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                     columns = chaisePage.dataUtils.editInputs.getTimestampTypeColumns(table, [IGNORE, HIDDEN]);
                     columns.forEach(function(column) {
                         var timeInputs = chaisePage.recordEditPage.getTimestampInputsForAColumn(column.name, recordIndex);
-                        var dateInput = timeInputs.date, timeInput = timeInputs.time, meridiemInput = timeInputs.meridiem;
+                        var dateInput = timeInputs.date, timeInput = timeInputs.time, meridiemBtn = timeInputs.meridiem;
 
                         expect(dateInput).toBeDefined();
                         expect(timeInput).toBeDefined();
-                        expect(meridiemInput).toBeDefined();
+                        expect(meridiemBtn).toBeDefined();
+
+                        // Test toggling of meridiem button
+                        // Testing meridiem before the time input test because toggling btn should work
+                        // with or without input in the other fields (i.e. date and time input fields).
+                        var initialMeridiem = '';
+                        meridiemBtn.getText().then(function(text) {
+                            initialMeridiem = text;
+                            return meridiemBtn.click();
+                        }).then(function() {
+                            return meridiemBtn.getText();
+                        }).then(function(newText) {
+                            if (initialMeridiem == 'AM') {
+                                expect(newText).toEqual('PM');
+                            } else {
+                                expect(newText).toEqual('AM');
+                            }
+                            return meridiemBtn.click();
+                        }).then(function() {
+                            return meridiemBtn.getText();
+                        }).then(function(newText) {
+                            expect(newText).toEqual(initialMeridiem);
+                        }).catch(function(error) {
+                            console.log(error);
+                            expect('There was an error in this promise chain.').toBe('Please see the error message.');
+                        });
 
                         // Test time input validation; date input tested in earlier describe block
                         var defaultTimeValue = '12:00:00';
@@ -528,7 +553,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                         timeInputFields.push({
                             date: dateInput,
                             time: timeInput,
-                            meridiem: meridiemInput,
+                            meridiem: meridiemBtn,
                             column: column
                         });
                     });


### PR DESCRIPTION
This PR addresses #863.

This fixes the scenario when a timestamp column is null and the user is unable to toggle the AM/PM button. This is because in edit mode, when a timestamp column has a null value, the `meridiem` property of the timestamp column's model object is set to `null` as well, and the toggling logic breaks from there.

Synapse-dev has records with null timestamp values, example demo: https://synapse-dev.isrd.isi.edu/~jessie/chaise/recordedit/#1/Zebrafish:Behavior/ID=BhvZfCza20160815A1@sort(ID::desc::)