### PR TITLE
add visible columns for product schema in edit and create contexts

### DIFF
--- a/test/e2e/data_setup/schema/product.json
+++ b/test/e2e/data_setup/schema/product.json
@@ -338,6 +338,8 @@
         },
         "tag:isrd.isi.edu,2016:visible-columns" : {
           "detailed" : ["id", ["product", "fk_category"], "website", "rating", "summary", "description", ["product", "fk_thumbnail"], "opened_on", "luxurious"],
+          "entry/create": ["id", "title", "website", ["product", "fk_category"], "rating", "summary", "description", "no_of_rooms", ["product", "fk_thumbnail"], ["product", "fk_cover"], "opened_on","luxurious"],
+          "entry/edit": ["id", "title", "website", ["product", "fk_category"], "rating", "summary", "description", "no_of_rooms", ["product", "fk_thumbnail"], ["product", "fk_cover"], "opened_on","luxurious"],
           "compact" : ["title", "website", "rating", "summary", "opened_on", "luxurious"]
         },
 


### PR DESCRIPTION
In [ermerstjs#355](https://github.com/informatics-isi-edu/ermrestjs/pull/355), I updated visible columns heuristics. As I mentioned in #1009, some chaise test cases are applying logic and therefore these test cases are failing after the changes.

To work around this problem, I changed visible columns annotation for edit and create to be the same list of columns chaise test cases expect. With this change, chaise test suits pass locally with my ermrestjs PR.