### PR TITLE
isForeignKey checked based on ermrestJS function

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -554,7 +554,7 @@
             var name = column.name;
             var type = column.type.name;
             var displayType;
-            if (isForeignKey(column)) {
+            if (column.isForeignKey) {
                 displayType = 'popup-select';
             } else {
                 switch (type) {
@@ -609,10 +609,6 @@
             }
         }
 
-        function isForeignKey(column) {
-            return column.isPseudo;
-        }
-
         // Returns true if a column type is found in the given array of types
         function matchType(columnType, types) {
             if (types.indexOf(columnType) !== -1) {
@@ -631,7 +627,7 @@
                         return value;
                     }
                     return '';
-                } else if (isForeignKey(column)) {
+                } else if (column.isForeignKey) {
                     return 'Select a value';
                 }
             } catch (e) {


### PR DESCRIPTION
This PR addresses [issue #374](https://github.com/informatics-isi-edu/ermrestjs/issues/374) in `ermrestJS`. 

`Chaise` uses the function on `ReferenceColumn` to check whether a column is a foreign key or not. [This PR](https://github.com/informatics-isi-edu/ermrestjs/pull/392) in `ermrestJS` has to be merged first.