### PR TITLE
Improve 412 error message

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -52,6 +52,9 @@
 
             if (exception instanceof ERMrest.UnauthorizedError || exception.code == errorNames.unauthorized) {
                 Session.login($window.location.href);
+            } else if (exception instanceof ERMrest.PreconditionFailedError) {
+                // A more useful message for 412 Precondition Failed
+                AlertsService.addAlert({type: 'warning', message: 'This page is out of sync with the server. Please refresh the page and try again.'});
             } else {
                 AlertsService.addAlert({type:'error', message:exception.message});
             }

--- a/common/templates/alerts.html
+++ b/common/templates/alerts.html
@@ -1,5 +1,5 @@
 <div ng-repeat="alert in alerts" class="row">
-    <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success'}" role="alert">
+    <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
         <button type="button" class="close" ng-click="closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>{{alert.type | toTitleCase}}</strong> {{alert.message}}
     </div>

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -57,7 +57,7 @@
                 var unfilteredRefAppLink = $rootScope.reference.table.reference.contextualize.compact.appLink;
                 $window.location.href = unfilteredRefAppLink;
             }, function deleteFail(error) {
-                AlertsService.addAlert({type: 'error', message: error.message});
+                ErrorService.catchAll(error);
                 $log.warn(error);
             });
         };


### PR DESCRIPTION
This PR partially addresses #846. The corresponding https://github.com/informatics-isi-edu/ermrestjs/pull/327url) must be merged before this PR.

It adds a 412 Precondition Failed error class so that if ermrestjs is unable to handle a 412 error successfully, the 412 error will still be passed to Chaise but Chaise will display with a more user-friendly error message that tells the user to refresh the page.
