### PR TITLE
Added overflow:hidden to the table in recordedit.

### DIFF
--- a/recordedit/recordEdit.css
+++ b/recordedit/recordEdit.css
@@ -168,6 +168,7 @@ td.entity-value {
 }
 
 #formEdit > table {
+  overflow: hidden;
   margin-bottom: 0px;
 }
 


### PR DESCRIPTION
This PR fixes the issue mentioned in this comment https://github.com/informatics-isi-edu/chaise/issues/921#issuecomment-284510136.

Recordedit page shows horizontal scrollbar even with very wide windows.

This was caused because of removing the `overflow:hidden` css from the table.

https://dev.isrd.isi.edu/~chirag/chaise/recordedit/#18988/product:accommodation