### PR TITLE
Edit link on recordset checks permissions

### DIFF
--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -9,7 +9,7 @@
         <div class="row">
             <div id="recordset-bookmark-container" class="col-xs-12">
                 <!-- edit -->
-                <a id="edit-link" ng-if="vm.page" ng-disabled="vm.pageLimit > vm.RECORDEDIT_MAX_ROWS" ng-href="{{ edit() }}" tooltip-placement="bottom"
+                <a id="edit-link" ng-if="vm.page && vm.reference.canUpdate && vm.config.editable" ng-disabled="vm.pageLimit > vm.RECORDEDIT_MAX_ROWS" ng-href="{{ edit() }}" tooltip-placement="bottom"
                     uib-tooltip="{{ ((vm.pageLimit > vm.RECORDEDIT_MAX_ROWS) ? 'Editing disabled when items per page > ' + vm.RECORDEDIT_MAX_ROWS : 'Click here to edit this page of records.' ) }}">
                     <span class="glyphicon glyphicon-pencil"></span> <strong>Edit</strong>
                 </a>&nbsp;&nbsp;


### PR DESCRIPTION
The edit link on `recordset` will show based on the user's permissions and `chaiseConfig.editRecord`. This is so a not logged in user won't see the edit button as well as user's who aren't allowed to modify records.