### PR TITLE
Use appLink when deleting a record in Record app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ before_install:
   - cd ErmrestDataUtils
   - sudo npm install
   - cd ../chaise
-  - cp test/ermrest_config.json /home/ermrest/
-  - chmod a+r /home/ermrest/ermrest_config.json
+  - sudo cp test/ermrest_config.json /home/ermrest/
+  - sudo chmod a+r /home/ermrest/ermrest_config.json
   - sudo npm install
   - sudo service httpd restart
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ before_install:
   - sudo cp test/ermrest_config.json /home/ermrest/
   - sudo chmod a+r /home/ermrest/ermrest_config.json
   - sudo npm install
-  - sudo service httpd restart
+  - sudo service apache2 restart
 
 install:
   - sudo make build

--- a/common/utils.js
+++ b/common/utils.js
@@ -118,7 +118,7 @@
          * given an app tag and location object, return the full url
          * @param {string} tag
          * @param {ERMrest.Location} location
-         * @param {string} context - optional, used to determine default app is tag is null/undefined
+         * @param {string} context - optional, used to determine default app if tag is null/undefined
          * @returns {string} url
          */
         function appTagToURL(tag, location, context) {

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -43,9 +43,9 @@
 
         vm.deleteRecord = function() {
             $rootScope.reference.delete().then(function deleteSuccess() {
-                 var location = $rootScope.reference.location;
-                //success, go to databrowser or home
-                $window.location.href = "../search/#" + location.catalog + '/' + location.schemaName + ':' + location.tableName;
+                // Get an appLink from a reference to the table that the existing reference came from
+                var unfilteredRefAppLink = $rootScope.reference.table.reference.contextualize.compact.appLink;
+                $window.location.href = unfilteredRefAppLink;
             }, function deleteFail(error) {
                 AlertsService.addAlert({type: 'error', message: error.message});
                 $log.warn(error);
@@ -115,8 +115,7 @@
                 rowname: $rootScope.recordDisplayname,
                 constraintName: ref.origFKR.constraint_names[0].join(':')
             };
-            var newRef = ref.contextualize.entryCreate;
-            var mapping = newRef.origFKR.mapping;
+            var mapping = ref.contextualize.entryCreate.origFKR.mapping;
 
             // Get the column pair that form this FKR between this related table and the main entity
             cookie.keys = {};

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -118,15 +118,15 @@
                                             <div ng-switch-when="timestamp">
                                                 <input type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{column.name}}"
                                                 ng-show="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" />
-                                                <div class="row" ng-show="::!form.isDisabled(column);" >
-                                                    <div class="col-xs-12" ng-class="{'col-md-4': form.editMode}">
+                                                <div class="row" ng-show="::!form.isDisabled(column);">
+                                                    <div class="col-xs-12">
                                                         <div class="input-group">
                                                             <span class="input-group-addon">Date</span>
                                                             <input class="form-control input-timestamptz" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].date" placeholder="YYYY-MM-DD" name="{{::column.name}}"
                                                                 ui-mask="9999-99-99" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date>
                                                         </div>
                                                     </div>
-                                                    <div class="col-xs-12" ng-class="{'col-md-4': form.editMode}">
+                                                    <div class="col-xs-12">
                                                         <div class="input-group">
                                                             <span class="input-group-addon">Time</span>
                                                             <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].time" name="{{::column.name}}"
@@ -136,7 +136,7 @@
                                                             </span>
                                                         </div>
                                                     </div>
-                                                    <div class="col-xs-12" ng-class="{'col-md-4': form.editMode}">
+                                                    <div class="col-xs-12">
                                                         <div class="btn-group" role="group" ng-if="::!form.isDisabled(column);">
                                                             <button type="button" name="{{::column.name}}" class="btn btn-primary" ng-click="form.applyCurrentDatetime(rowIndex, column.name, column.type.name);">Now</button>
                                                             <button type="button" name="{{::column.name}}" class="btn btn-danger" ng-click="form.clearModel(rowIndex, column.name, column.type.name);">Clear</button>

--- a/test/e2e/specs/record/helpers.js
+++ b/test/e2e/specs/record/helpers.js
@@ -285,14 +285,12 @@ exports.testDeleteButton = function () {
             return modalTitle.getText();
         }).then(function (text) {
             expect(text).toBe("Confirm Delete");
-
             return chaisePage.recordPage.getConfirmDeleteButton().click();
         }).then(function () {
             browser.driver.sleep(1000);
-
             return browser.driver.getCurrentUrl();
         }).then(function(url) {
-            expect(url.indexOf('/search/')).toBeGreaterThan(-1);
+            expect(url.indexOf('/recordset/')).toBeGreaterThan(-1);
         });
     });
 }
@@ -396,8 +394,8 @@ exports.relatedTableLinks = function (testParams, tableParams) {
             return chaisePage.recordEditPage.submitForm();
         }).then(function() {
             // wait until redirected to record page
-            var title = chaisePage.recordPage.getEntityTitleElement();
-            browser.wait(EC.presenceOf(title), browser.params.defaultTimeout);
+            return browser.wait(EC.presenceOf(element(by.id('entity-title'))), browser.params.defaultTimeout);
+        }).then(function() {
             done();
         }).catch(function(error) {
             console.log(error);

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -59,7 +59,7 @@ role="button" title="edit annotations" id="edit-btn">
                             <button ng-click="osd.homeView();" class="btn btn-success" type="button" role="button" title="go home" id="gohome-btn">
                                 <span class="glyphicon glyphicon-home"></span> Reset
                             </button>
-<button ng-if="(!osd.isSafari && !osd.isRetina)"
+<button ng-if="(!osd.isSafari)"
     ng-click="osd.downloadView();" class="btn btn-success" type="button" role="button">
    <span class="glyphicon glyphicon-camera"></span> Take a Screenshot </button>
                         </div>


### PR DESCRIPTION
This PR addresses #849.

The delete record link now takes the reference to the deleted record, gets the reference to the record's table, contextualizes this table's reference to compact, and then fetches its `appLink`.

This PR cannot be merged until informatics-isi-edu/ermrestjs#321 has been merged because it needs the new `reference.table.reference...` feature in ermrestjs.