### PR TITLE
PUT returns 200 with partial data

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -581,6 +581,54 @@
         }
 
         /**
+         * @param {ERMrest.Tuple[]} tuples - array of tuples
+         * @param {ERMrest.ReferenceColumn[]} columns - array of column names
+         * @return {Object[]} array of row value arrays [{isHTML: boolean, value: v}, ...]
+         */
+        function getRowValuesFromTupleData(tuples, columns) {
+            var rows = [];
+            for (var i = 0; i < tuples.length; i++) {
+                var tuple = tuples[i],
+                    row = [];
+
+                for (var j = 0; j < columns.length; j++) {
+                    var value,
+                        column = columns[j];
+
+                    if (column.isPseudo) {
+                        var keyColumns;
+
+                        if (column.key) {
+                            keyColumns = column.key.colset.columns;
+                        } else if (column.foreignKey) {
+                            keyColumns =  column.foreignKey.colset.columns;
+                        }
+
+                        for (var k = 0; k < keyColumns.length; k++) {
+                            var referenceColumn = keyColumns[k];
+
+                            value = tuple.data[referenceColumn.name];
+
+                            row.push({
+                                isHTML: false,
+                                value: value
+                            });
+                        }
+                    } else {
+                        value = tuple.data[column.name];
+
+                        row.push({
+                            isHTML: false,
+                            value: value
+                        });
+                    }
+                }
+                rows.push(row);
+            }
+            return rows;
+        }
+
+        /**
         *
         * @desc Converts the following characters to HTML entities for safe and
         * HTML5-valid usage in the `id` attributes of HTML elements: spaces, ampersands,
@@ -616,6 +664,7 @@
 
         return {
             getRowValuesFromPage: getRowValuesFromPage,
+            getRowValuesFromTupleData: getRowValuesFromTupleData,
             makeSafeIdAttr: makeSafeIdAttr,
             verify: verify
         };

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -243,15 +243,24 @@
             </div>
             </div>
             <div ng-show="form.resultset" class="container-fluid">
-                <h2 class="entity-title"><span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Edited</span> {{ form.resultsetModel.pageLimit }} records for table
+                <h2 class="entity-title">{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}
                     <a ng-href="{{::form.recordsetLink}}">
-                        <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
-                        <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
+                        <span ng-if="::form.omittedResultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.omittedResultsetModel.tableDisplayName.value"></span>
+                        <span ng-if="::!form.omittedResultsetModel.tableDisplayname.isHTML" ng-bind="::form.omittedResultsetModel.tableDisplayName.value"></span>
                     </a>
+                    Records Updated Successfully
                 </h2>
 
                 <div class="side-padding-15">
+                    <h3 class="entity-subtitle">{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+
                     <record-table vm="form.resultsetModel" default-row-linking="true"></record-table>
+
+                    <div ng-if="form.omittedResultsetModel">
+                        <h3 class="entity-subtitle">{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+
+                        <record-table vm="form.omittedResultsetModel" default-row-linking="true"></record-table>
+                    </div>
                 </div>
             </div>
         </div>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -243,7 +243,7 @@
             </div>
             </div>
             <div ng-show="form.resultset" class="container-fluid">
-                <h2 class="entity-title">{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}
+                <h2>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}
                     <a ng-href="{{::form.recordsetLink}}">
                         <span ng-if="::form.omittedResultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.omittedResultsetModel.tableDisplayName.value"></span>
                         <span ng-if="::!form.omittedResultsetModel.tableDisplayname.isHTML" ng-bind="::form.omittedResultsetModel.tableDisplayName.value"></span>
@@ -252,12 +252,12 @@
                 </h2>
 
                 <div class="side-padding-15">
-                    <h3 class="entity-subtitle">{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+                    <h3>{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
 
                     <record-table vm="form.resultsetModel" default-row-linking="true"></record-table>
 
                     <div ng-if="form.omittedResultsetModel">
-                        <h3 class="entity-subtitle">{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+                        <h3>{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
 
                         <record-table vm="form.omittedResultsetModel" default-row-linking="true"></record-table>
                     </div>


### PR DESCRIPTION
This PR addresses issue #1028. When the user submits a 'PUT' request via `Reference.update` and it returns a smaller set of data than what was submitted, `chaise` will properly display that information to the user.

For this to work, you have to have the proper permissions. [This link](https://dev.gpcrconsortium.org/~jchudy/chaise/recordedit/#1/assets:cpm@sort(last_modified_timestamp::desc::,id)?limit=25) is a link to my folder on dev.gpcr. 

To test this, follow the link above and submit the data. You should be able to change entities with `Site name` as `USC`. The 2 entities associated with `iHuman` shouldn't be editable.

NOTE: The following requires the changes to `ermrestJS` as well. The above does not rely on changes to `ermrestJS`. 
You can then follow [this link](https://dev.gpcrconsortium.org/~jchudy/chaise/recordedit/#1/assets:cpm/id=1) and try submitting the data. You should be presented with an error dialog that states that editing records for table cpm is not allowed. There is no information returned in the request that states as to why editing is not allowed, so we can't present a more meaningful error message.