### PR TITLE
Added separate method in chaise.page.js to performlogin

### DIFF
--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -873,6 +873,25 @@ function chaisePage() {
     this.waitForElementCondition = function(condition, timeout) {
         return browser.wait(condition, timeout || browser.params.defaultTimeout);
     };
+
+    this.performLogin = function(cookie, defer) {
+
+        defer = defer || require('q').defer();
+
+        browser.get(process.env.CHAISE_BASE_URL + "/login/");
+        browser.ignoreSynchronization = true;
+          
+        browser.wait(protractor.ExpectedConditions.visibilityOf(element(by.id("loginApp"))), browser.params.defaultTimeout).then(function() {
+            browser.driver.executeScript('document.cookie="' + cookie + ';path=/;' + (process.env.TRAVIS ? '"' : 'secure;"')).then(function() {
+              browser.ignoreSynchronization = false;
+              defer.resolve();
+            });
+        }, function() {
+            defer.reject();
+        });
+
+        return defer;
+    };
 };
 
 module.exports = new chaisePage();

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -54,19 +54,7 @@ exports.parameterize = function(config, configParams) {
 
         // Visit the default page and set the authorization cookie if required
         if (testConfiguration.authCookie) {
-          browser.get(process.env.CHAISE_BASE_URL + "/login/");
-          browser.ignoreSynchronization = true;
-          
-          browser.wait(protractor.ExpectedConditions.visibilityOf(element(by.id("loginApp"))), browser.params.defaultTimeout).then(function() {
-            browser.driver.executeScript('document.cookie="' + testConfiguration.authCookie + ';path=/;' + (process.env.TRAVIS ? '"' : 'secure;"')).then(function() {
-              browser.ignoreSynchronization = false;
-              defer.resolve();
-            });
-          
-          }, function() {
-            defer.reject();
-          });
-
+          require('./chaise.page.js').performLogin(testConfiguration.authCookie, defer);
         } else {
           defer.resolve();
         }
@@ -98,19 +86,7 @@ exports.parameterize = function(config, configParams) {
         // Visit the default page and set the authorization cookie if required
         if (testConfiguration.authCookie) {
           console.log("setting up cookie");
-          browser.get(process.env.CHAISE_BASE_URL + "/login/");
-          browser.ignoreSynchronization = true;
-          
-          browser.wait(protractor.ExpectedConditions.visibilityOf(element(by.id("loginApp"))),browser.params.defaultTimeout).then(function() {
-            browser.driver.executeScript('document.cookie="' + testConfiguration.authCookie + ';path=/;' + (process.env.TRAVIS ? '"' : 'secure;"')).then(function() {
-              browser.ignoreSynchronization = false;
-              defer.resolve();
-            });
-          
-            
-          }, function() {
-            defer.reject();
-          });
+          require('./chaise.page.js').performLogin(testConfiguration.authCookie, defer);
         } else {
           defer.resolve();
         }


### PR DESCRIPTION
This PR adds a separate method `performLogin` to `chaise.page.js` that performs login on behalf of a user when passed a cookie.

Documentation can be found [here](https://github.com/informatics-isi-edu/chaise/wiki/E2E-tests-guide#setting-webauthn-cookies-in-test-cases)