### PR TITLE
Fix disabled inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,6 +482,7 @@ testrecordadd:
 testrecordset:
 	$(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDrecordsetEdit)
 
+
 # Rule to run record edit app tests
 .PHONY: testrecordedit
 testrecordedit:

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -117,6 +117,13 @@
              */
             for (var i = 0; i < $rootScope.reference.columns.length; i++) {
                 var col = $rootScope.reference.columns[i];
+
+                // If this column is disabled, its value is already in the format
+                // needed for submission.
+                if (col.getInputDisabled(context.appContext)) {
+                    continue;
+                }
+
                 var rowVal = row[col.name];
                 if (rowVal) {
                     switch (col.type.name) {
@@ -160,7 +167,6 @@
             vm.readyToSubmit = true;
             vm.submissionButtonDisabled = true;
             for (var j = 0; j < model.rows.length; j++) {
-                var transformedRow = transformRowValues(model.rows[j]);
                 $rootScope.reference.columns.forEach(function (column) {
                     // If the column is a pseudo column, it needs to get the originating columns name for data submission
                     if (column.isPseudo) {
@@ -188,6 +194,7 @@
                         }
                     // not pseudo, column.name is sufficient for the keys
                     } else {
+                        var transformedRow = transformRowValues(model.rows[j]);
                         // set null if not set so that the whole data object is filled out for posting to ermrestJS
                         model.submissionRows[j][column.name] = (transformedRow[column.name] === undefined) ? null : transformedRow[column.name];
                     }
@@ -207,7 +214,6 @@
                 // submit $rootScope.tuples because we are changing and comparing data from the old data set for the tuple with the updated data set from the UI
                 $rootScope.reference.update($rootScope.tuples).then(function success(page) {
                     if (window.opener && window.opener.updated) {
-                        console.dir('I ran here and here is my opener:', window.opener);
                         window.opener.updated(context.queryParams.invalidate);
                     }
                     vm.readyToSubmit = false; // form data has already been submitted to ERMrest

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -167,6 +167,7 @@
             vm.readyToSubmit = true;
             vm.submissionButtonDisabled = true;
             for (var j = 0; j < model.rows.length; j++) {
+                var transformedRow = transformRowValues(model.rows[j]);
                 $rootScope.reference.columns.forEach(function (column) {
                     // If the column is a pseudo column, it needs to get the originating columns name for data submission
                     if (column.isPseudo) {
@@ -194,7 +195,6 @@
                         }
                     // not pseudo, column.name is sufficient for the keys
                     } else {
-                        var transformedRow = transformRowValues(model.rows[j]);
                         // set null if not set so that the whole data object is filled out for posting to ermrestJS
                         model.submissionRows[j][column.name] = (transformedRow[column.name] === undefined) ? null : transformedRow[column.name];
                     }

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -108,7 +108,7 @@
                                             <!-- date input-->
                                             <div ng-switch-when="date">
                                                 <div ng-show="form.isDisabled(column);" >
-                                                    <input type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}"
+                                                    <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}"
                                                     placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">
                                                 </div>
                                                 <div ng-show="!form.isDisabled(column);" class="input-group">
@@ -122,8 +122,8 @@
                                             </div>
                                             <!-- timestamp[tz] input -->
                                             <div ng-switch-when="timestamp">
-                                                <input type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{column.name}}"
-                                                ng-show="form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" />
+                                                <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{column.name}}"
+                                                ng-show="form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">
                                                 <div class="row" ng-show="::!form.isDisabled(column);">
                                                     <div class="col-xs-12">
                                                         <div class="input-group">

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -176,12 +176,20 @@
                                 for (var i = 0; i < $rootScope.reference.columns.length; i++) {
                                     column = $rootScope.reference.columns[i];
 
+                                    // If input is disabled, a disabled text input field is
+                                    // used in the UI. As of writing, ermrestjs
+                                    // formats column values as strings so there's
+                                    // no need to transform the column value.
+                                    if (column.getInputDisabled(context.appContext)) {
+                                        recordEditModel.rows[j][column.name] = values[i];
+                                        continue;
+                                    }
+
+                                    // Transform column values for use in view model
                                     switch (column.type.name) {
                                         case "timestamp":
                                         case "timestamptz":
                                             if (values[i]) {
-                                                // Cannot ensure that all timestamp values are formatted in ISO 8601
-                                                // TODO: Fix pretty print fn in ermrestjs to return ISO 8601 format instead of toLocaleString?
                                                 var ts = moment(values[i]);
                                                 value = {
                                                     date: ts.format('YYYY-MM-DD'),

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -176,9 +176,7 @@
                                 for (var i = 0; i < $rootScope.reference.columns.length; i++) {
                                     column = $rootScope.reference.columns[i];
 
-                                    // If input is disabled, a disabled text input field is
-                                    // used in the UI. As of writing, ermrestjs
-                                    // formats column values as strings so there's
+                                    // If input is disabled, there's
                                     // no need to transform the column value.
                                     if (column.getInputDisabled(context.appContext)) {
                                         recordEditModel.rows[j][column.name] = values[i];

--- a/test/e2e/data_setup/config/recordedit-multi-column-types.dev.json
+++ b/test/e2e/data_setup/config/recordedit-multi-column-types.dev.json
@@ -25,38 +25,60 @@
     "cleanup": true,
     "tests": {
         "params": {
-            "tableName": "table_1",
-            "key": {"columnName": "id", "value": 1, "operator": "="},
-            "row": [
-                {"name": "id", "value": 1, "displayType": "serial4"},
-                {"name": "int2_null_col", "value": null, "displayType": "int2"},
-                {"name": "int2_col", "value": 32767, "displayType": "int2"},
-                {"name": "int4_null_col", "value": null, "displayType": "int4"},
-                {"name": "int4_col", "value": -2147483648, "displayType": "int4"},
-                {"name": "int8_null_col", "value": null, "displayType": "int8"},
-                {"name": "int8_col", "value": 9007199254740991, "displayType": "int8"},
-                {"name": "float4_null_col", "value": null, "displayType": "float4"},
-                {"name": "float4_col", "value": 4.6123, "displayType": "float4"},
-                {"name": "float8_null_col", "value": null, "displayType": "float8"},
-                {"name": "float8_col", "value": 234523523.023045, "displayType": "float8"},
-                {"name": "text_null_col", "value": null, "displayType": "text"},
-                {"name": "text_col", "value": "sample", "displayType": "text"},
-                {"name": "longtext_null_col", "value": null, "displayType": "longtext"},
-                {"name": "longtext_col", "value": "asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja", "displayType": "longtext"},
-                {"name": "markdown_null_col", "value": null, "displayType": "markdown"},
-                {"name": "markdown_col", "value": "<strong>Sample</strong>", "displayType": "markdown"},
-                {"name": "bool_null_col", "value": null, "displayType": "boolean"},
-                {"name": "bool_true_col", "value": true, "displayType": "boolean"},
-                {"name": "bool_false_col", "value": false, "displayType": "boolean"},
-                {"name": "timestamp_null_col", "value": null, "displayType": "timestamp"},
-                {"name": "timestamp_col", "value": "2016-01-18T13:00:00", "displayType": "timestamp"},
-                {"name": "timestamptz_null_col", "value": null, "displayType": "timestamptz"},
-                {"name": "timestamptz_col", "value": "2016-01-18T00:00:00-08:00", "displayType": "timestamptz"},
-                {"name": "date_null_col", "value": null, "displayType": "date"},
-                {"name": "date_col", "value": "2016-08-15", "displayType": "date"},
-                {"name": "fk_null_col", "value": null, "displayType": "popup-select"},
-                {"name": "fk_col", "value": "1", "displayType": "popup-select"}
-            ]
+            "table_1": {
+                "tableName": "table_1",
+                "key": {"columnName": "id", "value": 1, "operator": "="},
+                "row": [
+                    {"name": "id", "value": 1, "displayType": "disabled"},
+                    {"name": "int2_null_col", "value": null, "displayType": "int2"},
+                    {"name": "int2_col", "value": 32767, "displayType": "int2"},
+                    {"name": "int4_null_col", "value": null, "displayType": "int4"},
+                    {"name": "int4_col", "value": -2147483648, "displayType": "int4"},
+                    {"name": "int8_null_col", "value": null, "displayType": "int8"},
+                    {"name": "int8_col", "value": 9007199254740991, "displayType": "int8"},
+                    {"name": "float4_null_col", "value": null, "displayType": "float4"},
+                    {"name": "float4_col", "value": 4.6123, "displayType": "float4"},
+                    {"name": "float8_null_col", "value": null, "displayType": "float8"},
+                    {"name": "float8_col", "value": 234523523.023045, "displayType": "float8"},
+                    {"name": "text_null_col", "value": null, "displayType": "text"},
+                    {"name": "text_col", "value": "sample", "displayType": "text"},
+                    {"name": "longtext_null_col", "value": null, "displayType": "longtext"},
+                    {"name": "longtext_col", "value": "asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja", "displayType": "longtext"},
+                    {"name": "markdown_null_col", "value": null, "displayType": "markdown"},
+                    {"name": "markdown_col", "value": "<strong>Sample</strong>", "displayType": "markdown"},
+                    {"name": "bool_null_col", "value": null, "displayType": "boolean"},
+                    {"name": "bool_true_col", "value": true, "displayType": "boolean"},
+                    {"name": "bool_false_col", "value": false, "displayType": "boolean"},
+                    {"name": "timestamp_null_col", "value": null, "displayType": "timestamp"},
+                    {"name": "timestamp_col", "value": "2016-01-18T13:00:00", "displayType": "timestamp"},
+                    {"name": "timestamptz_null_col", "value": null, "displayType": "timestamptz"},
+                    {"name": "timestamptz_col", "value": "2016-01-18T00:00:00-08:00", "displayType": "timestamptz"},
+                    {"name": "date_null_col", "value": null, "displayType": "date"},
+                    {"name": "date_col", "value": "2016-08-15", "displayType": "date"},
+                    {"name": "fk_null_col", "value": null, "displayType": "popup-select"},
+                    {"name": "fk_col", "value": "1", "displayType": "popup-select"}
+                ]
+            },
+            "table_w_generated_columns" : {
+                "tableName": "table_w_generated_columns",
+                "key": {"columnName": "id", "value": 1, "operator": "="},
+                "row": [
+                    {"name": "int2_col_gen", "value": 32767, "displayType": "disabled"},
+                    {"name": "int4_col_gen", "value": -2147483648, "displayType": "disabled"},
+                    {"name": "int8_col_gen", "value": 9007199254740991, "displayType": "disabled"},
+                    {"name": "float4_col_gen", "value": 4.6123, "displayType": "disabled"},
+                    {"name": "float8_col_gen", "value": 234523523.023045, "displayType": "disabled"},
+                    {"name": "text_col_gen", "value": "sample", "displayType": "disabled"},
+                    {"name": "longtext_col_gen", "value": "asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja", "displayType": "disabled"},
+                    {"name": "markdown_col_gen", "value": "<strong>Sample</strong>", "displayType": "disabled"},
+                    {"name": "bool_true_col_gen", "value": true, "displayType": "disabled"},
+                    {"name": "bool_false_col_gen", "value": false, "displayType": "disabled"},
+                    {"name": "timestamp_col_gen", "value": "2016-01-18T13:00:00", "displayType": "disabled"},
+                    {"name": "timestamptz_col_gen", "value": "2016-01-18T00:00:00-08:00", "displayType": "disabled"},
+                    {"name": "date_col_gen", "value": "2016-08-15", "displayType": "disabled"},
+                    {"name": "fk_col_gen", "value": "1", "displayType": "disabled"}
+                ]
+            }
         }
     }
 }

--- a/test/e2e/data_setup/data/multi-column-types/table_2.json
+++ b/test/e2e/data_setup/data/multi-column-types/table_2.json
@@ -1,6 +1,6 @@
 [
     {
         "id": 1,
-        "term": "Jessie Wong"
+        "term": "Abraham Lincoln"
     }
 ]

--- a/test/e2e/data_setup/data/multi-column-types/table_w_generated_columns.json
+++ b/test/e2e/data_setup/data/multi-column-types/table_w_generated_columns.json
@@ -1,0 +1,19 @@
+[
+    {
+        "id": 1,
+        "int2_col_gen": 32767,
+        "int4_col_gen": -2147483648,
+        "int8_col_gen": 9007199254740991,
+        "float4_col_gen": 4.6123,
+        "float8_col_gen": 234523523.023045,
+        "text_col_gen": "sample",
+        "longtext_col_gen": "asjdf;laksjdf;laj ;lkajsd;f lkajsdf;lakjs f;lakjs df;lasjd f;ladsjf;alskdjfa ;lskdjf a;lsdkjf a;lskdfjal;sdkfj as;ldfkj as;dlf kjasl;fkaj;lfkjasl;fjas;ldfkjals;dfkjas;dlkfja;sldkfjasl;dkfjas;dlfkjasl;dfkja; lsdjfk a;lskdjf a;lsdfj as;ldfja;sldkfja;lskjdfa;lskdjfa;lsdkfja;sldkfjas;ldfkjas;dlfkjas;lfkja;sldkjf a;lsjf ;laskj fa;slk jfa;sld fjas;l js;lfkajs;lfkasjf;alsja;lk ;l kja",
+        "markdown_col_gen": "<strong>Sample</strong>",
+        "bool_true_col_gen": true,
+        "bool_false_col_gen": false,
+        "timestamp_col_gen": "2016-01-18T13:00:00",
+        "timestamptz_col_gen": "2016-01-18T00:00:00-08:00",
+        "date_col_gen": "2016-08-15",
+        "fk_col_gen": 1
+    }
+]

--- a/test/e2e/data_setup/schema/multi-column-types.json
+++ b/test/e2e/data_setup/schema/multi-column-types.json
@@ -1,6 +1,6 @@
 {
     "schema_name": "multi-column-types",
-    "comment": "A schema composed of 2 tables: a main table (table_1) that has nearly all types of columns for testing in RecordEdit app, and another table (table_2) that supplies a foreign key to this main table.",
+    "comment": "A schema composed of 3 tables: a main table (table_1) that has nearly all types of columns for testing in RecordEdit app, a 2nd table (table_w_generated_columns) that has generated versions of different column types, and another table (table_2) that supplies a foreign key to table_1.",
     "tables": {
         "table_1": {
             "table_name": "table_1",
@@ -326,6 +326,222 @@
                             "table_name": "table_1",
                             "schema_name": "multi-column-types",
                             "column_name": "fk_col"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "table_name": "table_2",
+                            "schema_name": "multi-column-types",
+                            "column_name": "id"
+                        }
+                    ],
+                    "annotations": {}
+                }
+            ],
+            "annotations": {}
+        },
+        "table_w_generated_columns": {
+            "table_name": "table_w_generated_columns",
+            "comment": "This is a table of generated columns. The reason these columns are separate from the larger table_1 table is because table_1 was getting too large. ermrestjs would construct /attributegroup/ PUT request urls that uses all of a table's visible columns. When that exceeds 32, postgres complains that the composite key is too large.",
+            "schema_name": "multi-column-types",
+            "kind": "table",
+            "column_definitions": [
+                {
+                    "comment": null,
+                    "name": "id",
+                    "default": null,
+                    "nullok": false,
+                    "type": {
+                        "typename": "int2"
+                    },
+                    "annotations": {}
+                },
+                {
+                    "comment": "An generated int2 column with an initial non-null value",
+                    "name": "int2_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "int2"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated int4 column with an initial non-null value",
+                    "name": "int4_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "int4"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated int8 column with an initial non-null value",
+                    "name": "int8_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "int8"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated float4 column with an initial non-null value",
+                    "name": "float4_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "float4"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated float8 column with an initial non-null value",
+                    "name": "float8_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "float8"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated text column with an initial non-null value",
+                    "name": "text_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated longtext column with an initial non-null value",
+                    "name": "longtext_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "longtext"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated markdown column with an initial non-null value",
+                    "name": "markdown_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "markdown"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated boolean column with an initial true value",
+                    "name": "bool_true_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "boolean"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated boolean column with an initial false value",
+                    "name": "bool_false_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "boolean"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated timestamp column with an initial non-null value",
+                    "name": "timestamp_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "timestamp"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated timestamptz column with an initial non-null value",
+                    "name": "timestamptz_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "timestamptz"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated date column with an initial non-null value",
+                    "name": "date_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "date"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                },
+                {
+                    "comment": "A generated foreign key column with an initial non-null value",
+                    "name": "fk_col_gen",
+                    "default": null,
+                    "nullok": true,
+                    "type": {
+                        "typename": "int2"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
+                }
+            ],
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [
+                {
+                    "comment": "Describes the fk relationship between table_w_generated_columns:fk_col_gen and table_2:id",
+                    "foreign_key_columns": [
+                        {
+                            "table_name": "table_w_generated_columns",
+                            "schema_name": "multi-column-types",
+                            "column_name": "fk_col_gen"
                         }
                     ],
                     "referenced_columns": [


### PR DESCRIPTION
This PR addresses #1016. 

When a timestamp/timestamptz column is disabled, RecordEdit uses a disabled text input in the form, which was incompatible with the object structure used to represent timestamp-related values in the form.

To fix this, we won't apply any transformations on disabled columns so that they are simply the value received from ermrestjs.