### PR TITLE
No results doesn't flash before data loads

### DIFF
--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -49,7 +49,7 @@
 </div>
 
 <!-- record table -->
-<div>
+<div ng-if="vm.hasLoaded">
     <record-table id="rs-{{vm.makeSafeIdAttr(vm.tableDisplayName.value)}}" vm="vm" on-row-click-bind="onRowClick"></record-table>
 </div>
 


### PR DESCRIPTION
This PR addresses issue #1010. The table directive in `recordset` will no longer show `"No Results Found"` before the data has finished loading.