### PR TITLE
Record shows an appropriate message when no tuple is found

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -10,7 +10,7 @@
     })
 
     // Factory for each error type
-    .factory('ErrorService', ['AlertsService', 'errorNames', 'Session', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, errorNames, Session, $log, $rootScope, $uibModal, $window) {
+    .factory('ErrorService', ['AlertsService', 'errorNames', 'Session', 'textStrings', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, errorNames, Session, textStrings, $log, $rootScope, $uibModal, $window) {
 
         function errorPopup(message, errorCode, pageName, redirectLink) {
             var providedLink = true;
@@ -46,6 +46,20 @@
             });
         }
 
+        function noRecordError(filters) {
+            var noDataMessage = textStrings.noDataMessage;
+            for (var k = 0; k < filters.length; k++) {
+                noDataMessage += filters[k].column + filters[k].operator + filters[k].value;
+                if (k != filters.length-1) {
+                    noDataMessage += " or ";
+                }
+            }
+            var error = new Error(noDataMessage);
+            error.code = errorNames.notFound;
+
+            return error;
+        }
+
         // TODO: implement hierarchies of exceptions in ermrestJS and use that hierarchy to conditionally check for certain exceptions
         function catchAll(exception) {
             $log.info(exception);
@@ -59,7 +73,8 @@
 
         return {
             errorPopup: errorPopup,
-            catchAll: catchAll
+            catchAll: catchAll,
+            noRecordError: noRecordError
         };
     }]);
 })();

--- a/common/errors.js
+++ b/common/errors.js
@@ -10,7 +10,7 @@
     })
 
     // Factory for each error type
-    .factory('ErrorService', ['AlertsService', 'errorNames', 'Session', 'textStrings', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, errorNames, Session, textStrings, $log, $rootScope, $uibModal, $window) {
+    .factory('ErrorService', ['AlertsService', 'errorNames', 'Session', 'messageMap', '$log', '$rootScope', '$uibModal', '$window', function ErrorService(AlertsService, errorNames, Session, messageMap, $log, $rootScope, $uibModal, $window) {
 
         function errorPopup(message, errorCode, pageName, redirectLink) {
             var providedLink = true;
@@ -47,7 +47,7 @@
         }
 
         function noRecordError(filters) {
-            var noDataMessage = textStrings.noDataMessage;
+            var noDataMessage = messageMap.noDataMessage;
             for (var k = 0; k < filters.length; k++) {
                 noDataMessage += filters[k].column + filters[k].operator + filters[k].value;
                 if (k != filters.length-1) {

--- a/common/utils.js
+++ b/common/utils.js
@@ -19,6 +19,13 @@
         "entry": "/recordedit"
     })
 
+    // this constant is used to keep track of our strings that the user is shown
+    // so that when one is changed, it is changed in all places.
+    // this will make localization easier if we go that route
+    .constant("textStrings", {
+        "noDataMessage": "No entity exists with "
+    })
+
     .factory('UriUtils', ['$injector', '$window', 'parsedFilter', '$rootScope', 'appTagMapping', 'appContextMapping', 'ContextUtils',
         function($injector, $window, ParsedFilter, $rootScope, appTagMapping, appContextMapping, ContextUtils) {
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -22,7 +22,7 @@
     // this constant is used to keep track of our strings that the user is shown
     // so that when one is changed, it is changed in all places.
     // this will make localization easier if we go that route
-    .constant("textStrings", {
+    .constant("messagesMap", {
         "noDataMessage": "No entity exists with "
     })
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -75,6 +75,13 @@
                 }, function error(exception) {
                     throw exception;
                 }).then(function getPage(page) {
+                    $log.info("Page: ", page);
+
+                    if (page.tuples.length < 1) {
+                        var noDataError = ErrorService.noRecordError(context.filter.filters);
+                        throw noDataError;
+                    }
+
                     var tuple = $rootScope.tuple = page.tuples[0];
                     // Used directly in the record-display directive
                     $rootScope.recordDisplayname = tuple.displayname;

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -34,8 +34,8 @@
         $uibTooltipProvider.options({appendToBody: true});
     }])
 
-    .run(['AlertsService', 'ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
-        function runRecordEditApp(AlertsService, ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
+    .run(['AlertsService', 'ERMrest', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
+        function runRecordEditApp(AlertsService, ERMrest, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
 
         var session,
             context = { booleanValues: ['', true, false] };
@@ -152,18 +152,7 @@
                             $log.info("Page: ", page);
 
                             if (page.tuples.length < 1) {
-
-                                var filters = context.filter.filters;
-                                var noDataMessage = "No entity exists with ";
-                                for (var k = 0; k < filters.length; k++) {
-                                    noDataMessage += filters[k].column + filters[k].operator + filters[k].value;
-                                    if (k != filters.length-1) {
-                                        noDataMessage += " or ";
-                                    }
-                                }
-                                var noDataError = new Error(noDataMessage);
-                                noDataError.code = errorNames.notFound;
-
+                                var noDataError = ErrorService.noRecordError(context.filter.filters);
                                 throw noDataError;
                             }
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -34,8 +34,8 @@
         $uibTooltipProvider.options({appendToBody: true});
     }])
 
-    .run(['AlertsService', 'ERMrest', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
-        function runRecordEditApp(AlertsService, ERMrest, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
+    .run(['AlertsService', 'ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
+        function runRecordEditApp(AlertsService, ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
 
         var session,
             context = { booleanValues: ['', true, false] };

--- a/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
+++ b/test/e2e/specs/record/data-dependent/00-record.presentation.spec.js
@@ -67,4 +67,17 @@ describe('View existing record,', function() {
             expect(title).toEqual(chaiseConfig.headTitle);
         });
     });
+
+    it("should load an error dialog when the entity defined in the filter doesn't exist.", function() {
+        var noEntityMessage = "No entity exists with",
+            tupleParams = testParams.tuples[0];
+        // entity with id=10,000 should not exist
+        var url = browser.params.url + ":" + tupleParams.table_name + "/id=10000";
+        browser.get(url);
+        chaisePage.waitForElement(element(by.css(".modal-open"))).then(function() {
+            return chaisePage.recordPage.getModalText().getText();
+        }).then(function(text) {
+            expect(text.includes(noEntityMessage)).toBeTruthy();
+        });
+    });
 });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -676,6 +676,10 @@ var recordPage = function() {
     this.getPermalinkButton = function() {
         return element(by.id('permalink'));
     };
+
+    this.getModalText = function() {
+        return element(by.css(".modal-body"));    
+    };
 };
 
 var recordsetPage = function() {
@@ -880,7 +884,7 @@ function chaisePage() {
 
         browser.get(process.env.CHAISE_BASE_URL + "/login/");
         browser.ignoreSynchronization = true;
-          
+
         browser.wait(protractor.ExpectedConditions.visibilityOf(element(by.id("loginApp"))), browser.params.defaultTimeout).then(function() {
             browser.driver.executeScript('document.cookie="' + cookie + ';path=/;' + (process.env.TRAVIS ? '"' : 'secure;"')).then(function() {
               browser.ignoreSynchronization = false;


### PR DESCRIPTION
This PR addresses issue #964. `Record` app will notify the user (with a useful error message) when their filter doesn't return a row. This had been previously implemented in `Recordedit`, so the logic was factored out into the `ErrorService` and reused in both places.

This PR also includes a `constant` defined in `utils.js` called `textStrings` (name open to discussion) that will be where all of our strings will be defined so that they exist in one place. Simply put, this makes it much easier to track down the wordage for messages we output. This will provide one place to make changes to that wordage rather than in many. This will also make `localization` easier in the future (if we decide to provide that as well).