### PR TITLE
Copy not generated columns

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -177,9 +177,11 @@
                                     column = $rootScope.reference.columns[i];
 
                                     // If input is disabled, there's no need to transform the column value.
-                                    // if copy, don't populate the field
-                                    if (column.getInputDisabled(context.appContext) && !context.queryParams.copy) {
-                                        recordEditModel.rows[j][column.name] = values[i];
+                                    if (column.getInputDisabled(context.appContext)) {
+                                        // if not copy, populate the field without transforming it
+                                        if (context.mode != context.modes.COPY) {
+                                            recordEditModel.rows[j][column.name] = values[i];
+                                        }
                                         continue;
                                     }
 
@@ -219,11 +221,8 @@
                                             break;
                                     }
 
-                                    // line 181 checks for input disabled (generated) and not copy
-                                    // no need to check for copy here because that case above guards against the negative case for copy
-                                    if (!column.getInputDisabled(context.appContext)) {
-                                        recordEditModel.rows[j][column.name] = value;
-                                    }
+                                    // no need to check for copy here because the case above guards against the negative case for copy
+                                    recordEditModel.rows[j][column.name] = value;
                                 }
                             }
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -176,9 +176,9 @@
                                 for (var i = 0; i < $rootScope.reference.columns.length; i++) {
                                     column = $rootScope.reference.columns[i];
 
-                                    // If input is disabled, there's
-                                    // no need to transform the column value.
-                                    if (column.getInputDisabled(context.appContext)) {
+                                    // If input is disabled, there's no need to transform the column value.
+                                    // if copy, don't populate the field
+                                    if (column.getInputDisabled(context.appContext) && !context.queryParams.copy) {
                                         recordEditModel.rows[j][column.name] = values[i];
                                         continue;
                                     }
@@ -219,7 +219,9 @@
                                             break;
                                     }
 
-                                    if (!context.queryParams.copy || !column.getInputDisabled(context.appContext)) {
+                                    // line 181 checks for input disabled (generated) and not copy
+                                    // no need to check for copy here because that case above guards against the negative case for copy
+                                    if (!column.getInputDisabled(context.appContext)) {
                                         recordEditModel.rows[j][column.name] = value;
                                     }
                                 }

--- a/test/e2e/data_setup/data/editable-id/editable-id-table.json
+++ b/test/e2e/data_setup/data/editable-id/editable-id-table.json
@@ -1,1 +1,1 @@
-[{"id": 1, "text": "text", "int": 17}]
+[{"id": 1, "text": "text", "int": 17, "generated": 1}]

--- a/test/e2e/data_setup/schema/editable-id.json
+++ b/test/e2e/data_setup/schema/editable-id.json
@@ -43,11 +43,21 @@
                     "type": {
                         "typename": "int"
                     }
+                }, {
+                    "name": "generated",
+                    "nullok": true,
+                    "type": {
+                        "typename": "int"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null,
+                        "tag:isrd.isi.edu,2016:immutable": null
+                    }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["id", "text", "int"]
+                    "*": ["id", "text", "int", "generated"]
                 },
                 "tag:misd.isi.edu,2015:display" : {
                     "markdown_name": "**Editable Id Table**"

--- a/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
+++ b/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
@@ -97,6 +97,12 @@ describe('View existing record,', function() {
                 });
             });
 
+            it("should have 'Automatically Generated' in an input that is generated rather than copying the value from the copied record.", function() {
+                chaisePage.recordEditPage.getInputById(0, "generated").getAttribute("placeholder").then(function (text) {
+                    expect(text).toBe("Automatically generated");
+                });
+            });
+
             it("should alert the user if trying to submit data without changing the id.", function() {
                 chaisePage.recordEditPage.submitForm();
                 browser.wait(function() {


### PR DESCRIPTION
This PR addresses issue #1034. When a record is copied, the generated columns are no longer copied and instead it shows "Automatically generated" in the input field.

I adjusted the test cases to account for this scenario and added a column to the table for the copy tests that is generated.