### PR TITLE
Recordset search cleanup

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -519,3 +519,8 @@ input.search-progress {
     background-size: 25px 25px;
     background-position-x: 99%;
 }
+
+/************* search input ****************/
+.form-control-feedback > span.search-remove {
+    border-bottom: none;
+}

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -1,7 +1,7 @@
 <div ng-show="vm.initialized" class="row" style="margin-bottom: 10px;">
     <div class="col-lg-4 col-md-5 col-sm-6 col-xs-7">
         <!-- search box -->
-        <div class="input-group">
+        <div class="input-group has-feedback">
             <input type="text"
                    id="search-input"
                    ng-model="vm.search"
@@ -12,16 +12,15 @@
                    placeholder="Search"
                    autofocus
                    ng-disabled="!vm.hasLoaded && !vm.backgroundSearch">
-                <span class="input-group-btn">
-                    <button id="search-submit" class="btn btn-primary" ng-click="enterPressed(vm.search)" role="button" ng-disabled="!vm.hasLoaded && !vm.backgroundSearch">
-                        &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
-                    </button>
-                    <button type="button" tabIndex="-1" class="btn btn-primary btn-no-focus" tooltip-placement="bottom"
+            <div class="form-control-feedback coltooltip" ng-show="vm.reference.location.searchTerm || (vm.hasLoaded && vm.backgroundSearch)" ng-style="{'cursor': 'pointer', 'right': '50px', 'pointer-events': 'all', 'z-index': '5'}"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
+                <span class="glyphicon glyphicon-remove coltooltiptext search-remove" ng-click="::clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+            </div>
+            <span class="input-group-btn">
+                <button id="search-submit" class="btn btn-primary" ng-click="enterPressed(vm.search)" role="button" ng-disabled="!vm.hasLoaded && !vm.backgroundSearch" tooltip-placement="bottom"
                     uib-tooltip-html="'<p>Use space to separate between conjunctive terms, | (no spaces) to separate disjunctive terms and quotations for exact phrases.</p><p>For example, <i><b>usc 1234</b></i> returns all records containing &ldquo;usc&rdquo; and &ldquo;1234&rdquo;.</p><p><i><b>usc|1234</b></i> returns all records containing &ldquo;usc&rdquo; or &ldquo;1234&rdquo;.</b></i></p><p><i><b>&ldquo;usc 1234&rdquo;</b></i> returns all records containing &ldquo;usc 1234&rdquo;.</p>'">
-                        <span class="glyphicon glyphicon-question-sign"></span>
-                    </button>
-                    <button id="search-clear" class="btn btn-primary" ng-disabled="!vm.reference.location.searchTerm || (!vm.hasLoaded && !vm.backgroundSearch)" ng-click="clearSearch()" type="button">Reset</button>
-                </span>
+                    &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
+                </button>
+            </span>
         </div>
     </div>
     <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1">

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -13,7 +13,7 @@
                    autofocus
                    ng-disabled="!vm.hasLoaded && !vm.backgroundSearch">
             <div class="form-control-feedback coltooltip" ng-show="vm.reference.location.searchTerm || (vm.hasLoaded && vm.backgroundSearch)" ng-style="{'cursor': 'pointer', 'right': '50px', 'pointer-events': 'all', 'z-index': '5'}"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
-                <span class="glyphicon glyphicon-remove coltooltiptext search-remove" ng-click="::clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+                <span id="search-clear" class="glyphicon glyphicon-remove coltooltiptext search-remove" ng-click="::clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
             </div>
             <span class="input-group-btn">
                 <button id="search-submit" class="btn btn-primary" ng-click="enterPressed(vm.search)" role="button" ng-disabled="!vm.hasLoaded && !vm.backgroundSearch" tooltip-placement="bottom"

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -12,7 +12,7 @@
                    placeholder="Search"
                    autofocus
                    ng-disabled="!vm.hasLoaded && !vm.backgroundSearch">
-            <div class="form-control-feedback coltooltip" ng-show="vm.reference.location.searchTerm || (vm.hasLoaded && vm.backgroundSearch)" ng-style="{'cursor': 'pointer', 'right': '50px', 'pointer-events': 'all', 'z-index': '5'}"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
+            <div class="form-control-feedback coltooltip" ng-hide="!vm.reference.location.searchTerm || !vm.hasLoaded || vm.backgroundSearch" ng-style="{'cursor': 'pointer', 'right': '50px', 'pointer-events': 'all', 'z-index': '5'}"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
                 <span id="search-clear" class="glyphicon glyphicon-remove coltooltiptext search-remove" ng-click="::clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
             </div>
             <span class="input-group-btn">


### PR DESCRIPTION
This PR addresses issues #907 and #991. 
 - The info button on recordset has been removed and the corresponding information from the tooltip is now present on the search button.
 - The reset button has been removed in favor of having an `X` inside of the search input box with the same behavior. 