### PR TITLE
Multi edit for recordedit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ E2EDIrecordDefaults=test/e2e/specs/recordedit/data-independent/add-defaults/prot
 E2EDIrecordEdit=test/e2e/specs/recordedit/data-independent/edit/protractor.conf.js
 E2EDIrecordEditDeleteRecord=test/e2e/specs/recordedit/data-independent/delete-record/protractor.conf.js
 E2EDIrecordMultiAdd=test/e2e/specs/recordedit/data-independent/multi-add/protractor.conf.js
+E2EDIrecordMultiEdit=test/e2e/specs/recordedit/data-independent/multi-edit/protractor.conf.js
 E2EDrecordEditCompositeKey=test/e2e/specs/recordedit/data-dependent/composite-key/protractor.conf.js
 E2EDrecordEditSubmissionDisabled=test/e2e/specs/recordedit/data-dependent/submission-disabled/protractor.conf.js
 # Record tests
@@ -432,7 +433,8 @@ distclean: clean
 # Rule to run tests
 .PHONY: test
 test:
-	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
+	#$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) &&
+	$(BIN)/protractor $(E2EDIrecordMultiEdit) #&& $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
 
 # Rule to run karma
 .PHONY: karma
@@ -443,7 +445,7 @@ karma:
 .PHONY: testall
 testall:
 	$(BIN)/karma start
-	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
+	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDIrecordMultiEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
 
 #Rule to run navbar tests
 .PHONY: testnavbar
@@ -477,7 +479,7 @@ testrecordset:
 
 .PHONY: testrecordedit
 testrecordedit:
-	$(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled)
+	$(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDIrecordMultiEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled)
 
 #Rule to run viewer app tests
 .PHONY: testviewer

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,7 @@ distclean: clean
 # Rule to run tests
 .PHONY: test
 test:
-	#$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) &&
-	$(BIN)/protractor $(E2EDIrecordMultiEdit) #&& $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
+	$(BIN)/protractor $(E2Enavbar) && $(BIN)/protractor $(E2EnavbarHeadTitle) && $(BIN)/protractor $(E2EDrecord) && $(BIN)/protractor $(E2EDrecordRelatedTable) && $(BIN)/protractor $(E2ErecordNoDeleteBtn) && $(BIN)/protractor $(E2EDrecordCopy) && $(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDIrecordAdd) && $(BIN)/protractor $(E2EDIrecordDefaults) && $(BIN)/protractor $(E2EDIrecordMultiAdd) && $(BIN)/protractor $(E2EDIrecordEdit) && $(BIN)/protractor $(E2EDIrecordMultiEdit) && $(BIN)/protractor $(E2EDrecordEditCompositeKey) && $(BIN)/protractor $(E2EDIrecordEditDeleteRecord) && $(BIN)/protractor $(E2EDrecordEditSubmissionDisabled) && $(BIN)/protractor $(E2EDviewer) && $(BIN)/protractor $(E2EDIsearch) && $(BIN)/protractor $(E2EDsearch) && $(BIN)/protractor $(E2Elogin)
 
 # Rule to run karma
 .PHONY: karma

--- a/common/utils.js
+++ b/common/utils.js
@@ -268,13 +268,14 @@
                 // split by ';' and '&'
                 var regExp = new RegExp('(;|&|[^;&]+)', 'g');
                 var items = parts[2].match(regExp);
+                var filters = [];
 
                 // if a single filter
                 if (items.length === 1) {
-                    context.filter = processSingleFilterString(items[0]);
+                    filters.push(processSingleFilterString(items[0]));
+                    context.filter = {filters: filters};
 
                 } else {
-                    var filters = [];
                     var type = null;
                     for (var i = 0; i < items.length; i++) {
                         // process anything that's inside () first

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha": "x",
     "moment": "^2.15.1",
     "phantomjs-prebuilt": "x",
-    "protractor": "x",
+    "protractor": "4.0.14",
     "q": "^1.4.1",
     "request": "x",
     "set-cookie-parser": "x",

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -215,7 +215,30 @@
                     // submit $rootScope.tuples because we are changing and comparing data from the old data set for the tuple with the updated data set from the UI
                     $rootScope.reference.update($rootScope.tuples).then(function success(page) {
                         vm.readyToSubmit = false; // form data has already been submitted to ERMrest
-                        vm.redirectAfterSubmission(page);
+                        if (model.rows.length == 1) {
+                            vm.redirectAfterSubmission(page);
+                        } else {
+                            console.log(page);
+                            AlertsService.addAlert({type: 'success', message: 'Your data has been submitted. Showing you the result set...'});
+                            // can't use page.reference because it reflects the specific values that were inserted
+                            vm.recordsetLink = $rootScope.reference.contextualize.compact.appLink
+                            //set values for the view to flip to recordedit resultset view
+                            vm.resultsetModel = {
+                                hasLoaded: true,
+                                reference: page.reference,
+                                tableDisplayName: page.reference.displayname,
+                                columns: page.reference.columns,
+                                enableSort: false,
+                                sortby: null,
+                                sortOrder: null,
+                                page: page,
+                                pageLimit: model.rows.length,
+                                rowValues: [],
+                                search: null
+                            }
+                            vm.resultsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
+                            vm.resultset = true;
+                        }
                     }, function error(response) {
                         vm.showSubmissionError(response);
                         vm.submissionButtonDisabled = false;

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -218,7 +218,6 @@
                         if (model.rows.length == 1) {
                             vm.redirectAfterSubmission(page);
                         } else {
-                            console.log(page);
                             AlertsService.addAlert({type: 'success', message: 'Your data has been submitted. Showing you the result set...'});
                             // can't use page.reference because it reflects the specific values that were inserted
                             vm.recordsetLink = $rootScope.reference.contextualize.compact.appLink

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -229,10 +229,10 @@
             </div>
             </div>
             <div ng-show=form.resultset class="container-fluid">
-                <h2 class="entity-title">Created {{ form.resultsetModel.pageLimit }} records for table <a ng-href="{{form.recordsetLink}}">{{ form.resultsetModel.tableDisplayName }}</a></h2>
+                <h2 class="entity-title"><span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Edited</span> {{ form.resultsetModel.pageLimit }} records for table <a ng-href="{{form.recordsetLink}}">{{ form.resultsetModel.tableDisplayName }}</a></h2>
 
                 <div class="side-padding-15">
-                    <record-table vm="form.resultsetModel" default-row-linking="false"></record-table>
+                    <record-table vm="form.resultsetModel" default-row-linking="true"></record-table>
                 </div>
             </div>
         </div>

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -102,13 +102,19 @@
                 // Case for editing an entity
                 if (context.filter) {
                     if ($rootScope.reference.canUpdate) {
-                        // check id range before reading?
                         $rootScope.reference.read(context.filter.filters.length).then(function getPage(page) {
                             $log.info("Page: ", page);
 
                             if (page.tuples.length < 1) {
-                                var filter = context.filter;
-                                var noDataMessage = "No entity exists with " + filter.column + filter.operator + filter.value;
+
+                                var filters = context.filter.filters;
+                                var noDataMessage = "No entity exists with ";
+                                for (var k = 0; k < filters.length; k++) {
+                                    noDataMessage += filters[k].column + filters[k].operator + filters[k].value;
+                                    if (k != filters.length-1) {
+                                        noDataMessage += " or ";
+                                    }
+                                }
                                 var noDataError = new Error(noDataMessage);
                                 noDataError.code = errorNames.notFound;
 

--- a/test/e2e/data_setup/config/recordadd-multi.dev.json
+++ b/test/e2e/data_setup/config/recordadd-multi.dev.json
@@ -14,6 +14,10 @@
             },
             "tables": {
                 "createNew": true
+            },
+            "entities": {
+            	"createNew": true,
+                "path": "test/e2e/data_setup/data/multi-add"
             }
         }],
         "schema": "multi-add"
@@ -33,11 +37,13 @@
             },
             "multi_edit" : {
                 "table_name" : "multi-add-table",
-                "keys_2" : [{ "name": "id", "value": "2001", "operator" : "=" },
-                            { "name": "id", "value": "2002", "operator" : "=" }],
-                "keys_3" : [{ "name": "id", "value": "2002", "operator" : "=" },
-                            { "name": "id", "value": "2003", "operator" : "=" },
-                            { "name": "id", "value": "2004", "operator" : "=" }]
+                "int_column_name" : "int",
+                "text_column_name" : "text",
+                "keys_2" : [{ "name": "id", "value": "1000", "operator" : "=" },
+                            { "name": "id", "value": "1001", "operator" : "=" }],
+                "keys_3" : [{ "name": "id", "value": "1000", "operator" : "=" },
+                            { "name": "id", "value": "1001", "operator" : "=" },
+                            { "name": "id", "value": "1002", "operator" : "=" }]
             }
         }
     }

--- a/test/e2e/data_setup/config/recordadd-multi.dev.json
+++ b/test/e2e/data_setup/config/recordadd-multi.dev.json
@@ -30,6 +30,14 @@
                 "input_1_text_val" : "asdfg",
                 "input_2_text_val" : "qwerty",
                 "input_3_int_val" : "17"
+            },
+            "multi_edit" : {
+                "table_name" : "multi-add-table",
+                "keys_2" : [{ "name": "id", "value": "2001", "operator" : "=" },
+                            { "name": "id", "value": "2002", "operator" : "=" }],
+                "keys_3" : [{ "name": "id", "value": "2002", "operator" : "=" },
+                            { "name": "id", "value": "2003", "operator" : "=" },
+                            { "name": "id", "value": "2004", "operator" : "=" }]
             }
         }
     }

--- a/test/e2e/data_setup/data/multi-add/multi-add-table.json
+++ b/test/e2e/data_setup/data/multi-add/multi-add-table.json
@@ -1,0 +1,3 @@
+[{"id": 1000, "text": "test text", "int": 7},
+ {"id": 1001, "text": "description", "int": 12},
+ {"id": 1002, "text": "just text", "int": 34}]

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -61,7 +61,7 @@ exports.testPresentation = function (tableParams) {
 			expect(pageColumns.length).toBe(columns.length);
 			var index = 0;
 			pageColumns.forEach(function(c) {
-				c.getInnerHtml().then(function(txt) {
+				c.getAttribute('innerHTML').then(function(txt) {
 					txt = txt.trim();
 					var col = columns[index++];
 					expect(col).toBeDefined();
@@ -111,7 +111,7 @@ exports.testPresentation = function (tableParams) {
                         expect(aTag.getText()).toEqual(column.value);
                     });
                 } else {
-                    expect(el.getInnerHtml()).toBe(column.value);
+                    expect(el.getAttribute('innerHTML')).toBe(column.value);
                 }
 			});
 		});
@@ -158,7 +158,7 @@ exports.testPresentation = function (tableParams) {
 
                 // verify all columns are present
                 (function(i, displayName) {
-                    chaisePage.recordPage.getRelatedTableColumnNamesByTable(displayName).getInnerHtml().then(function(columnNames) {
+                    chaisePage.recordPage.getRelatedTableColumnNamesByTable(displayName).getAttribute('innerHTML').then(function(columnNames) {
                         for (var j = 0; j < columnNames.length; j++) {
                             expect(columnNames[j]).toBe(relatedTables[i].columns[j]);
                         }
@@ -326,7 +326,7 @@ exports.relatedTableLinks = function (testParams, tableParams) {
         chaisePage.recordPage.getRelatedTableRows(relatedTableName).then(function(rows) {
             return rows[0].all(by.tagName("td"));
         }).then(function(cells) {
-            return cells[3].getInnerHtml();
+            return cells[3].getAttribute('innerHTML');
         }).then(function(cell) {
             // check that an element was created inside the td with an href attribute
             expect(cell.indexOf("href")).toBeGreaterThan(-1);
@@ -413,7 +413,7 @@ exports.relatedTableLinks = function (testParams, tableParams) {
             relatedTableName = tableParams.related_table_name_with_more_results,
             relatedTableLink = chaisePage.recordPage.getMoreResultsLink(relatedTableName);
 
-        browser.wait(EC.elementToBeClickable(relatedTableLink), browser.params.defaultTimeout).then(function() {
+        browser.wait(EC.visibilityOf(relatedTableLink), browser.params.defaultTimeout).then(function() {
             // waits until the count is what we expect, so we know the refresh occured
             browser.wait(function() {
                 return chaisePage.recordPage.getRelatedTableRows(relatedTableName).count().then(function(ct) {
@@ -477,6 +477,7 @@ exports.relatedTableActions = function (testParams, tableParams) {
         }).then(function(cell) {
             return cell[0].all(by.css(".edit-action-button"));
         }).then(function(editButtons) {
+            browser.sleep(1000);
             return editButtons[0].click();
         }).then(function() {
             return browser.getAllWindowHandles();
@@ -509,7 +510,7 @@ exports.relatedTableActions = function (testParams, tableParams) {
             return rows[count - 1].all(by.tagName("td"));
         }).then(function(cells) {
             rowCells = cells;
-            return cells[1].getInnerHtml();
+            return cells[1].getAttribute('innerHTML');
         }).then(function(cell) {
             oldValue = cell;
             return table.all(by.css(".delete-action-button"));
@@ -543,7 +544,7 @@ exports.relatedTableActions = function (testParams, tableParams) {
             return rows[count - 1].all(by.tagName("td"));
         }).then(function(cells) {
             rowCells = cells;
-            return cells[1].getInnerHtml();
+            return cells[1].getAttribute('innerHTML');
         }).then(function(cell) {
             oldValue = cell;
             return table.all(by.css(".delete-action-button"))
@@ -559,7 +560,7 @@ exports.relatedTableActions = function (testParams, tableParams) {
             return confirmButton.click();
         }).then(function() {
             browser.wait(
-                function() {return rowCells[1].getInnerHtml() !== oldValue},
+                function() {return rowCells[1].getAttribute('innerHTML') !== oldValue},
                 browser.params.defaultTimeout);
             done();
         })

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -414,6 +414,13 @@ exports.relatedTableLinks = function (testParams, tableParams) {
             relatedTableLink = chaisePage.recordPage.getMoreResultsLink(relatedTableName);
 
         browser.wait(EC.elementToBeClickable(relatedTableLink), browser.params.defaultTimeout).then(function() {
+            // waits until the count is what we expect, so we know the refresh occured
+            browser.wait(function() {
+                return chaisePage.recordPage.getRelatedTableRows(relatedTableName).count().then(function(ct) {
+                    return (ct == tableParams.booking_count + 1);
+                });
+            }, browser.params.defaultTimeout);
+
             return chaisePage.recordPage.getRelatedTableRows(relatedTableName).count();
         }).then(function(count) {
             expect(count).toBe(tableParams.booking_count + 1);

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -152,7 +152,7 @@ describe('Record Add', function() {
                 rowname: chance.sentence(),
                 keys: {id: 1}
             };
-            browser.manage().addCookie({name: 'test', value: JSON.stringify(testCookie)});
+            browser.manage().addCookie(name: 'test', value: JSON.stringify(testCookie));
 
             // Reload the page with prefill query param in url
             browser.get(browser.params.url + ":" + testParams.tables[0].table_name + '?prefill=test');

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -160,17 +160,15 @@ describe('Record Add', function() {
 
         it('should pre-fill fields from the prefill cookie', function() {
             chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
-                return browser.manage().getCookies();
-            }).then(function(cookies) {
-                var cookie = {name: "no cookie"};
-                for (var i = 0; i < cookies.length; i++) {
-                    if (cookies[i].name === "test") {
-                        cookie = cookies[i];
-                    }
+                return browser.manage().getCookie('test');
+            }).then(function(cookie) {
+                if (cookie) {
+                    var field = element.all(by.css('.popup-select-value')).first();
+                    expect(field.getText()).toBe(testCookie.rowname);
+                } else {
+                    // Fail the test
+                    expect('Cookie did not load').toEqual('but cookie should have loaded');
                 }
-                expect(cookie.name).toBe("test");
-                var field = element.all(by.css('.popup-select-value')).first();
-                expect(field.getText()).toBe(testCookie.rowname);
             });
         });
 

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -160,15 +160,17 @@ describe('Record Add', function() {
 
         it('should pre-fill fields from the prefill cookie', function() {
             chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
-                return browser.manage().getCookie('test');
-            }).then(function(cookie) {
-                if (cookie) {
-                    var field = element.all(by.css('.popup-select-value')).first();
-                    expect(field.getText()).toBe(testCookie.rowname);
-                } else {
-                    // Fail the test
-                    expect('Cookie did not load').toEqual('but cookie should have loaded');
+                return browser.manage().getCookies();
+            }).then(function(cookies) {
+                var cookie = {name: "no cookie"};
+                for (var i = 0; i < cookies.length; i++) {
+                    if (cookies[i].name === "test") {
+                        cookie = cookies[i];
+                    }
                 }
+                expect(cookie.name).toBe("test");
+                var field = element.all(by.css('.popup-select-value')).first();
+                expect(field.getText()).toBe(testCookie.rowname);
             });
         });
 

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -152,7 +152,7 @@ describe('Record Add', function() {
                 rowname: chance.sentence(),
                 keys: {id: 1}
             };
-            browser.manage().addCookie('test', JSON.stringify(testCookie));
+            browser.manage().addCookie({name: 'test', value: JSON.stringify(testCookie)});
 
             // Reload the page with prefill query param in url
             browser.get(browser.params.url + ":" + testParams.tables[0].table_name + '?prefill=test');

--- a/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/add/00-recordedit.add.spec.js
@@ -152,7 +152,7 @@ describe('Record Add', function() {
                 rowname: chance.sentence(),
                 keys: {id: 1}
             };
-            browser.manage().addCookie(name: 'test', value: JSON.stringify(testCookie));
+            browser.manage().addCookie('test', JSON.stringify(testCookie));
 
             // Reload the page with prefill query param in url
             browser.get(browser.params.url + ":" + testParams.tables[0].table_name + '?prefill=test');

--- a/test/e2e/specs/recordedit/data-independent/edit/01-recordedit.edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/edit/01-recordedit.edit.spec.js
@@ -1,4 +1,4 @@
-var chaisePage = require('../../../../utils/chaise.page.js'), IGNORE = "tag:isrd.isi.edu,2016:ignore", HIDDEN = "tag:misd.isi.edu,2015:hidden";
+var chaisePage = require('../../../../utils/chaise.page.js');
 var recordEditHelpers = require('../../helpers.js');
 
 describe('Edit existing record,', function() {

--- a/test/e2e/specs/recordedit/data-independent/multi-add/06-recordedit.add-x-forms.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-add/06-recordedit.add-x-forms.spec.js
@@ -165,7 +165,7 @@ describe('Record Add', function() {
                 browser.get(browser.params.url + ":" + testParams.table_name);
             });
 
-            it("should show a resultset table with 201 entities.", function() {
+            it("should show a resultset table with " + tableParams.max_input_rows+1 + " entities.", function() {
                 browser.wait(EC.elementToBeClickable(multiFormOpenButton), browser.params.defaultTimeout);
 
                 var intInput = chaisePage.recordEditPage.getInputById(0, "int");
@@ -176,7 +176,7 @@ describe('Record Add', function() {
                 }).then(function() {
                     chaisePage.recordEditPage.clearInput(multiFormInput);
                     browser.sleep(10);
-                    multiFormInput.sendKeys(200);
+                    multiFormInput.sendKeys(testParams.max_input_rows);
 
                     return chaisePage.recordEditPage.getMultiFormInputSubmitButtonScript();
                 }).then(function(submitBtn) {
@@ -185,7 +185,7 @@ describe('Record Add', function() {
                     // wait for dom to finish rendering the forms
                     browser.wait(function() {
                         return chaisePage.recordEditPage.getForms().count().then(function(ct) {
-                            return (ct == 201);
+                            return (ct == tableParams.max_input_rows+1);
                         });
                     }, browser.params.defaultTimeout);
 
@@ -198,13 +198,13 @@ describe('Record Add', function() {
                     // so DOM can render table
                     browser.wait(function() {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
-                            return (ct == 201);
+                            return (ct == tableParams.max_input_rows+1);
                         });
                     }, browser.params.defaultTimeout);
 
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function(ct) {
-                    expect(ct).toBe(201);
+                    expect(ct).toBe(tableParams.max_input_rows+1);
                 });
             })
         });

--- a/test/e2e/specs/recordedit/data-independent/multi-add/06-recordedit.add-x-forms.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-add/06-recordedit.add-x-forms.spec.js
@@ -165,7 +165,7 @@ describe('Record Add', function() {
                 browser.get(browser.params.url + ":" + testParams.table_name);
             });
 
-            it("should show a resultset table with " + tableParams.max_input_rows+1 + " entities.", function() {
+            it("should show a resultset table with " + testParams.max_input_rows+1 + " entities.", function() {
                 browser.wait(EC.elementToBeClickable(multiFormOpenButton), browser.params.defaultTimeout);
 
                 var intInput = chaisePage.recordEditPage.getInputById(0, "int");
@@ -185,7 +185,7 @@ describe('Record Add', function() {
                     // wait for dom to finish rendering the forms
                     browser.wait(function() {
                         return chaisePage.recordEditPage.getForms().count().then(function(ct) {
-                            return (ct == tableParams.max_input_rows+1);
+                            return (ct == testParams.max_input_rows+1);
                         });
                     }, browser.params.defaultTimeout);
 
@@ -198,13 +198,13 @@ describe('Record Add', function() {
                     // so DOM can render table
                     browser.wait(function() {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
-                            return (ct == tableParams.max_input_rows+1);
+                            return (ct == testParams.max_input_rows+1);
                         });
                     }, browser.params.defaultTimeout);
 
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function(ct) {
-                    expect(ct).toBe(tableParams.max_input_rows+1);
+                    expect(ct).toBe(testParams.max_input_rows+1);
                 });
             })
         });

--- a/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
@@ -3,40 +3,190 @@ var recordEditHelpers = require('../../helpers.js');
 
 describe('Edit existing record,', function() {
 
-	var testConfiguration = browser.params.configuration.tests, testParams = testConfiguration.params.multi_edit;
+	var testConfiguration = browser.params.configuration.tests,
+        testParams = testConfiguration.params.multi_edit,
+        intDisplayName = testParams.int_column_name,
+        textDisplayName = testParams.text_column_name;
 
-    describe("when the user edits 2 records at a time, ", function() {
+    // database values before changes
+    var intInput1DefaultVal = "7",
+        textInput1DefaultVal = "test text",
+        intInput2DefaultVal = "12",
+        textInput2DefaultVal = "description",
+        intInput3DefaultVal = "34",
+        textInput3DefaultVal = "just text";
+
+    // changes to values for case of 2 forms
+    var intInput1FirstVal = "4",
+        textInput1FirstVal = "modified val",
+        intInput2FirstVal = "66",
+        textInput2FirstVal = "decription 2";
+
+    // changes to values for case of 3 forms
+    var intInput1SecondVal = "5",
+        textInput1SecondVal = "changed it again",
+        intInput2SecondVal = "768",
+        textInput2SecondVal = "decription 3";
+        intInput3FirstVal = "934",
+        textInput3FirstVal = "I am number 3";
+
+    describe("when the user edits " + testParams.keys_2.length + " records at a time, ", function() {
 
         beforeAll(function () {
             var keys = [];
-            tableParams.keys_2.forEach(function(key) {
+            testParams.keys_2.forEach(function(key) {
                 keys.push(key.name + key.operator + key.value);
             });
             browser.ignoreSynchronization = true;
-            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join("&"));
+            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join(";"));
         });
 
         it("should change their values and show a resultset table with 2 entities.", function() {
+            var intInput1 = chaisePage.recordEditPage.getInputById(0, intDisplayName),
+                intInput2 = chaisePage.recordEditPage.getInputById(1, intDisplayName),
+                textInput1 = chaisePage.recordEditPage.getInputById(0, textDisplayName),
+                textInput2 = chaisePage.recordEditPage.getInputById(1, textDisplayName);
+
             chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
 
+                // modify first form
+                // check value before that it loaded correctly
+                expect(intInput1.getAttribute("value")).toBe(intInput1DefaultVal);
+                chaisePage.recordEditPage.clearInput(intInput1);
+                browser.sleep(10);
+                intInput1.sendKeys(intInput1FirstVal);
+                // check value after it was changed
+                expect(intInput1.getAttribute("value")).toBe(intInput1FirstVal);
+
+                expect(textInput1.getAttribute("value")).toBe(textInput1DefaultVal);
+                chaisePage.recordEditPage.clearInput(textInput1);
+                browser.sleep(10);
+                textInput1.sendKeys(textInput1FirstVal);
+                expect(textInput1.getAttribute("value")).toBe(textInput1FirstVal);
+
+                // modify second form
+                expect(intInput2.getAttribute("value")).toBe(intInput2DefaultVal);
+                chaisePage.recordEditPage.clearInput(intInput2);
+                browser.sleep(10);
+                intInput2.sendKeys(intInput2FirstVal);
+                expect(intInput2.getAttribute("value")).toBe(intInput2FirstVal);
+
+                expect(textInput2.getAttribute("value")).toBe(textInput2DefaultVal);
+                chaisePage.recordEditPage.clearInput(textInput2);
+                browser.sleep(10);
+                textInput2.sendKeys(textInput2FirstVal);
+                expect(textInput2.getAttribute("value")).toBe(textInput2FirstVal);
+            });
+        });
+
+        describe("Submit " + testParams.keys_2.length + " records", function() {
+            beforeAll(function() {
+                // submit form
+                chaisePage.recordEditPage.submitForm();
+            });
+
+            it("should change the view to the resultset table and verify the count.", function() {
+                // Make sure the table shows up with the expected # of rows
+                browser.wait(function() {
+                    return chaisePage.recordsetPage.getRows().count().then(function(ct) {
+                        return (ct == testParams.keys_2.length);
+                    });
+                }, browser.params.defaultTimeout);
+
+                browser.driver.getCurrentUrl().then(function(url) {
+                    expect(url.startsWith(process.env.CHAISE_BASE_URL + "/recordedit/")).toBe(true);
+
+                    return chaisePage.recordsetPage.getRows().count();
+                }).then(function(ct) {
+                    expect(ct).toBe(testParams.keys_2.length);
+                });
             });
         });
     });
 
-    describe("when the user edits 3 records at a time, ", function() {
+    describe("when the user edits " + testParams.keys_3.length + " records at a time, ", function() {
 
         beforeAll(function () {
             var keys = [];
-            tableParams.keys_3.forEach(function(key) {
+            testParams.keys_3.forEach(function(key) {
                 keys.push(key.name + key.operator + key.value);
             });
             browser.ignoreSynchronization = true;
-            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join("&"));
+            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join(";"));
         });
 
         it("should change their values and show a resultset table with 3 entities.", function() {
+            var intInput1 = chaisePage.recordEditPage.getInputById(0, intDisplayName),
+                intInput2 = chaisePage.recordEditPage.getInputById(1, intDisplayName),
+                intInput3 = chaisePage.recordEditPage.getInputById(2, intDisplayName),
+                textInput1 = chaisePage.recordEditPage.getInputById(0, textDisplayName),
+                textInput2 = chaisePage.recordEditPage.getInputById(1, textDisplayName),
+                textInput3 = chaisePage.recordEditPage.getInputById(2, textDisplayName);
+
             chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
 
+                // modify first form
+                expect(intInput1.getAttribute("value")).toBe(intInput1FirstVal);
+                chaisePage.recordEditPage.clearInput(intInput1);
+                browser.sleep(10);
+                intInput1.sendKeys(intInput1SecondVal);
+                expect(intInput1.getAttribute("value")).toBe(intInput1SecondVal);
+
+                expect(textInput1.getAttribute("value")).toBe(textInput1FirstVal);
+                chaisePage.recordEditPage.clearInput(textInput1);
+                browser.sleep(10);
+                textInput1.sendKeys(textInput1SecondVal);
+                expect(textInput1.getAttribute("value")).toBe(textInput1SecondVal);
+
+                // modify second form
+                expect(intInput2.getAttribute("value")).toBe(intInput2FirstVal);
+                chaisePage.recordEditPage.clearInput(intInput2);
+                browser.sleep(10);
+                intInput2.sendKeys(intInput2SecondVal);
+                expect(intInput2.getAttribute("value")).toBe(intInput2SecondVal);
+
+                expect(textInput2.getAttribute("value")).toBe(textInput2FirstVal);
+                chaisePage.recordEditPage.clearInput(textInput2);
+                browser.sleep(10);
+                textInput2.sendKeys(textInput2SecondVal);
+                expect(textInput2.getAttribute("value")).toBe(textInput2SecondVal);
+
+                // modify third form
+                expect(intInput3.getAttribute("value")).toBe(intInput3DefaultVal);
+                chaisePage.recordEditPage.clearInput(intInput3);
+                browser.sleep(10);
+                intInput3.sendKeys(intInput3FirstVal);
+                expect(intInput3.getAttribute("value")).toBe(intInput3FirstVal);
+
+                expect(textInput3.getAttribute("value")).toBe(textInput3DefaultVal);
+                chaisePage.recordEditPage.clearInput(textInput3);
+                browser.sleep(10);
+                textInput3.sendKeys(textInput3FirstVal);
+                expect(textInput3.getAttribute("value")).toBe(textInput3FirstVal);
+            });
+        });
+
+        describe("Submit " + testParams.keys_3.length + " records", function() {
+            beforeAll(function() {
+                // submit form
+                chaisePage.recordEditPage.submitForm();
+            });
+
+            it("should change the view to the resultset table and verify the count.", function() {
+                // Make sure the table shows up with the expected # of rows
+                browser.wait(function() {
+                    return chaisePage.recordsetPage.getRows().count().then(function(ct) {
+                        return (ct == testParams.keys_3.length);
+                    });
+                }, browser.params.defaultTimeout);
+
+                browser.driver.getCurrentUrl().then(function(url) {
+                    expect(url.startsWith(process.env.CHAISE_BASE_URL + "/recordedit/")).toBe(true);
+
+                    return chaisePage.recordsetPage.getRows().count();
+                }).then(function(ct) {
+                    expect(ct).toBe(testParams.keys_3.length);
+                });
             });
         });
     });

--- a/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
@@ -1,0 +1,43 @@
+var chaisePage = require('../../../../utils/chaise.page.js');
+var recordEditHelpers = require('../../helpers.js');
+
+describe('Edit existing record,', function() {
+
+	var testConfiguration = browser.params.configuration.tests, testParams = testConfiguration.params.multi_edit;
+
+    describe("when the user edits 2 records at a time, ", function() {
+
+        beforeAll(function () {
+            var keys = [];
+            tableParams.keys_2.forEach(function(key) {
+                keys.push(key.name + key.operator + key.value);
+            });
+            browser.ignoreSynchronization = true;
+            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join("&"));
+        });
+
+        it("should change their values and show a resultset table with 2 entities.", function() {
+            chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+
+            });
+        });
+    });
+
+    describe("when the user edits 3 records at a time, ", function() {
+
+        beforeAll(function () {
+            var keys = [];
+            tableParams.keys_3.forEach(function(key) {
+                keys.push(key.name + key.operator + key.value);
+            });
+            browser.ignoreSynchronization = true;
+            browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join("&"));
+        });
+
+        it("should change their values and show a resultset table with 3 entities.", function() {
+            chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+
+            });
+        });
+    });
+});

--- a/test/e2e/specs/recordedit/data-independent/multi-edit/protractor.conf.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-edit/protractor.conf.js
@@ -1,0 +1,23 @@
+var pConfig = require('./../../../../utils/protractor.configuration.js');
+
+var config = pConfig.getConfig({
+
+  // Change this to your desired filed name and Comment below testConfiguration object declaration
+    configFileName: 'recordadd-multi.dev.json',
+
+  /* Just in case if you plan on not giving a file for configuration, you can always specify a testConfiguration object
+   * Comment above 2 lines
+   * Empty configuration will run test cases against catalog 1 and default schema
+    testConfiguration: {
+      ....
+    },
+  */
+
+    page: 'recordedit',
+    setBaseUrl: function(browser, data) {
+      browser.params.url = process.env.CHAISE_BASE_URL + "/recordedit" + "/#" + data.catalogId + "/" + data.schema.name;
+      return browser.params.url;
+    }
+});
+
+exports.config = config;

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -57,7 +57,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 		chaisePage.recordEditPage.getAllColumnCaptions().then(function(pageColumns) {
 			expect(pageColumns.length).toBe(columns.length);
 			pageColumns.forEach(function(c) {
-				c.getInnerHtml().then(function(txt) {
+				c.getAttribute('innerHTML').then(function(txt) {
 					txt = txt.trim();
 					var col = columns.find(function(cl) { return txt == cl.displayName });
 					expect(col).toBeDefined();
@@ -224,7 +224,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 
 					chaisePage.recordEditPage.getAllColumnCaptions().then(function(pcs) {
 						pcs.forEach(function(pc) {
-							pc.getInnerHtml().then(function(txt) {
+							pc.getAttribute('innerHTML').then(function(txt) {
 								txt = txt.trim();
 								var col = columns.find(function(cl) { return txt == cl.displayName });
 								if (col) {
@@ -296,7 +296,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 
 					chaisePage.recordEditPage.getAllColumnCaptions().then(function(pcs) {
 						pcs.forEach(function(pc) {
-							pc.getInnerHtml().then(function(txt) {
+							pc.getAttribute('innerHTML').then(function(txt) {
 								txt = txt.trim();
 								var col = columns.find(function(cl) { return txt == cl.displayName });
 								if (col) {

--- a/test/e2e/specs/recordset/helpers.js
+++ b/test/e2e/specs/recordset/helpers.js
@@ -38,7 +38,7 @@ exports.testPresentation = function (tableParams) {
 	});
 
 	it("should have " + tableParams.columns.length + " columns", function() {
-		chaisePage.recordsetPage.getColumns().getInnerHtml().then(function(columnNames) {
+		chaisePage.recordsetPage.getColumns().getAttribute('innerHTML').then(function(columnNames) {
 			for (var j = 0; j < columnNames.length; j++) {
 				expect(columnNames[j]).toBe(tableParams.columns[j].title);
 			}


### PR DESCRIPTION
This PR addresses issue #870, allowing the multi-edit functionality for the recordedit page. Recordedit expects a uri in the form of `.../t:s/<column-name>=<val>;<column-name>=<val>;...`. This will show however many records that the user defines in the uri. 

After submitting the data, the user will be shown the resultset view of the recordedit app rather than being redirected to recordset. This can be tested from [here](https://dev.isrd.isi.edu/~jchudy/chaise/recordedit/#1/legacy:dataset/id=9;id=10).