### PR TITLE
Add link in related tables is based on association reference as necessary

### DIFF
--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -146,7 +146,7 @@
             addRecordRequests[referrer_id] = ref.uri;
 
             // 3. Get appLink, append ?prefill=[COOKIE_NAME]&referrer=[referrer_id]
-            var appLink = ref.contextualize.entryCreate.appLink;
+            var appLink = (ref.derivedAssociationReference ? ref.derivedAssociationReference.contextualize.entryCreate.appLink : ref.contextualize.entryCreate.appLink);
             appLink = appLink + (appLink.indexOf("?") === -1? "?" : "&") +
                 'prefill=' + UriUtils.fixedEncodeURIComponent(COOKIE_NAME) +
                 '&invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);


### PR DESCRIPTION
This PR addresses issue #958. This PR requires that [this PR](https://github.com/informatics-isi-edu/ermrestjs/pull/330) be merged first. The changes in the corresponding PR in ermrestJS  expose the functionality that this PR is implementing.

This can be tested [here](https://cirm-dev.isrd.isi.edu/~jchudy/chaise/record/#1/Microscopy:Specimen/ID=20160920-mKDCrlf1IRES21d-GA-0). Clicking the `Add` link for `Genes` should bring you to an association table. Clicking the `Add` link for `Slide` should bring you to a related table without an association.