### PR TITLE
Recordedit copy uses reference displayname as entity title

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -99,7 +99,7 @@
 
             // On resolution
             ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
-                
+
                 //contextualize the reference based on the mode (determined above) recordedit is in
                 if (context.mode == context.modes.EDIT) {
                     $rootScope.reference = reference.contextualize.entryEdit;
@@ -164,7 +164,7 @@
                             // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
                             // The submission data is copied back to the tuples object before submitted in the PUT request
                             $rootScope.tuples = angular.copy(page.tuples);
-                            $rootScope.displayname = ((context.queryParams.copy && page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
+                            $rootScope.displayname = ((context.queryParams.copy || page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
 
                             for (var j = 0; j < page.tuples.length; j++) {
                                 // initialize row objects {column-name: value,...}

--- a/test/e2e/data_setup/config/record-copy-btn.dev.json
+++ b/test/e2e/data_setup/config/record-copy-btn.dev.json
@@ -27,8 +27,8 @@
         "params": {
             "tuples" : [{
                 "table_name": "editable-id-table",
-                "table_inner_html_display": "<strong>Editable Id Table</strong>",
                 "table_displayname": "Editable Id Table",
+                "table_inner_html_display": "<strong>Editable Id Table</strong>",
                 "entity_title": "1",
                 "entity_inner_html_title": "<strong>1</strong>",
                 "html_table_name": "html-name-table",

--- a/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
+++ b/test/e2e/specs/record/copy-btn/06-record.copybutton.spec.js
@@ -81,11 +81,11 @@ describe('View existing record,', function() {
 
                     return titleElement.getText();
                 }).then(function(txt) {
-                    expect(txt).toBe("Create 1 Record");
+                    expect(txt).toBe("Create " + tupleParams.table_displayname +" Record");
 
                     return titleElement.element(by.css('span[ng-bind-html]')).getAttribute("innerHTML");
                 }).then(function(html) {
-                    expect(html).toBe(tupleParams.entity_inner_html_title);
+                    expect(html).toBe(tupleParams.table_inner_html_display);
 
                     return chaisePage.recordEditPage.getForms().count();
                 }).then(function(ct) {

--- a/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
@@ -41,42 +41,46 @@ describe('Edit existing record,', function() {
             browser.get(browser.params.url + ":" + testParams.table_name + "/" + keys.join(";"));
         });
 
+        it("should have the table displayname as part of the entity title.", function() {
+            // if submit button is visible, this means the recordedit page has loaded
+            chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+                expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Create multi-add-table Record")
+            });
+        });
+
         it("should change their values and show a resultset table with 2 entities.", function() {
             var intInput1 = chaisePage.recordEditPage.getInputById(0, intDisplayName),
                 intInput2 = chaisePage.recordEditPage.getInputById(1, intDisplayName),
                 textInput1 = chaisePage.recordEditPage.getInputById(0, textDisplayName),
                 textInput2 = chaisePage.recordEditPage.getInputById(1, textDisplayName);
 
-            chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+            // modify first form
+            // check value before that it loaded correctly
+            expect(intInput1.getAttribute("value")).toBe(intInput1DefaultVal);
+            chaisePage.recordEditPage.clearInput(intInput1);
+            browser.sleep(10);
+            intInput1.sendKeys(intInput1FirstVal);
+            // check value after it was changed
+            expect(intInput1.getAttribute("value")).toBe(intInput1FirstVal);
 
-                // modify first form
-                // check value before that it loaded correctly
-                expect(intInput1.getAttribute("value")).toBe(intInput1DefaultVal);
-                chaisePage.recordEditPage.clearInput(intInput1);
-                browser.sleep(10);
-                intInput1.sendKeys(intInput1FirstVal);
-                // check value after it was changed
-                expect(intInput1.getAttribute("value")).toBe(intInput1FirstVal);
+            expect(textInput1.getAttribute("value")).toBe(textInput1DefaultVal);
+            chaisePage.recordEditPage.clearInput(textInput1);
+            browser.sleep(10);
+            textInput1.sendKeys(textInput1FirstVal);
+            expect(textInput1.getAttribute("value")).toBe(textInput1FirstVal);
 
-                expect(textInput1.getAttribute("value")).toBe(textInput1DefaultVal);
-                chaisePage.recordEditPage.clearInput(textInput1);
-                browser.sleep(10);
-                textInput1.sendKeys(textInput1FirstVal);
-                expect(textInput1.getAttribute("value")).toBe(textInput1FirstVal);
+            // modify second form
+            expect(intInput2.getAttribute("value")).toBe(intInput2DefaultVal);
+            chaisePage.recordEditPage.clearInput(intInput2);
+            browser.sleep(10);
+            intInput2.sendKeys(intInput2FirstVal);
+            expect(intInput2.getAttribute("value")).toBe(intInput2FirstVal);
 
-                // modify second form
-                expect(intInput2.getAttribute("value")).toBe(intInput2DefaultVal);
-                chaisePage.recordEditPage.clearInput(intInput2);
-                browser.sleep(10);
-                intInput2.sendKeys(intInput2FirstVal);
-                expect(intInput2.getAttribute("value")).toBe(intInput2FirstVal);
-
-                expect(textInput2.getAttribute("value")).toBe(textInput2DefaultVal);
-                chaisePage.recordEditPage.clearInput(textInput2);
-                browser.sleep(10);
-                textInput2.sendKeys(textInput2FirstVal);
-                expect(textInput2.getAttribute("value")).toBe(textInput2FirstVal);
-            });
+            expect(textInput2.getAttribute("value")).toBe(textInput2DefaultVal);
+            chaisePage.recordEditPage.clearInput(textInput2);
+            browser.sleep(10);
+            textInput2.sendKeys(textInput2FirstVal);
+            expect(textInput2.getAttribute("value")).toBe(textInput2FirstVal);
         });
 
         describe("Submit " + testParams.keys_2.length + " records", function() {

--- a/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/multi-edit/08-recordedit.multi-edit.spec.js
@@ -44,7 +44,7 @@ describe('Edit existing record,', function() {
         it("should have the table displayname as part of the entity title.", function() {
             // if submit button is visible, this means the recordedit page has loaded
             chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
-                expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Create multi-add-table Record")
+                expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Edit multi-add-table Records")
             });
         });
 


### PR DESCRIPTION
This PR addresses issue #1063. When copying a record, the reference displayname is shown so the entity title is `Create <table.displayname> Record`.