### PR TITLE
Toggling AM/PM

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -275,8 +275,9 @@
                                             meridiem: 'AM'
                                         };
                                     }
+                                } else {
+                                    recordEditModel.rows[0][column.name] = column.default;
                                 }
-                                recordEditModel.rows[0][column.name] = column.default;
                             } else if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
                                 // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
                                 recordEditModel.rows[0][column.name] = {

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -639,6 +639,24 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                             }
                         });
 
+                        meridiemBtn.click().then(function() {
+                            return meridiemBtn.getText();
+                        }).then(function(newText) {
+                            if (initialMeridiem == 'AM') {
+                                expect(newText).toEqual('PM');
+                            } else {
+                                expect(newText).toEqual('AM');
+                            }
+                            return meridiemBtn.click();
+                        }).then(function() {
+                            return meridiemBtn.getText();
+                        }).then(function(newText) {
+                            expect(newText).toEqual(initialMeridiem);
+                        }).catch(function(error) {
+                            console.log(error);
+                            expect('There was an error in this promise chain.').toBe('Please see the error message.');
+                        });
+
                         timeInputFields.push({
                             date: dateInput,
                             time: timeInput,

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -639,6 +639,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                             }
                         });
 
+                        // toggle after data is input as well
                         meridiemBtn.click().then(function() {
                             return meridiemBtn.getText();
                         }).then(function(newText) {


### PR DESCRIPTION
This PR fixes issue #1039. There was a condition for when the page was initialized to set a default value for some fields (if it was available) in the `entry/create` context. If that default wasn't available (it's a function) or it's `null`, `timestamp` and `timestamptz` subfields were initialized to `null` with a default meridiem of `AM`. 

This was then being overwritten to the default value. That should have been nested in an `else` case.