### PR TITLE
Makefile wasn't checksumming ermrestjs properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,9 @@ HTML=search/index.html \
 	 record/index.html
 
 # ERMrestjs Deps
-ERMRESTJS_DIR=../../ermrestjs
-ERMRESTJS_DEPS=$(ERMRESTJS_DIR)/ermrest.js
+ERMRESTJS_RT_DIR=../../ermrestjs
+ERMRESTJS_BLD_DIR=../ermrestjs/build
+ERMRESTJS_DEPS=ermrest.js
 
 # Shared utilities
 COMMON=common
@@ -627,8 +628,10 @@ $(JS_CONFIG): chaise-config-sample.js
 		echo "<script src='../$$file?v=$$checksum'></script>" >> .make-viewer-asset-block ; \
 	done
 	for script in $(ERMRESTJS_DEPS); do \
-		checksum=$$($(MD5) $$script | awk '{ print $$1 }') ; \
-		echo "<script src='$$script?v=$$checksum'></script>" >> .make-viewer-asset-block ; \
+		buildpath=$(ERMRESTJS_BLD_DIR)/$$script ; \
+		runtimepath=$(ERMRESTJS_RT_DIR)/$$script ; \
+		checksum=$$($(MD5) $$buildpath | awk '{ print $$1 }') ; \
+		echo "<script src='$$runtimepath?v=$$checksum'></script>" >> .make-viewer-asset-block ; \
 	done
 	for file in $(VIEWER_JS_SOURCE); do \
 		checksum=$$($(MD5) $$file | awk '{ print $$1 }') ; \
@@ -650,8 +653,10 @@ $(JS_CONFIG): chaise-config-sample.js
 		echo "<script src='../$$file?v=$$checksum'></script>" >> .make-de-asset-block ; \
 	done
 	for script in $(ERMRESTJS_DEPS); do \
-		checksum=$$($(MD5) $$script | awk '{ print $$1 }') ; \
-		echo "<script src='$$script?v=$$checksum'></script>" >> .make-de-asset-block ; \
+		buildpath=$(ERMRESTJS_BLD_DIR)/$$script ; \
+		runtimepath=$(ERMRESTJS_RT_DIR)/$$script ; \
+		checksum=$$($(MD5) $$buildpath | awk '{ print $$1 }') ; \
+		echo "<script src='$$runtimepath?v=$$checksum'></script>" >> .make-de-asset-block ; \
 	done
 	for file in $(RE_JS_SOURCE); do \
 		checksum=$$($(MD5) $$file | awk '{ print $$1 }') ; \
@@ -673,8 +678,10 @@ $(JS_CONFIG): chaise-config-sample.js
 		echo "<script src='../$$file?v=$$checksum'></script>" >> .make-rs-asset-block ; \
 	done
 	for script in $(ERMRESTJS_DEPS); do \
-		checksum=$$($(MD5) $$script | awk '{ print $$1 }') ; \
-		echo "<script src='$$script?v=$$checksum'></script>" >> .make-rs-asset-block ; \
+		buildpath=$(ERMRESTJS_BLD_DIR)/$$script ; \
+		runtimepath=$(ERMRESTJS_RT_DIR)/$$script ; \
+		checksum=$$($(MD5) $$buildpath | awk '{ print $$1 }') ; \
+		echo "<script src='$$runtimepath?v=$$checksum'></script>" >> .make-rs-asset-block ; \
 	done
 	for file in $(RECSET_JS_SOURCE); do \
 		checksum=$$($(MD5) $$file | awk '{ print $$1 }') ; \
@@ -696,8 +703,10 @@ $(JS_CONFIG): chaise-config-sample.js
 		echo "<script src='../$$file?v=$$checksum'></script>" >> .make-record-asset-block ; \
 	done
 	for script in $(ERMRESTJS_DEPS); do \
-		checksum=$$($(MD5) $$script | awk '{ print $$1 }') ; \
-		echo "<script src='$$script?v=$$checksum'></script>" >> .make-record-asset-block ; \
+		buildpath=$(ERMRESTJS_BLD_DIR)/$$script ; \
+		runtimepath=$(ERMRESTJS_RT_DIR)/$$script ; \
+		checksum=$$($(MD5) $$buildpath | awk '{ print $$1 }') ; \
+		echo "<script src='$$runtimepath?v=$$checksum'></script>" >> .make-record-asset-block ; \
 	done
 	for file in $(RECORD_JS_SOURCE); do \
 		checksum=$$($(MD5) $$file | awk '{ print $$1 }') ; \


### PR DESCRIPTION
This PR addresses issue #986. The makefile now has a separate path for the `ermrestJS` build directory and the runtime directory. This is so that `chaise` can properly choose when to use the cached version of `ermrestJS`.



NOTE:
For my own local development on the dev servers, I have been using the following command to make `chaise` properly:
`make ERMRESTJS_DIR=../../ermrestjs/build all`

This changed the value of the `ERMRESTJS_DIR` variable for the make tasks to properly reflect my folder structure on the dev servers. I now use `make ERMRESTJS_RT_DIR=../../ermrestjs/build all`.