### PR TITLE
Changed ellipsis implementation to use onload instead of polling

### DIFF
--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -19,13 +19,14 @@
                     fromTuple: "=?"
                 },
                 link: function (scope, element) {
-                    scope.overflow = []; // for each cell in the row
-
-                    scope.hideContent = false;
-                    scope.linkText = "more";
-                    scope.maxHeightStyle = { };
 
                     var init = function() {
+
+                        scope.overflow = []; // for each cell in the row
+                        scope.hideContent = false;
+                        scope.linkText = "more";
+                        scope.maxHeightStyle = { };
+
 
                         var editLink = null;
 
@@ -223,16 +224,22 @@
                             }
                         };
 
-                        // Watch for change in rowValues, this is useful in case of pagination
-                        // As Angular just changes the content and doesnot destroys elements
-                        scope.$watchCollection('rowValues', function (v) {
-                            init();
+                    }
+
+
+                    // Watch for change in rowValues, this is useful in case of pagination
+                    // As Angular just changes the content and doesnot destroys elements
+                    scope.$watchCollection('rowValues', function (v) {
+                        init();
+
+                        // add timeout only if maxRecordsetRowHeight is not false in chaiseConfig
+                        if (chaiseConfig.maxRecordsetRowHeight != false ) {
                             $timeout(function() {
                                 containsOverflow = false;
                                 resizeRow();
-                            }, 10);
-                        });
-                    }
+                            }, 0);
+                        }
+                    });
                 }
             };
         }])

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -25,7 +25,7 @@
         </div>
         <div ng-if="overflow[$index+1]" style="display:inline;">
             ...
-            <span style="display:inline-block; text-decoration: underline" class="text-primary readmore" ng-click="readmore($index+1)">{{linkText}}</span>
+            <span style="display:inline-block; text-decoration: underline;cursor: pointer;" class="text-primary readmore" ng-click="readmore($index+1)">{{linkText}}</span>
         </div>
     </div>
 </td>

--- a/common/utils.js
+++ b/common/utils.js
@@ -577,8 +577,40 @@
             });
         }
 
+        /**
+         * Gets all tags with only a src attribute
+         * @param element Any element from where to start the function.
+         * @returns {Array} An array of Matching element
+         */
+        function getElements(tag, element) {
+            if (!element) throw new Error("No element passed for getImageAndIframes");
+            var tags = element.querySelectorAll(tag + '[src]');//Get all tags with src attributes
+            var matches = [];
+            for (var i = 0, j = tags.length; i < j; i++) {
+                var attributes = tags[i].attributes;
+
+                if (attributes[0].name === 'src') {//if the attribute is a src attribute, add it to the matches
+                    matches.push(tags[i]);
+                }
+            }
+
+            return matches; //Matches will now just contain tags with only src attribute
+        }
+
+        /**
+         * Gets all images and iframe with only a src attribute
+         * @param element Any element from where to start the function.
+         * @returns {Array} An array of images and iframes
+         */
+        function getImageAndIframes(element) {
+            var images = getElements('img', element);
+            var iframes = getElements('iframe', element);
+            return images.concat(iframes);
+        }
+
         return {
-            setBootstrapDropdownButtonBehavior: setBootstrapDropdownButtonBehavior
+            setBootstrapDropdownButtonBehavior: setBootstrapDropdownButtonBehavior,
+            getImageAndIframes: getImageAndIframes
         }
     }])
 


### PR DESCRIPTION
This **PR** handles the issue with performance related to the more/less behavior.

Initially it used to do polling to check for height changes for dynamic HTML elements like `image` and `iframe`. This used to take a lot of processing power.

Now, the code explicitly attaches `onload` event handlers onto these elements. This handler is called once the image and iframe is loaded and updates the height to add/removes the ellipsis.

You can test it on GPCR for recordedit . 
https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/experiments:experiment

**Image:** 
https://synapse-dev.isrd.isi.edu/~chirag/chaise/recordset/#1/Zebrafish:Behavior@sort(Image%20Date::desc::)

**Iframe**
https://synapse-dev.isrd.isi.edu/~chirag/chaise/recordset/#1/Zebrafish:Cropped%20Image@sort(Extract%20Date::desc::,ID)?limit=10