### PR TITLE
Recordedit float and integer

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -176,12 +176,12 @@
                                         case "int2":
                                         case "int4":
                                         case "int8":
-                                            value = (values[i] ? parseInt(values[i], 10) : '');
+                                            value = (values[i] ? parseInt(values[i], 10) : null);
                                             break;
                                         case "float4":
                                         case "float8":
                                         case "numeric":
-                                            value = (values[i] ? parseFloat(values[i]) : '');
+                                            value = (values[i] ? parseFloat(values[i]) : null);
                                             break;
                                         default:
                                             value = values[i];

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -176,12 +176,14 @@
                                         case "int2":
                                         case "int4":
                                         case "int8":
-                                            value = (values[i] ? parseInt(values[i], 10) : null);
+                                            var intVal = parseInt(values[i], 10);
+                                            value = (!isNaN(intVal) ? intVal : null);
                                             break;
                                         case "float4":
                                         case "float8":
                                         case "numeric":
-                                            value = (values[i] ? parseFloat(values[i]) : null);
+                                            var floatVal = parseFloat(values[i]);
+                                            value = (!isNaN(floatVal) ? floatVal : null);
                                             break;
                                         default:
                                             value = values[i];


### PR DESCRIPTION
`Recordedit` was incorrectly setting integer and float values when they were null upon fetching the record. They should have been setting null if the value was not defined yet.

This resolves issue #954.