### PR TITLE
Date validator doesn't run if the date obj is null

### DIFF
--- a/common/validators.js
+++ b/common/validators.js
@@ -117,7 +117,7 @@
                 scope.$watch(attr.validateValues, function(newObj, oldObj) {
                     // If newObj and oldObj are identical, then this listener fn was triggered
                     // due to app initialization, not an actual model change. Do nothing.
-                    if (newObj === oldObj) {
+                    if (newObj === oldObj || newObj == null) {
                         return;
                     }
                     var date = newObj.date,


### PR DESCRIPTION
This PR addresses issue #1068. The date validator was being run after the data was submitted on a null date field.