### PR TITLE
Heuristics for when to show related tables changed

### DIFF
--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -25,9 +25,7 @@
             var canEdit = ($rootScope.reference && $rootScope.reference.canUpdate && $rootScope.modifyRecord);
             // If user can edit this record (canEdit === true), then change showEmptyRelatedTables.
             // Otherwise, canEdit will be undefined, so no need to change anything b/c showEmptyRelatedTables is already false.
-            if (canEdit === true) {
-                vm.showEmptyRelatedTables = true;
-            }
+
             return canEdit;
         };
 
@@ -124,7 +122,11 @@
         };
 
         vm.canCreateRelated = function(relatedRef) {
-            return (relatedRef.canCreate && $rootScope.modifyRecord);
+            var canCreate = (relatedRef.canCreate && $rootScope.modifyRecord);
+            if (canCreate && !vm.showEmptyRelatedTables) {
+                vm.showEmptyRelatedTables = canCreate;
+            }
+            return canCreate;
         };
 
         // Send user to RecordEdit to create a new row in this related table

--- a/test/e2e/specs/multi-permissions/visibility/00-record.spec.js
+++ b/test/e2e/specs/multi-permissions/visibility/00-record.spec.js
@@ -86,10 +86,11 @@ describe('When viewing Record app', function() {
             expect(button.isPresent()).toBe(false);
         });
 
-        it('should display the related tables toggle as "Show All Related Records"', function() {
+        // As create only user, 'Hide Empty Related Tables' should appear because the user can create entities for one or more related tables
+        it('should display the related tables toggle as "Hide Empty Related Records"', function() {
             var button = recordPage.getShowAllRelatedEntitiesButton();
             expect(button.isDisplayed()).toBe(true);
-            expect(button.getText()).toBe("Show All Related Records");
+            expect(button.getText()).toBe("Hide Empty Related Records");
         });
 
         describe('the related tables', function() {


### PR DESCRIPTION
This PR addresses issue #1055. The Show/Hide empty related tables toggle is now based on whether the user can modify at least one of the related tables. If they can, it shows all empty related tables by default.