### PR TITLE
Loading... text does not show up when there are no related tables.

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -89,7 +89,7 @@
                     </div>
                 </div>
             </uib-accordion>
-            <span ng-show="loading">Loading...</span>
+            <span id="rt-loading" ng-show="loading">Loading...</span>
         </div>
     </div>
 </body>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -68,7 +68,6 @@
                 // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
                 session = Session.getSessionValue();
 
-                $rootScope.loading = true;
                 // $rootScope.reference != reference after contextualization
                 $rootScope.reference = reference.contextualize.detailed;
                 $rootScope.reference.session = session;
@@ -93,6 +92,8 @@
 
                 // related references
                 $rootScope.relatedReferences = $rootScope.reference.related(tuple);
+
+                $rootScope.loading = $rootScope.relatedReferences.length > 0;
 
                 // Collate tuple.isHTML and tuple.values into an array of objects
                 // i.e. {isHTML: false, value: 'sample'}
@@ -163,7 +164,7 @@
                 throw exception;
             });
         })
-        
+
 
         /**
          * it saves the location in $rootScope.location.

--- a/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
+++ b/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
@@ -64,8 +64,15 @@ describe('View existing record,', function() {
 
             it("should show when the page loads.", function() {
                 browser.wait(EC.elementToBeClickable(copyButton), browser.params.defaultTimeout);
+
                 copyButton.isDisplayed().then(function (bool) {
                     expect(bool).toBeTruthy();
+                });
+            });
+
+            it("should not show Loading... text when there are no related tables.", function() {
+                element(by.id('rt-loading')).isDisplayed().then(function (displayed) {
+                    expect(displayed).toBeFalsy();
                 });
             });
 


### PR DESCRIPTION
This PR addresses issue #1056. I added the test to the _copy_ spec because that spec relied on a schema where the main entity did not have any related tables.