### PR TITLE
401 handling

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -11,6 +11,8 @@
         // Private variable to store current session object
         var _session = null;
 
+        var _changeCbs = [];
+
         return {
 
             getSession: function() {
@@ -28,6 +30,16 @@
 
             getSessionValue: function() {
                 return _session;
+            },
+
+            subscribeOnChange: function(fn) {
+                if (typeof fn  == 'function') _changeCbs.push(fn);
+            },
+
+            executeListeners: function() {
+                _changeCbs.forEach(function(cb) {
+                   cb(); 
+                });
             },
 
             login: function (referrer) {
@@ -221,6 +233,9 @@
                     // and it can continue firing other queued calls
                     Session.getSession().then(function(_session) {
                         defer.resolve();
+
+                        Session.executeListeners();
+
                     }, function(exception) {
                         throw exception;
                     });

--- a/common/authen.js
+++ b/common/authen.js
@@ -206,11 +206,12 @@
             
             var Session = $injector.get("Session");
             
-            // Bind callback function for httpUnauthorizedFn handler
-            // This callback will be called whenver 
-            ERMrest.httpUnauthorizedFn(function() {
+            // Bind callback function by invoking setHttpUnauthorizedFn handler passing the callback
+            // This callback will be called whenever 401 HTTP error is encountered unless there is 
+            // already login flow in progress
+            ERMrest.setHttpUnauthorizedFn(function() {
                 var defer = $q.defer();
-                
+
                 // Call login in a new window to perform authentication
                 // and return a promise to notify ermrestjs that the user has loggedin
                 Session.loginInANewWindow(function() {

--- a/common/authen.js
+++ b/common/authen.js
@@ -13,6 +13,8 @@
 
         var _changeCbs = {};
 
+        var _counter = 0;
+
         var _executeListeners = function() {
             for (var k in _changeCbs) {
                 _changeCbs[k]();
@@ -37,7 +39,9 @@
             },
 
             subscribeOnChange: function(fn) {
-                var id = new Date().getTime();
+                // To avoid same ids for an instance we add counter
+                var id = new Date().getTime() + (++_counter);
+                
                 if (typeof fn  == 'function') {
                     _changeCbs[id] = fn;
                 } 

--- a/common/authen.js
+++ b/common/authen.js
@@ -30,6 +30,7 @@
                     return response.data;
                 }, function(response) {
                     _session = null;
+                    _executeListeners();
                     return $q.reject(response);
                 });
             },
@@ -41,7 +42,7 @@
             subscribeOnChange: function(fn) {
                 // To avoid same ids for an instance we add counter
                 var id = new Date().getTime() + (++_counter);
-                
+
                 if (typeof fn  == 'function') {
                     _changeCbs[id] = fn;
                 } 

--- a/common/authen.js
+++ b/common/authen.js
@@ -13,13 +13,22 @@
 
         var _changeCbs = [];
 
+
+        var _executeListeners = function() {
+            _changeCbs.forEach(function(cb) {
+               cb(); 
+            });
+        },
+
         return {
 
             getSession: function() {
                 return $http.get(serviceURL + "/authn/session").then(function(response) {
                     _session = response.data;
+                    _executeListeners();
                     return response.data;
                 }, function(response) {
+                    _session = null;
                     return $q.reject(response);
                 });
             },
@@ -30,12 +39,6 @@
 
             subscribeOnChange: function(fn) {
                 if (typeof fn  == 'function') _changeCbs.push(fn);
-            },
-
-            executeListeners: function() {
-                _changeCbs.forEach(function(cb) {
-                   cb(); 
-                });
             },
 
             login: function (referrer) {
@@ -229,9 +232,6 @@
                     // and it can continue firing other queued calls
                     Session.getSession().then(function(_session) {
                         defer.resolve();
-
-                        Session.executeListeners();
-
                     }, function(exception) {
                         throw exception;
                     });

--- a/common/authen.js
+++ b/common/authen.js
@@ -11,14 +11,13 @@
         // Private variable to store current session object
         var _session = null;
 
-        var _changeCbs = [];
-
+        var _changeCbs = {};
 
         var _executeListeners = function() {
-            _changeCbs.forEach(function(cb) {
-               cb(); 
-            });
-        },
+            for (var k in _changeCbs) {
+                _changeCbs[k]();
+            }
+        };
 
         return {
 
@@ -38,7 +37,15 @@
             },
 
             subscribeOnChange: function(fn) {
-                if (typeof fn  == 'function') _changeCbs.push(fn);
+                var id = new Date().getTime();
+                if (typeof fn  == 'function') {
+                    _changeCbs[id] = fn;
+                } 
+                return id;
+            },
+
+            unsubscribeOnChange: function(id) {
+                delete _changeCbs[id];
             },
 
             login: function (referrer) {

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -51,6 +51,17 @@
                 scope.signUpURL = chaiseConfig.signUpURL;
                 scope.profileURL = chaiseConfig.profileURL;
 
+                Session.subscribeOnChange(function() {
+                    $rootScope.session = Session.getSessionValue();
+
+                    if ($rootScope.session == null) {
+                        scope.user = null;
+                    } else {
+                        var user = $rootScope.session.client;
+                        scope.user = user.display_name || user.full_name || user.email || user;
+                    }
+                });
+
                 Session.getSession().then(function(session) {
                     $rootScope.session = session;
 

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -62,15 +62,7 @@
                     }
                 });
 
-                Session.getSession().then(function(session) {
-                    $rootScope.session = session;
-
-                    var user = session.client;
-                    scope.user = user.display_name || user.full_name || user.email || user;
-                }, function(error) {
-                    // No session = no user
-                    scope.user = null;
-                });
+                Session.getSession();
 
                 scope.login = function login() {
                     Session.login($window.location.href);

--- a/common/table.js
+++ b/common/table.js
@@ -141,13 +141,6 @@
                 scope.$emit('recordset-update');
 
             }, function error(exception) {
-                // If the errorcode is unauthorizederror (401) then open the login window to make the user login
-                if (exception instanceof ERMrest.UnauthorizedError || exception.code == 401) {
-                    return Session.loginInANewWindow(function() {
-                        //Once the user has logged in successfully trigger read again
-                        read(scope, isBackground);
-                    });
-                }
                 scope.vm.hasLoaded = true;
                 setSearchStates(scope, isBackground);
                 if (!isBackground && scope.vm.foregroundSearch) scope.vm.foregroundSearch = false;

--- a/common/utils.js
+++ b/common/utils.js
@@ -41,10 +41,6 @@
             title: "Your session has expired. Please login to continue.",
             message: "To open the login window press"
         },
-        "noSession" : {
-            title: "You need to be logged in to continue.",
-            message: "To open the login window press"
-        },
         "tableMissing": "No table specified in the form of 'schema-name:table-name' and no Default is set."
     })
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -41,6 +41,10 @@
             title: "Your session has expired. Please login to continue.",
             message: "To open the login window press"
         },
+        "noSession" : {
+            title: "You need to be logged in to continue.",
+            message: "To open the login window press"
+        },
         "tableMissing": "No table specified in the form of 'schema-name:table-name' and no Default is set."
     })
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -41,6 +41,10 @@
             title: "Your session has expired. Please login to continue.",
             message: "To open the login window press"
         },
+        "noSession": {
+            title: "Your need to be logged in to continue.",
+            message: "To open the login window press"
+        },
         "tableMissing": "No table specified in the form of 'schema-name:table-name' and no Default is set."
     })
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -56,110 +56,115 @@
         DataUtils.verify(context.filter, 'No filter was defined. Cannot find a record without a filter.');
 
         ERMrest.appLinkFn(UriUtils.appTagToURL);
-        Session.getSession().then(function getSession(_session) {
-            return ERMrest.resolve(ermrestUri, {cid: context.appName});
-        }, function(exception){
-            // do nothing but return without a session
-            return ERMrest.resolve(ermrestUri, {cid: context.appName});
-        }).then(function getReference(reference) {
-            // if the user can fetch the reference, they can see the content for the rest of the page
-            // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
-            session = Session.getSessionValue();
 
-            $rootScope.loading = true;
-            // $rootScope.reference != reference after contextualization
-            $rootScope.reference = reference.contextualize.detailed;
-            $rootScope.reference.session = session;
+        // Subscribe to on change event for session
+        var subId = Session.subscribeOnChange(function() {
 
-            $log.info("Reference: ", $rootScope.reference);
+            // Unsubscribe onchange event to avoid this function getting called again
+            Session.unsubscribeOnChange(subId);
 
-            // There should only ever be one entity related to this reference
-            return $rootScope.reference.read(1);
-        }, function error(exception) {
-            throw exception;
-        }).then(function getPage(page) {
-            $log.info("Page: ", page);
+            ERMrest.resolve(ermrestUri, {cid: context.appName});
+                .then(function getReference(reference) {
+                    // if the user can fetch the reference, they can see the content for the rest of the page
+                    // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
+                    session = Session.getSessionValue();
 
-            if (page.tuples.length < 1) {
-                var noDataError = ErrorService.noRecordError(context.filter.filters);
-                throw noDataError;
-            }
+                    $rootScope.loading = true;
+                    // $rootScope.reference != reference after contextualization
+                    $rootScope.reference = reference.contextualize.detailed;
+                    $rootScope.reference.session = session;
 
-            var tuple = $rootScope.tuple = page.tuples[0];
-            // Used directly in the record-display directive
-            $rootScope.recordDisplayname = tuple.displayname;
+                    $log.info("Reference: ", $rootScope.reference);
 
-            // related references
-            $rootScope.relatedReferences = $rootScope.reference.related(tuple);
+                    // There should only ever be one entity related to this reference
+                    return $rootScope.reference.read(1);
+                }, function error(exception) {
+                    throw exception;
+                }).then(function getPage(page) {
+                    $log.info("Page: ", page);
 
-            // Collate tuple.isHTML and tuple.values into an array of objects
-            // i.e. {isHTML: false, value: 'sample'}
-            $rootScope.recordValues = [];
-            tuple.values.forEach(function(value, index) {
-                $rootScope.recordValues.push({
-                    isHTML: tuple.isHTML[index],
-                    value: value
-                });
-            });
+                    if (page.tuples.length < 1) {
+                        var noDataError = ErrorService.noRecordError(context.filter.filters);
+                        throw noDataError;
+                    }
 
-            $rootScope.columns = $rootScope.reference.columns;
+                    var tuple = $rootScope.tuple = page.tuples[0];
+                    // Used directly in the record-display directive
+                    $rootScope.recordDisplayname = tuple.displayname;
 
-            $rootScope.tableModels = [];
-            $rootScope.lastRendered = null;
+                    // related references
+                    $rootScope.relatedReferences = $rootScope.reference.related(tuple);
 
-            for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
-                $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
-
-                var pageSize;
-                if ($rootScope.relatedReferences[i].display.defaultPageSize) {
-                    pageSize = $rootScope.relatedReferences[i].display.defaultPageSize;
-                } else {
-                    pageSize = constants.defaultPageSize;
-                }
-
-                (function(i) {
-                    $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
-                        var model = {
-                            reference: $rootScope.relatedReferences[i],
-                            columns: $rootScope.relatedReferences[i].columns,
-                            page: page,
-                            pageLimit: ($rootScope.relatedReferences[i].display.defaultPageSize ? $rootScope.relatedReferences[i].display.defaultPageSize : constants.defaultPageSize),
-                            hasNext: page.hasNext,      // used to determine if a link should be shown
-                            hasLoaded: true,            // used to determine if the current table and next table should be rendered
-                            open: true,                 // to define if the accordion is open or closed
-                            enableSort: true,           // allow sorting on table
-                            sortby: null,               // column name, user selected or null
-                            sortOrder: null,            // asc (default) or desc
-                            rowValues: [],              // array of rows values
-                            search: null,                // search term
-                            displayType: $rootScope.relatedReferences[i].display.type,
-                            context: "compact/brief",
-                            fromTuple: $rootScope.tuple
-                        };
-                        model.rowValues = DataUtils.getRowValuesFromPage(page);
-                        model.config = {
-                            viewable: true,
-                            editable: $rootScope.modifyRecord,
-                            deletable: $rootScope.modifyRecord && $rootScope.showDeleteButton,
-                            selectable: false
-                        };
-                        $rootScope.tableModels[i] = model;
-                    }, function readFail(error) {
-                        var model = {
-                            hasLoaded: true
-                        };
-                        $rootScope.tableModels[i] = model;
-                        throw error;
-                    }).catch(function(e) {
-                        // The .catch from the outer promise won't catch errors from this closure
-                        // so a .catch needs to be appended here.
-                        throw e;
+                    // Collate tuple.isHTML and tuple.values into an array of objects
+                    // i.e. {isHTML: false, value: 'sample'}
+                    $rootScope.recordValues = [];
+                    tuple.values.forEach(function(value, index) {
+                        $rootScope.recordValues.push({
+                            isHTML: tuple.isHTML[index],
+                            value: value
+                        });
                     });
-                })(i);
-            }
-        }).catch(function genericCatch(exception) {
-            throw exception;
-        });
+
+                    $rootScope.columns = $rootScope.reference.columns;
+
+                    $rootScope.tableModels = [];
+                    $rootScope.lastRendered = null;
+
+                    for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
+                        $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
+
+                        var pageSize;
+                        if ($rootScope.relatedReferences[i].display.defaultPageSize) {
+                            pageSize = $rootScope.relatedReferences[i].display.defaultPageSize;
+                        } else {
+                            pageSize = constants.defaultPageSize;
+                        }
+
+                        (function(i) {
+                            $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
+                                var model = {
+                                    reference: $rootScope.relatedReferences[i],
+                                    columns: $rootScope.relatedReferences[i].columns,
+                                    page: page,
+                                    pageLimit: ($rootScope.relatedReferences[i].display.defaultPageSize ? $rootScope.relatedReferences[i].display.defaultPageSize : constants.defaultPageSize),
+                                    hasNext: page.hasNext,      // used to determine if a link should be shown
+                                    hasLoaded: true,            // used to determine if the current table and next table should be rendered
+                                    open: true,                 // to define if the accordion is open or closed
+                                    enableSort: true,           // allow sorting on table
+                                    sortby: null,               // column name, user selected or null
+                                    sortOrder: null,            // asc (default) or desc
+                                    rowValues: [],              // array of rows values
+                                    search: null,                // search term
+                                    displayType: $rootScope.relatedReferences[i].display.type,
+                                    context: "compact/brief",
+                                    fromTuple: $rootScope.tuple
+                                };
+                                model.rowValues = DataUtils.getRowValuesFromPage(page);
+                                model.config = {
+                                    viewable: true,
+                                    editable: $rootScope.modifyRecord,
+                                    deletable: $rootScope.modifyRecord && $rootScope.showDeleteButton,
+                                    selectable: false
+                                };
+                                $rootScope.tableModels[i] = model;
+                            }, function readFail(error) {
+                                var model = {
+                                    hasLoaded: true
+                                };
+                                $rootScope.tableModels[i] = model;
+                                throw error;
+                            }).catch(function(e) {
+                                // The .catch from the outer promise won't catch errors from this closure
+                                // so a .catch needs to be appended here.
+                                throw e;
+                            });
+                        })(i);
+                    }
+                }).catch(function genericCatch(exception) {
+                    throw exception;
+                });
+        })
+        
 
         /**
          * it saves the location in $rootScope.location.

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -57,8 +57,6 @@
 
         ERMrest.appLinkFn(UriUtils.appTagToURL);
         Session.getSession().then(function getSession(_session) {
-            session = _session;
-
             return ERMrest.resolve(ermrestUri, {cid: context.appName});
         }, function(exception){
             // do nothing but return without a session
@@ -66,6 +64,8 @@
         }).then(function getReference(reference) {
             // if the user can fetch the reference, they can see the content for the rest of the page
             // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
+            session = Session.getSessionValue();
+
             $rootScope.loading = true;
             // $rootScope.reference != reference after contextualization
             $rootScope.reference = reference.contextualize.detailed;

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -63,106 +63,105 @@
             // Unsubscribe onchange event to avoid this function getting called again
             Session.unsubscribeOnChange(subId);
 
-            ERMrest.resolve(ermrestUri, {cid: context.appName});
-                .then(function getReference(reference) {
-                    // if the user can fetch the reference, they can see the content for the rest of the page
-                    // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
-                    session = Session.getSessionValue();
+            ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+                // if the user can fetch the reference, they can see the content for the rest of the page
+                // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
+                session = Session.getSessionValue();
 
-                    $rootScope.loading = true;
-                    // $rootScope.reference != reference after contextualization
-                    $rootScope.reference = reference.contextualize.detailed;
-                    $rootScope.reference.session = session;
+                $rootScope.loading = true;
+                // $rootScope.reference != reference after contextualization
+                $rootScope.reference = reference.contextualize.detailed;
+                $rootScope.reference.session = session;
 
-                    $log.info("Reference: ", $rootScope.reference);
+                $log.info("Reference: ", $rootScope.reference);
 
-                    // There should only ever be one entity related to this reference
-                    return $rootScope.reference.read(1);
-                }, function error(exception) {
-                    throw exception;
-                }).then(function getPage(page) {
-                    $log.info("Page: ", page);
+                // There should only ever be one entity related to this reference
+                return $rootScope.reference.read(1);
+            }, function error(exception) {
+                throw exception;
+            }).then(function getPage(page) {
+                $log.info("Page: ", page);
 
-                    if (page.tuples.length < 1) {
-                        var noDataError = ErrorService.noRecordError(context.filter.filters);
-                        throw noDataError;
-                    }
+                if (page.tuples.length < 1) {
+                    var noDataError = ErrorService.noRecordError(context.filter.filters);
+                    throw noDataError;
+                }
 
-                    var tuple = $rootScope.tuple = page.tuples[0];
-                    // Used directly in the record-display directive
-                    $rootScope.recordDisplayname = tuple.displayname;
+                var tuple = $rootScope.tuple = page.tuples[0];
+                // Used directly in the record-display directive
+                $rootScope.recordDisplayname = tuple.displayname;
 
-                    // related references
-                    $rootScope.relatedReferences = $rootScope.reference.related(tuple);
+                // related references
+                $rootScope.relatedReferences = $rootScope.reference.related(tuple);
 
-                    // Collate tuple.isHTML and tuple.values into an array of objects
-                    // i.e. {isHTML: false, value: 'sample'}
-                    $rootScope.recordValues = [];
-                    tuple.values.forEach(function(value, index) {
-                        $rootScope.recordValues.push({
-                            isHTML: tuple.isHTML[index],
-                            value: value
-                        });
+                // Collate tuple.isHTML and tuple.values into an array of objects
+                // i.e. {isHTML: false, value: 'sample'}
+                $rootScope.recordValues = [];
+                tuple.values.forEach(function(value, index) {
+                    $rootScope.recordValues.push({
+                        isHTML: tuple.isHTML[index],
+                        value: value
                     });
-
-                    $rootScope.columns = $rootScope.reference.columns;
-
-                    $rootScope.tableModels = [];
-                    $rootScope.lastRendered = null;
-
-                    for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
-                        $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
-
-                        var pageSize;
-                        if ($rootScope.relatedReferences[i].display.defaultPageSize) {
-                            pageSize = $rootScope.relatedReferences[i].display.defaultPageSize;
-                        } else {
-                            pageSize = constants.defaultPageSize;
-                        }
-
-                        (function(i) {
-                            $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
-                                var model = {
-                                    reference: $rootScope.relatedReferences[i],
-                                    columns: $rootScope.relatedReferences[i].columns,
-                                    page: page,
-                                    pageLimit: ($rootScope.relatedReferences[i].display.defaultPageSize ? $rootScope.relatedReferences[i].display.defaultPageSize : constants.defaultPageSize),
-                                    hasNext: page.hasNext,      // used to determine if a link should be shown
-                                    hasLoaded: true,            // used to determine if the current table and next table should be rendered
-                                    open: true,                 // to define if the accordion is open or closed
-                                    enableSort: true,           // allow sorting on table
-                                    sortby: null,               // column name, user selected or null
-                                    sortOrder: null,            // asc (default) or desc
-                                    rowValues: [],              // array of rows values
-                                    search: null,                // search term
-                                    displayType: $rootScope.relatedReferences[i].display.type,
-                                    context: "compact/brief",
-                                    fromTuple: $rootScope.tuple
-                                };
-                                model.rowValues = DataUtils.getRowValuesFromPage(page);
-                                model.config = {
-                                    viewable: true,
-                                    editable: $rootScope.modifyRecord,
-                                    deletable: $rootScope.modifyRecord && $rootScope.showDeleteButton,
-                                    selectable: false
-                                };
-                                $rootScope.tableModels[i] = model;
-                            }, function readFail(error) {
-                                var model = {
-                                    hasLoaded: true
-                                };
-                                $rootScope.tableModels[i] = model;
-                                throw error;
-                            }).catch(function(e) {
-                                // The .catch from the outer promise won't catch errors from this closure
-                                // so a .catch needs to be appended here.
-                                throw e;
-                            });
-                        })(i);
-                    }
-                }).catch(function genericCatch(exception) {
-                    throw exception;
                 });
+
+                $rootScope.columns = $rootScope.reference.columns;
+
+                $rootScope.tableModels = [];
+                $rootScope.lastRendered = null;
+
+                for (var i = 0; i < $rootScope.relatedReferences.length; i++) {
+                    $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
+
+                    var pageSize;
+                    if ($rootScope.relatedReferences[i].display.defaultPageSize) {
+                        pageSize = $rootScope.relatedReferences[i].display.defaultPageSize;
+                    } else {
+                        pageSize = constants.defaultPageSize;
+                    }
+
+                    (function(i) {
+                        $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
+                            var model = {
+                                reference: $rootScope.relatedReferences[i],
+                                columns: $rootScope.relatedReferences[i].columns,
+                                page: page,
+                                pageLimit: ($rootScope.relatedReferences[i].display.defaultPageSize ? $rootScope.relatedReferences[i].display.defaultPageSize : constants.defaultPageSize),
+                                hasNext: page.hasNext,      // used to determine if a link should be shown
+                                hasLoaded: true,            // used to determine if the current table and next table should be rendered
+                                open: true,                 // to define if the accordion is open or closed
+                                enableSort: true,           // allow sorting on table
+                                sortby: null,               // column name, user selected or null
+                                sortOrder: null,            // asc (default) or desc
+                                rowValues: [],              // array of rows values
+                                search: null,                // search term
+                                displayType: $rootScope.relatedReferences[i].display.type,
+                                context: "compact/brief",
+                                fromTuple: $rootScope.tuple
+                            };
+                            model.rowValues = DataUtils.getRowValuesFromPage(page);
+                            model.config = {
+                                viewable: true,
+                                editable: $rootScope.modifyRecord,
+                                deletable: $rootScope.modifyRecord && $rootScope.showDeleteButton,
+                                selectable: false
+                            };
+                            $rootScope.tableModels[i] = model;
+                        }, function readFail(error) {
+                            var model = {
+                                hasLoaded: true
+                            };
+                            $rootScope.tableModels[i] = model;
+                            throw error;
+                        }).catch(function(e) {
+                            // The .catch from the outer promise won't catch errors from this closure
+                            // so a .catch needs to be appended here.
+                            throw e;
+                        });
+                    })(i);
+                }
+            }).catch(function genericCatch(exception) {
+                throw exception;
+            });
         })
         
 

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -278,14 +278,8 @@
                         vm.resultset = true;
                     }
                 }, function error(exception) {
-                    if (exception instanceof ERMrest.UnauthorizedError || exception.code == 401) {
-                        Session.loginInANewWindow(function() {
-                            submit();
-                        });
-                    } else {
-                        vm.showSubmissionError(exception);
-                        vm.submissionButtonDisabled = false;
-                    }
+                    vm.showSubmissionError(exception);
+                    vm.submissionButtonDisabled = false;
                 });
             } else {
                 var creatRef = $rootScope.reference.unfilteredReference.contextualize.entryCreate;
@@ -329,14 +323,8 @@
                         vm.resultset = true;
                     }
                 }, function error(exception) {
-                    if (exception instanceof ERMrest.UnauthorizedError || exception.code == 401) {
-                        Session.loginInANewWindow(function() {
-                            submit();
-                        });
-                    } else {
-                        vm.showSubmissionError(exception);
-                        vm.submissionButtonDisabled = false;
-                    }
+                    vm.showSubmissionError(exception);
+                    vm.submissionButtonDisabled = false;
                 });
             }
         }
@@ -389,11 +377,7 @@
                     // redirect after successful delete
                     $window.location.href = "../search/#" + location.catalog + '/' + location.schemaName + ':' + location.tableName;
                 }, function deleteFailure(response) {
-                    if (exception instanceof ERMrest.UnauthorizedError || exception.code == 401) {
-                        Session.loginInANewWindow(function() {
-                            deleteRecord();
-                        });
-                    } else if (response instanceof ERMrest.PreconditionFailedError) {
+                    if (response instanceof ERMrest.PreconditionFailedError) {
                         $uibModal.open({
                             templateUrl: "../common/templates/refresh.modal.html",
                             controller: "ErrorDialogController",

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -92,7 +92,6 @@
 
 
             Session.getSession().then(function getSession(_session) {
-                session = _session;
                 ERMrest.appLinkFn(UriUtils.appTagToURL);
 
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
@@ -106,6 +105,8 @@
                 } else if (context.mode == context.modes.CREATE || context.mode == context.modes.COPY) {
                     $rootScope.reference = reference.contextualize.entryCreate;
                 }
+
+                session = Session.getSessionValue();
 
                 $rootScope.reference.session = session;
                 $rootScope.session = session;

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -37,68 +37,69 @@
     .run(['AlertsService', 'ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
         function runRecordEditApp(AlertsService, ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
 
-            var session,
-                context = { booleanValues: ['', true, false] };
+        var session,
+            context = { booleanValues: ['', true, false] };
 
-            $rootScope.displayReady = false;
+        $rootScope.displayReady = false;
 
-            UriUtils.setOrigin();
-            headInjector.addTitle();
-            headInjector.addCustomCSS();
+        UriUtils.setOrigin();
+        headInjector.addTitle();
+        headInjector.addCustomCSS();
 
-            // This is to allow the dropdown button to open at the top/bottom depending on the space available
-            UiUtils.setBootstrapDropdownButtonBehavior();
-            UriUtils.setLocationChangeHandling();
+        // This is to allow the dropdown button to open at the top/bottom depending on the space available
+        UiUtils.setBootstrapDropdownButtonBehavior();
+        UriUtils.setLocationChangeHandling();
 
-            // If defined but false, throw an error
-            if (!chaiseConfig.editRecord && chaiseConfig.editRecord !== undefined) {
-                var message = 'Chaise is currently configured to disallow editing records. Check the editRecord setting in chaise-config.js.';
-                var error = new Error(message);
-                error.code = "Record Editing Disabled";
+        // If defined but false, throw an error
+        if (!chaiseConfig.editRecord && chaiseConfig.editRecord !== undefined) {
+            var message = 'Chaise is currently configured to disallow editing records. Check the editRecord setting in chaise-config.js.';
+            var error = new Error(message);
+            error.code = "Record Editing Disabled";
 
-                throw error;
-            }
+            throw error;
+        }
 
-            var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
+        var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
 
-            context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
-            context.appName = "recordedit";
-            context.MAX_ROWS_TO_ADD = 201;
+        context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
+        context.appName = "recordedit";
+        context.MAX_ROWS_TO_ADD = 201;
 
-            // modes = create, edit, copy
-            // create is contextualized to entry/create
-            // edit is contextualized to entry/edit
-            // copy is contextualized to entry/create
-            // NOTE: copy is technically creating an entity so it needs the proper visible column list as well as the data for the record associated with the given filter
+        // modes = create, edit, copy
+        // create is contextualized to entry/create
+        // edit is contextualized to entry/edit
+        // copy is contextualized to entry/create
+        // NOTE: copy is technically creating an entity so it needs the proper visible column list as well as the data for the record associated with the given filter
 
-            context.modes = {
-                COPY: "copy",
-                CREATE: "create",
-                EDIT: "edit"
-            }
-            // mode defaults to create
-            context.mode = context.modes.CREATE;
+        context.modes = {
+            COPY: "copy",
+            CREATE: "create",
+            EDIT: "edit"
+        }
+        // mode defaults to create
+        context.mode = context.modes.CREATE;
 
-            // Mode can be any 3 with a filter
-            if (context.filter) {
-                // prefill always means create
-                // copy means copy regardless of a limit defined
-                // edit is everything else with a filter
-                context.mode = (context.queryParams.prefill ? context.modes.CREATE : (context.queryParams.copy ? context.modes.COPY : context.modes.EDIT));
-            } else if (context.queryParams.limit) {
-                context.mode = context.modes.EDIT;
-            }
+        // Mode can be any 3 with a filter
+        if (context.filter) {
+            // prefill always means create
+            // copy means copy regardless of a limit defined
+            // edit is everything else with a filter
+            context.mode = (context.queryParams.prefill ? context.modes.CREATE : (context.queryParams.copy ? context.modes.COPY : context.modes.EDIT));
+        } else if (context.queryParams.limit) {
+            context.mode = context.modes.EDIT;
+        }
 
-            Session.getSession().then(function getSession(_session) {
-                ERMrest.appLinkFn(UriUtils.appTagToURL);
+        ERMrest.appLinkFn(UriUtils.appTagToURL);
 
-                return ERMrest.resolve(ermrestUri, {cid: context.appName});
-            }, function sessionFailed() {
+        // Subscribe to on change event for session
+        var subId = Session.subscribeOnChange(function() {
 
-                ERMrest.appLinkFn(UriUtils.appTagToURL);
-                // do nothing but return without a session
-                return ERMrest.resolve(ermrestUri, {cid: context.appName});
-            }).then(function getReference(reference) {
+            // Unsubscribe onchange event to avoid this function getting called again
+            Session.unsubscribeOnChange(subId);
+
+            // On resolution
+            ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+                
                 //contextualize the reference based on the mode (determined above) recordedit is in
                 if (context.mode == context.modes.EDIT) {
                     $rootScope.reference = reference.contextualize.entryEdit;
@@ -132,188 +133,184 @@
                     // Keep a copy of the initial rows data so that we can see if user has made any changes later
                     recordEditModel.oldRows = angular.copy(recordEditModel.rows);
                     $log.info('Old model.rows:', recordEditModel.oldRows);
-
                 }
-                $log.info('Model: ', recordEditModel);
-                // Keep a copy of the initial rows data so that we can see if user has made any changes later
-                recordEditModel.oldRows = angular.copy(recordEditModel.rows);
-                $log.info('Old model.rows:', recordEditModel.oldRows);
-            }
 
-            // Case for editing an entity
-            if (context.mode == context.modes.EDIT || context.mode == context.modes.COPY) {
-                if ($rootScope.reference.canUpdate) {
+                // Case for editing an entity
+                if (context.mode == context.modes.EDIT || context.mode == context.modes.COPY) {
+                    if ($rootScope.reference.canUpdate) {
 
-                    var numberRowsToRead;
-                    if (context.queryParams.limit) {
-                        numberRowsToRead = Number(context.queryParams.limit);
-                        if (context.queryParams.limit > context.MAX_ROWS_TO_ADD) {
-                            var limitMessage = "Trying to edit " + context.queryParams.limit + " records. A maximum of " + context.MAX_ROWS_TO_ADD + " records can be edited at once. Showing the first " + context.MAX_ROWS_TO_ADD + " records.";
-                            AlertsService.addAlert(limitMessage, 'error');
-                        }
-                    } else {
-                        numberRowsToRead = context.MAX_ROWS_TO_ADD;
-                    }
-
-                    $rootScope.reference.read(numberRowsToRead).then(function getPage(page) {
-                        $log.info("Page: ", page);
-
-                        if (page.tuples.length < 1) {
-                            var noDataError = ErrorService.noRecordError(context.filter.filters);
-                            throw noDataError;
-                        }
-
-                        var column, value;
-
-                        // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
-                        // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
-                        // The submission data is copied back to the tuples object before submitted in the PUT request
-                        $rootScope.tuples = angular.copy(page.tuples);
-                        $rootScope.displayname = ((context.queryParams.copy && page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
-
-                        for (var j = 0; j < page.tuples.length; j++) {
-                            // initialize row objects {column-name: value,...}
-                            recordEditModel.rows[j] = {};
-                            // needs to be initialized so foreign keys can be set
-                            recordEditModel.submissionRows[j] = {};
-
-                            var tuple = page.tuples[j],
-                            values = tuple.values;
-
-                            for (var i = 0; i < $rootScope.reference.columns.length; i++) {
-                                column = $rootScope.reference.columns[i];
-
-                                // If input is disabled, there's no need to transform the column value.
-                                if (column.getInputDisabled(context.appContext)) {
-                                    // if not copy, populate the field without transforming it
-                                    if (context.mode != context.modes.COPY) {
-                                        recordEditModel.rows[j][column.name] = values[i];
-                                    }
-                                    continue;
-                                }
-
-                                // Transform column values for use in view model
-                                switch (column.type.name) {
-                                    case "timestamp":
-                                    case "timestamptz":
-                                        if (values[i]) {
-                                            var ts = moment(values[i]);
-                                            value = {
-                                                date: ts.format('YYYY-MM-DD'),
-                                                time: ts.format('hh:mm:ss'),
-                                                meridiem: ts.format('A')
-                                            };
-                                        } else {
-                                            value = {
-                                                date: null,
-                                                time: null,
-                                                meridiem: 'AM'
-                                            };
-                                        }
-                                        break;
-                                    case "int2":
-                                    case "int4":
-                                    case "int8":
-                                        var intVal = parseInt(values[i], 10);
-                                        value = (!isNaN(intVal) ? intVal : null);
-                                        break;
-                                    case "float4":
-                                    case "float8":
-                                    case "numeric":
-                                        var floatVal = parseFloat(values[i]);
-                                        value = (!isNaN(floatVal) ? floatVal : null);
-                                        break;
-                                    default:
-                                        value = values[i];
-                                        break;
-                                }
-
-                                // no need to check for copy here because the case above guards against the negative case for copy
-                                recordEditModel.rows[j][column.name] = value;
+                        var numberRowsToRead;
+                        if (context.queryParams.limit) {
+                            numberRowsToRead = Number(context.queryParams.limit);
+                            if (context.queryParams.limit > context.MAX_ROWS_TO_ADD) {
+                                var limitMessage = "Trying to edit " + context.queryParams.limit + " records. A maximum of " + context.MAX_ROWS_TO_ADD + " records can be edited at once. Showing the first " + context.MAX_ROWS_TO_ADD + " records.";
+                                AlertsService.addAlert(limitMessage, 'error');
                             }
+                        } else {
+                            numberRowsToRead = context.MAX_ROWS_TO_ADD;
                         }
+
+                        $rootScope.reference.read(numberRowsToRead).then(function getPage(page) {
+                            $log.info("Page: ", page);
+
+                            if (page.tuples.length < 1) {
+                                var noDataError = ErrorService.noRecordError(context.filter.filters);
+                                throw noDataError;
+                            }
+
+                            var column, value;
+
+                            // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
+                            // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
+                            // The submission data is copied back to the tuples object before submitted in the PUT request
+                            $rootScope.tuples = angular.copy(page.tuples);
+                            $rootScope.displayname = ((context.queryParams.copy && page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
+
+                            for (var j = 0; j < page.tuples.length; j++) {
+                                // initialize row objects {column-name: value,...}
+                                recordEditModel.rows[j] = {};
+                                // needs to be initialized so foreign keys can be set
+                                recordEditModel.submissionRows[j] = {};
+
+                                var tuple = page.tuples[j],
+                                values = tuple.values;
+
+                                for (var i = 0; i < $rootScope.reference.columns.length; i++) {
+                                    column = $rootScope.reference.columns[i];
+
+                                    // If input is disabled, there's no need to transform the column value.
+                                    if (column.getInputDisabled(context.appContext)) {
+                                        // if not copy, populate the field without transforming it
+                                        if (context.mode != context.modes.COPY) {
+                                            recordEditModel.rows[j][column.name] = values[i];
+                                        }
+                                        continue;
+                                    }
+
+                                    // Transform column values for use in view model
+                                    switch (column.type.name) {
+                                        case "timestamp":
+                                        case "timestamptz":
+                                            if (values[i]) {
+                                                var ts = moment(values[i]);
+                                                value = {
+                                                    date: ts.format('YYYY-MM-DD'),
+                                                    time: ts.format('hh:mm:ss'),
+                                                    meridiem: ts.format('A')
+                                                };
+                                            } else {
+                                                value = {
+                                                    date: null,
+                                                    time: null,
+                                                    meridiem: 'AM'
+                                                };
+                                            }
+                                            break;
+                                        case "int2":
+                                        case "int4":
+                                        case "int8":
+                                            var intVal = parseInt(values[i], 10);
+                                            value = (!isNaN(intVal) ? intVal : null);
+                                            break;
+                                        case "float4":
+                                        case "float8":
+                                        case "numeric":
+                                            var floatVal = parseFloat(values[i]);
+                                            value = (!isNaN(floatVal) ? floatVal : null);
+                                            break;
+                                        default:
+                                            value = values[i];
+                                            break;
+                                    }
+
+                                    // no need to check for copy here because the case above guards against the negative case for copy
+                                    recordEditModel.rows[j][column.name] = value;
+                                }
+                            }
+
+                            $rootScope.displayReady = true;
+                            $log.info('Model: ', recordEditModel);
+                            // Keep a copy of the initial rows data so that we can see if user has made any changes later
+                            recordEditModel.oldRows = angular.copy(recordEditModel.rows);
+                        }, function error(response) {
+                            throw response;
+                        });
+                    } else if (session) {
+                        var notAuthorizedMessage = "You are not authorized to Update entities.";
+                        var notAuthorizedError = new Error(notAuthorizedMessage);
+                        // user logged in but not allowed (forbidden)
+                        notAuthorizedError.code = errorNames.forbidden;
+
+                        throw notAuthorizedError;
+                    } else {
+                        var notAuthorizedMessage = "You are not authorized to Update entities.";
+                        var notAuthorizedError = new Error(notAuthorizedMessage);
+                        // user not logged in (unauthorized)
+                        notAuthorizedError.code = errorNames.unauthorized;
+
+                        throw notAuthorizedError;
+                    }
+                } else if (context.mode == context.modes.CREATE) {
+                    if ($rootScope.reference.canCreate) {
+                        $rootScope.displayname = $rootScope.reference.displayname;
+
+                        // populate defaults
+                        angular.forEach($rootScope.reference.columns, function(column) {
+                            // if column.default == undefined, the second condition would be true so we need to check if column.default is defined
+                            // only want to set values in the input fields so make sure it isn't a function
+                            // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
+                            if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
+                                if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
+                                    if (column.default !== null) {
+                                        var ts = moment(column.default);
+                                        recordEditModel.rows[0][column.name] = {
+                                            date: ts.format('YYYY-MM-DD'),
+                                            time: ts.format('hh:mm:ss'),
+                                            meridiem: ts.format('A')
+                                        };
+                                    } else {
+                                        recordEditModel.rows[0][column.name] = {
+                                            date: null,
+                                            time: null,
+                                            meridiem: 'AM'
+                                        };
+                                    }
+                                } else {
+                                    recordEditModel.rows[0][column.name] = column.default;
+                                }
+                            } else if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
+                                // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
+                                recordEditModel.rows[0][column.name] = {
+                                    date: null,
+                                    time: null,
+                                    meridiem: 'AM'
+                                };
+                            }
+                        });
 
                         $rootScope.displayReady = true;
-                        $log.info('Model: ', recordEditModel);
-                        // Keep a copy of the initial rows data so that we can see if user has made any changes later
-                        recordEditModel.oldRows = angular.copy(recordEditModel.rows);
-                    }, function error(response) {
-                        throw response;
-                    });
-                } else if (session) {
-                    var notAuthorizedMessage = "You are not authorized to Update entities.";
-                    var notAuthorizedError = new Error(notAuthorizedMessage);
-                    // user logged in but not allowed (forbidden)
-                    notAuthorizedError.code = errorNames.forbidden;
+                        // if there is a session, user isn't allowed to create
+                    } else if (session) {
+                        var forbiddenMessage = "You are not authorized to Create entities.";
+                        var forbiddenError = new Error(forbiddenMessage);
 
-                    throw notAuthorizedError;
-                } else {
-                    var notAuthorizedMessage = "You are not authorized to Update entities.";
-                    var notAuthorizedError = new Error(notAuthorizedMessage);
-                    // user not logged in (unauthorized)
-                    notAuthorizedError.code = errorNames.unauthorized;
+                        forbiddenError.code = errorNames.forbidden;
 
-                    throw notAuthorizedError;
+                        throw forbiddenError;
+                        // user isn't logged in and needs permissions to create
+                    } else {
+                        var notAuthorizedMessage = "You are not authorized to Create entities.";
+                        var notAuthorizedError = new Error(notAuthorizedMessage);
+
+                        notAuthorizedError.code = errorNames.unauthorized;
+
+                        throw notAuthorizedError;
+                    }
                 }
-            } else if (context.mode == context.modes.CREATE) {
-                if ($rootScope.reference.canCreate) {
-                    $rootScope.displayname = $rootScope.reference.displayname;
-
-                    // populate defaults
-                    angular.forEach($rootScope.reference.columns, function(column) {
-                        // if column.default == undefined, the second condition would be true so we need to check if column.default is defined
-                        // only want to set values in the input fields so make sure it isn't a function
-                        // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
-                        if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
-                            if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
-                                if (column.default !== null) {
-                                    var ts = moment(column.default);
-                                    recordEditModel.rows[0][column.name] = {
-                                        date: ts.format('YYYY-MM-DD'),
-                                        time: ts.format('hh:mm:ss'),
-                                        meridiem: ts.format('A')
-                                    };
-                                } else {
-                                    recordEditModel.rows[0][column.name] = {
-                                        date: null,
-                                        time: null,
-                                        meridiem: 'AM'
-                                    };
-                                }
-                            } else {
-                                recordEditModel.rows[0][column.name] = column.default;
-                            }
-                        } else if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
-                            // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
-                            recordEditModel.rows[0][column.name] = {
-                                date: null,
-                                time: null,
-                                meridiem: 'AM'
-                            };
-                        }
-                    });
-
-                    $rootScope.displayReady = true;
-                    // if there is a session, user isn't allowed to create
-                } else if (session) {
-                    var forbiddenMessage = "You are not authorized to Create entities.";
-                    var forbiddenError = new Error(forbiddenMessage);
-
-                    forbiddenError.code = errorNames.forbidden;
-
-                    throw forbiddenError;
-                    // user isn't logged in and needs permissions to create
-                } else {
-                    var notAuthorizedMessage = "You are not authorized to Create entities.";
-                    var notAuthorizedError = new Error(notAuthorizedMessage);
-
-                    notAuthorizedError.code = errorNames.unauthorized;
-
-                    throw notAuthorizedError;
-                }
-            }
-        }, function error(response) {
-            throw response;
+            }, function error(response) {
+                throw response;
+            });
         });
+
     }]);
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -96,6 +96,8 @@
 
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }, function sessionFailed() {
+
+                ERMrest.appLinkFn(UriUtils.appTagToURL);
                 // do nothing but return without a session
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }).then(function getReference(reference) {

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -183,52 +183,55 @@
 
 
             ERMrest.appLinkFn(UriUtils.appTagToURL);
-            Session.getSession().then(function getSession(_session) {
-                return ERMrest.resolve(ermrestUri, {cid: context.appName});
-            }, function(exception) {
-                // do nothing but return without a session
-                return ERMrest.resolve(ermrestUri, {cid: context.appName});
-            }).then(function getReference(reference) {
 
-                session = Session.getSessionValue();
+            // Subscribe to on change event for session
+            var subId = Session.subscribeOnChange(function() {
 
-                recordsetModel.reference = reference.contextualize.compact;
-                recordsetModel.context = "compact";
-                recordsetModel.reference.session = session;
+                // Unsubscribe onchange event to avoid this function getting called again
+                Session.unsubscribeOnChange(subId);
 
-                $log.info("Reference:", recordsetModel.reference);
+                ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+                    session = Session.getSessionValue();
 
-                if (p_context.queryParams.limit)
-                    recordsetModel.pageLimit = parseInt(p_context.queryParams.limit);
-                else if (recordsetModel.reference.display.defaultPageSize)
-                    recordsetModel.pageLimit = recordsetModel.reference.display.defaultPageSize;
-                else
-                    recordsetModel.pageLimit = 25;
-                recordsetModel.tableDisplayName = recordsetModel.reference.displayname;
-                
-                 // the additional provided name
-                if (p_context.queryParams && p_context.queryParams.subset) {
-                    recordsetModel.subTitle = p_context.queryParams.subset;
-                }
+                    recordsetModel.reference = reference.contextualize.compact;
+                    recordsetModel.context = "compact";
+                    recordsetModel.reference.session = session;
 
-                recordsetModel.columns = recordsetModel.reference.columns;
-                recordsetModel.search = recordsetModel.reference.location.searchTerm;
+                    $log.info("Reference:", recordsetModel.reference);
 
-                return recordsetModel.reference.read(recordsetModel.pageLimit);
-            }, function error(response) {
-                throw response;
-            }).then(function getPage(page) {
-                recordsetModel.page = page;
-                recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
-                recordsetModel.initialized = true;
-                recordsetModel.hasLoaded = true;
-            }, function error(response) {
-                throw response;
-            }).catch(function genericCatch(exception) {
-                $log.warn(exception);
-                recordsetModel.hasLoaded = true;
+                    if (p_context.queryParams.limit)
+                        recordsetModel.pageLimit = parseInt(p_context.queryParams.limit);
+                    else if (recordsetModel.reference.display.defaultPageSize)
+                        recordsetModel.pageLimit = recordsetModel.reference.display.defaultPageSize;
+                    else
+                        recordsetModel.pageLimit = 25;
+                    recordsetModel.tableDisplayName = recordsetModel.reference.displayname;
+                    
+                     // the additional provided name
+                    if (p_context.queryParams && p_context.queryParams.subset) {
+                        recordsetModel.subTitle = p_context.queryParams.subset;
+                    }
 
-                throw exception;
+                    recordsetModel.columns = recordsetModel.reference.columns;
+                    recordsetModel.search = recordsetModel.reference.location.searchTerm;
+
+                    return recordsetModel.reference.read(recordsetModel.pageLimit);
+                }, function error(response) {
+                    throw response;
+                }).then(function getPage(page) {
+                    recordsetModel.page = page;
+                    recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
+                    recordsetModel.initialized = true;
+                    recordsetModel.hasLoaded = true;
+                }, function error(response) {
+                    throw response;
+                }).catch(function genericCatch(exception) {
+                    $log.warn(exception);
+                    recordsetModel.hasLoaded = true;
+
+                    throw exception;
+                });
+
             });
 
             /**

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -184,13 +184,14 @@
 
             ERMrest.appLinkFn(UriUtils.appTagToURL);
             Session.getSession().then(function getSession(_session) {
-                session = _session;
-
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }, function(exception) {
                 // do nothing but return without a session
                 return ERMrest.resolve(ermrestUri, {cid: context.appName});
             }).then(function getReference(reference) {
+
+                session = Session.getSessionValue();
+
                 recordsetModel.reference = reference.contextualize.compact;
                 recordsetModel.context = "compact";
                 recordsetModel.reference.session = session;


### PR DESCRIPTION
This PR adds an explicit interceptor for handling 401 errors in `authen.js`.

Whenever a 401 error is encountered the handler is called. The handler renders the login window and on successful login, fetches the new session and sets it in the `authen` module.

It also adds logic to subscribe to change in session. This is used in navbar to update the once the user has logged in.

Can be tested here https://dev.gpcrconsortium.org/~chirag/chaise/recordedit/#1/experiments:experiment