### PR TITLE
Standalone authn API

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -15,11 +15,12 @@
 
         NotFoundError.prototype.constructor = NotFoundError;
 
+        // authn API no longer communicates through ermrest, removing the need to check for ermrest location
+        var serviceURL = $window.location.origin;
+
         return {
 
             getSession: function() {
-                var serviceURL = (chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : $window.location.origin + "/ermrest");
-
                 return $http.get(serviceURL + "/authn/session").then(function(response) {
                     return response.data;
                 }, function(response) {
@@ -29,7 +30,6 @@
             },
 
             login: function (referrer) {
-                var serviceURL = (chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : $window.location.origin + "/ermrest");
                 var url = serviceURL + '/authn/preauth?referrer=' + UriUtils.fixedEncodeURIComponent(referrer);
                 var config = {
                     headers: {
@@ -69,7 +69,6 @@
             },
 
             loginInANewWindow: function(cb) {
-                var serviceURL = (chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : $window.location.origin + "/ermrest");
                 var referrerId = (new Date().getTime());
                 var url = serviceURL + '/authn/preauth?referrer=' + UriUtils.fixedEncodeURIComponent(window.location.href.substring(0,window.location.href.indexOf('chaise')) + "chaise/login?referrerid=" + referrerId);
                 var config = {
@@ -118,7 +117,6 @@
             },
 
             logout: function() {
-                var serviceURL = (chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : $window.location.origin + "/ermrest");
                 var logoutURL = chaiseConfig['logoutURL'];
                 var url = serviceURL + "/authn/session";
                 if (logoutURL !== undefined) {


### PR DESCRIPTION
`Chaise` has been changed to use the standalone authn API. This change was made to the `authen` service that is used by all of the `chaise` apps except for viewer. When viewer is refactored to use the `Reference` API, this change will be reflected there as well.

I tested each login flow manually where the authn API endpoint is hit. This includes:
- when there is an existing session (fetching an existing session based on cookie storage)
- when the user comes to the app without a valid pre-existing session (clicking login) 
- when the user has their session expire while updating or creating (login popup window)
- when the user logs out of the application (clicking logout)

This PR resolves issue #298.