### PR TITLE
Deep Copy tuples in Recordedit

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -197,7 +197,6 @@
 
             if (vm.editMode) {
                 // loop through model.submissionRows
-                // there should only be 1 row for editing but we want to account for it for future development
                 for (var i = 0; i < model.submissionRows.length; i++) {
                     var row = model.submissionRows[i];
                     var data = $rootScope.tuples[i].data;

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -169,7 +169,10 @@
 
                             var column, value;
 
-                            $rootScope.tuples = page.tuples;
+                            // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
+                            // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
+                            // The submission data is copied back to the tuples object before submitted in the PUT request
+                            $rootScope.tuples = angular.copy(page.tuples);
                             $rootScope.displayname = ((context.queryParams.copy && page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
 
                             for (var j = 0; j < page.tuples.length; j++) {


### PR DESCRIPTION
The tuples that are returned with the Page object from `Reference.read` in `recordedit` are copied and then attached to $rootScope for mutation. This prevents us from mutating Objects directly for submission purposes.

This PR resolves issue #994.