### PR TITLE
Copy button creates 1 form

### DIFF
--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -37,7 +37,7 @@
         vm.copyRecord = function() {
             var newRef = $rootScope.reference.contextualize.entryEdit;
 
-            var appLink = newRef.appLink + "?copy=true";
+            var appLink = newRef.appLink + "?copy=true&limit=1";
             $window.location.href = appLink;
         };
 

--- a/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
+++ b/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
@@ -50,6 +50,11 @@ describe('View existing record,', function() {
                     return chaisePage.recordEditPage.getEntityTitle();
                 }).then(function(txt) {
                     expect(txt.indexOf('Create')).toBeGreaterThan(-1);
+
+                    return chaisePage.recordEditPage.getForms().count();
+                }).then(function(ct) {
+                    // only 1 row is copied at this time
+                    expect(ct).toBe(1);
                 }).catch(function(error) {
                     console.log(error);
                     expect('There was an error.').toBe('Please check the error message.');


### PR DESCRIPTION
The copy button in `record` includes a limit in the generated url so that only the number of forms specified are created upon loading the `recordedit` app. This fixes issue #928.