### PR TITLE
Remove deep copy in recordedit

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -175,7 +175,7 @@
 
                                 // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
                                 // The submission data is copied back to the tuples object before submitted in the PUT request
-                                var shallowTuple = tuple.deepCopyData();
+                                var shallowTuple = tuple.copy();
                                 $rootScope.tuples.push(shallowTuple);
 
                                 for (var i = 0; i < $rootScope.reference.columns.length; i++) {

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -161,9 +161,7 @@
                             var column, value;
 
                             // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
-                            // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
-                            // The submission data is copied back to the tuples object before submitted in the PUT request
-                            $rootScope.tuples = angular.copy(page.tuples);
+                            $rootScope.tuples = [];
                             $rootScope.displayname = ((context.queryParams.copy || page.tuples.length > 1) ? $rootScope.reference.displayname : page.tuples[0].displayname);
 
                             for (var j = 0; j < page.tuples.length; j++) {
@@ -173,7 +171,12 @@
                                 recordEditModel.submissionRows[j] = {};
 
                                 var tuple = page.tuples[j],
-                                values = tuple.values;
+                                    values = tuple.values;
+
+                                // We don't want to mutate the actual tuples associated with the page returned from `reference.read`
+                                // The submission data is copied back to the tuples object before submitted in the PUT request
+                                var shallowTuple = tuple.deepCopyData();
+                                $rootScope.tuples.push(shallowTuple);
 
                                 for (var i = 0; i < $rootScope.reference.columns.length; i++) {
                                     column = $rootScope.reference.columns[i];


### PR DESCRIPTION
This PR addresses issue #1102. In `recordedit` we were creating a deep copy of the whole `page.tuples` array. This would recursively copy every single object in each `Tuple` in the array. This is unnecessary given that we are only ever modifying the data associated with the `Tuple`. I added a function to the `Tuple` class in ermrestJS to handle this so that the `Tuple`'s prototype can be used.

**NOTE: This PR cannot be merged until [this](https://github.com/informatics-isi-edu/ermrestjs/pull/405) PR is merged in `ermrestJS`.