### PR TITLE
App links

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -57,7 +57,7 @@
      */
     .factory('recordTableUtils', ['DataUtils', '$timeout', function(DataUtils, $timeout) {
         function read(scope) {
-            
+
             scope.vm.hasLoaded = false;
 
             var isBackground = !scope.vm.foregroundSearch && scope.vm.backgroundSearch;
@@ -73,7 +73,7 @@
                 $timeout(function() {
                     if (scope.vm.foregroundSearch) scope.vm.foregroundSearch = false;
                 }, 200);
-                
+
                 // tell parent controller data updated
                 scope.$emit('recordset-update');
 
@@ -172,7 +172,7 @@
 
 
                 var inputChangedPromise;
-                
+
                 scope.inputChanged = function() {
                     if (scope.vm.enableAutoSearch) {
 
@@ -224,7 +224,7 @@
                     addRecordRequests[referrer_id] = 0;
 
                     // open a new tab
-                    var newRef = scope.vm.reference.contextualize.entryCreate;
+                    var newRef = scope.vm.reference.table.reference.contextualize.entryCreate;
                     var appLink = newRef.appLink;
                     appLink = appLink + (appLink.indexOf("?") === -1? "?" : "&") +
                         'invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -13,7 +13,7 @@
         vm.showEmptyRelatedTables = false;
 
         vm.createRecord = function() {
-            var newRef = $rootScope.reference.contextualize.entryCreate;
+            var newRef = $rootScope.reference.table.reference.contextualize.entryCreate;
             var appURL = newRef.appLink;
             if (!appURL) {
                 AlertsService.addAlert({type: 'error', message: "Application Error: app linking undefined for " + newRef.compactPath});
@@ -35,7 +35,7 @@
         };
 
         vm.copyRecord = function() {
-            var newRef = $rootScope.reference.contextualize.entryEdit;
+            var newRef = $rootScope.reference.contextualize.entryCreate;
 
             var appLink = newRef.appLink + "?copy=true";
             $window.location.href = appLink;
@@ -137,7 +137,7 @@
             addRecordRequests[referrer_id] = ref.uri;
 
             // 3. Get appLink, append ?prefill=[COOKIE_NAME]&referrer=[referrer_id]
-            var appLink = newRef.appLink;
+            var appLink = ref.table.reference.contextualize.entryCreate.appLink;
             appLink = appLink + (appLink.indexOf("?") === -1? "?" : "&") +
                 'prefill=' + UriUtils.fixedEncodeURIComponent(COOKIE_NAME) +
                 '&invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -251,7 +251,7 @@
                     });
                 }
             } else {
-                $rootScope.reference.create(model.submissionRows).then(function success(page) {
+                $rootScope.reference.table.reference.create(model.submissionRows).then(function success(page) {
                     vm.readyToSubmit = false; // form data has already been submitted to ERMrest
                     if (vm.prefillCookie) {
                         $cookies.remove(context.queryParams.prefill);


### PR DESCRIPTION
The changes in this PR are to account for changes that are being made in ermrestJS in [this PR](https://github.com/informatics-isi-edu/ermrestjs/pull/321). This PR **cannot** be merged until the  aforementioned PR in ermrestJS is merged or else the build will fail.

After removing the code that changed the URI when contextualizing to `entry/create` in ermrestJS, the some of the links being generated to navigate between apps were incorrect. In cases where no filter is needed for the app link, `reference.table.reference` is used to get a more appropriate link.

This addresses issue #932.