### PR TITLE
make the results more narrow

### DIFF
--- a/views/ermretrieveresults.html
+++ b/views/ermretrieveresults.html
@@ -203,8 +203,8 @@
                                 </div>
                             </div>
                             <div class="pull-right">
-                                <span class="btn btn-label">Download:</span>
-                                <ui-select ng-model="FacetsData.exportOptions.format" theme="select2" style="min-width: 250px; white-space: normal;" search-enabled="false" ng-disabled="disabled" on-select="facetResults.onExportFormatSelect($event)">
+                                <span class="btn-label">Download:</span>
+                                <ui-select ng-model="FacetsData.exportOptions.format" theme="select2" style="min-width: 80px; white-space: normal;" search-enabled="false" ng-disabled="disabled" on-select="facetResults.onExportFormatSelect($event)">
                                     <ui-select-match placeholder="CSV">{{FacetsData.exportOptions.format.name}}</ui-select-match>
                                     <ui-select-choices repeat="format in FacetsData.exportOptions.supportedFormats">{{format.name}}</ui-select-choices>
                                 </ui-select>


### PR DESCRIPTION
On my macbook pro (resolution 1280x00) the download ‘form’ in the results bar drops to a line below. This is a quick fix to make the selection field for the download format (CSV or JSON) narrower. If we add more formats with names longer than JSON, this might need to be reworked.