### PR TITLE
Timestamptz bug

### DIFF
--- a/common/validators.js
+++ b/common/validators.js
@@ -80,7 +80,7 @@
                     if (ctrl.$isEmpty(modelValue)) {
                         return true;
                     }
-                    return moment(modelValue, ['hh:mm:ss', 'hh:mm', 'hh'], true).isValid();
+                    return moment(modelValue, ['H:m:s', 'H:m', 'H'], true).isValid();
                 };
                 /*
                 The parser below takes the view value and inserts the appropriate colons before updating the model value.
@@ -124,7 +124,9 @@
                         dateIsValid = moment(date, ['YYYY-MM-DD', 'YYYY-M-DD', 'YYYY-M-D', 'YYYY-MM-D'], true).isValid(),
                         dateIsEmpty = (date === null || date === '' || date === undefined),
                         time = newObj.time,
-                        timeIsValid = moment(time, ['hh:mm:ss', 'hh:mm', 'hh'], true).isValid(),
+                        // H:m:s matches all permutation of hours:minutes:seconds where there is a single digit or 2 digits input
+                        // eg. 02:02:02 === 2:2:2 are both validated as proper
+                        timeIsValid = moment(time, ['H:m:s', 'H:m', 'H'], true).isValid(),
                         timeIsEmpty = (time === null || time === '' || time === undefined);
 
                     if (dateIsValid) {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -126,7 +126,7 @@
                                     rowVal.time = '00:00:00';
                                     rowVal = moment(rowVal.date + rowVal.time + rowVal.meridiem, 'YYYY-MM-DDhh:mm:ssA').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
                                 // in create if the user doesn't change the timestamp field, it will be an object in form {time: null, date: null, meridiem: AM}
-                                // meridiem should never be null,time is allowed to 
+                                // meridiem should never be null,time can be left empty (null) but the case above would catch that.
                                 } else if (!rowVal.date) {
                                     rowVal = null;
                                 }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -12,7 +12,6 @@
         vm.resultset = false;
         vm.editMode = (context.mode == context.modes.EDIT ? true : false);
         vm.showDeleteButton = chaiseConfig.deleteRecord === true ? true : false;
-        context.appContext = vm.editMode ? 'entry/edit': 'entry/create';
         vm.booleanValues = context.booleanValues;
         vm.mdHelpLinks = { // Links to Markdown references to be used in help text
             editor: "https://jbt.github.io/markdown-editor/#RZDLTsMwEEX3/opBXQCRmqjlsYBVi5CKxGOBWFWocuOpM6pjR54Jbfl6nKY08mbO1dwj2yN4pR+ENx23Juw8PBuSEJU6B3zwovdgAzIED1IhONwINNqjezxyRG6dkLcQWmlaAWIwxI3TBzT/pUi2klypLJsHZ0BwL1kGSq1eRDsq6Rf7cKXUCBaoTeebJBho2tGAN0cc+LbnIbg7BUNyr9SnrhuH6dUsCjKYNYm4m+bap3McP6L2NqX/y+9tvcaYLti3Jvm5Ns2H3k0+FBdpvfsGDUvuHY789vuqEmn4oShsCNZhXob6Ou+3LxmqsAMJQL50rUHQHqjWFpW6WM7gpPn6fAIXbBhUUe9yS1K1605XkN+EWGuhksfENEbTFmWlibGoNQvG4ijlouVy3MQE8cAVoTO7EE2ibd54e/0H",
@@ -116,7 +115,7 @@
                 var col = $rootScope.reference.columns[i];
 
                 var rowVal = row[col.name];
-                if (rowVal && !column.getInputDisabled(context.appContext)) {
+                if (rowVal && !col.getInputDisabled(context.appContext)) {
                     switch (col.type.name) {
                         case "timestamp":
                         case "timestamptz":
@@ -127,7 +126,7 @@
                                     rowVal.time = '00:00:00';
                                     rowVal = moment(rowVal.date + rowVal.time + rowVal.meridiem, 'YYYY-MM-DDhh:mm:ssA').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
                                 // in create if the user doesn't change the timestamp field, it will be an object in form {time: val, date: val, meridiem: AM/PM}
-                                } else if ( (!rowVal.date || !rowVal.time || !rowVal.meridiem) ) {
+                                } else if (!rowVal.date) {
                                     rowVal = null;
                                 }
                             }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -125,7 +125,8 @@
                                 } else if (rowVal.date && rowVal.time === null) {
                                     rowVal.time = '00:00:00';
                                     rowVal = moment(rowVal.date + rowVal.time + rowVal.meridiem, 'YYYY-MM-DDhh:mm:ssA').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-                                // in create if the user doesn't change the timestamp field, it will be an object in form {time: val, date: val, meridiem: AM/PM}
+                                // in create if the user doesn't change the timestamp field, it will be an object in form {time: null, date: null, meridiem: AM}
+                                // meridiem should never be null,time is allowed to 
                                 } else if (!rowVal.date) {
                                     rowVal = null;
                                 }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -116,7 +116,7 @@
                 var col = $rootScope.reference.columns[i];
 
                 var rowVal = row[col.name];
-                if (rowVal) {
+                if (rowVal && !column.getInputDisabled(context.appContext)) {
                     switch (col.type.name) {
                         case "timestamp":
                         case "timestamptz":
@@ -126,8 +126,8 @@
                                 } else if (rowVal.date && rowVal.time === null) {
                                     rowVal.time = '00:00:00';
                                     rowVal = moment(rowVal.date + rowVal.time + rowVal.meridiem, 'YYYY-MM-DDhh:mm:ssA').format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-                                // if the input is disabled, rowVal will be a string instead of a datetime object
-                                } else if ((!rowVal.date || !rowVal.time || !rowVal.meridiem) && !col.getInputDisabled(context.appContext)) {
+                                // in create if the user doesn't change the timestamp field, it will be an object in form {time: val, date: val, meridiem: AM/PM}
+                                } else if ( (!rowVal.date || !rowVal.time || !rowVal.meridiem) ) {
                                     rowVal = null;
                                 }
                             }

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -135,7 +135,7 @@
                                                                 <div class="input-group">
                                                                     <span class="input-group-addon">Time</span>
                                                                     <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].time" placeholder="HH:MM:SS" name="{{::column.name}}"
-                                                                        ui-mask="19?:?5?9?:?5?9" ui-options="form.maskOptions.time" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" time timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]">
+                                                                         model-view-value="true" ng-disabled="::form.isDisabled(column);" time timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]">
                                                                     <span class="input-group-btn">
                                                                         <button class="btn btn-primary" name="{{::column.name}}" type="button" ng-click="::form.toggleMeridiem(rowIndex, column.name);" ng-bind="form.recordEditModel.rows[rowIndex][column.name].meridiem || 'AM'" ng-disabled="::form.isDisabled(column);">AM</button>
                                                                     </span>

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -88,6 +88,7 @@
         } else if (context.queryParams.limit) {
             context.mode = context.modes.EDIT;
         }
+        context.appContext = (context.mode == context.modes.EDIT ? "entry/edit" : "entry/create");
 
         ERMrest.appLinkFn(UriUtils.appTagToURL);
 
@@ -277,7 +278,7 @@
                                             };
                                         }
                                     } else {
-                                        recordEditModel.rows[0][column.name] = column.default;
+                                        recordEditModel.rows[0][column.name] = (column.default !== null ? column.default : null);
                                     }
                                 } else if ((column.type.name === 'timestamp' || column.type.name === 'timestamptz')) {
                                     // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -256,35 +256,37 @@
 
                         // populate defaults
                         angular.forEach($rootScope.reference.columns, function(column) {
-                            // if column.default == undefined, the second condition would be true so we need to check if column.default is defined
-                            // only want to set values in the input fields so make sure it isn't a function
-                            // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
-                            if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
-                                if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
-                                    if (column.default !== null) {
-                                        var ts = moment(column.default);
-                                        recordEditModel.rows[0][column.name] = {
-                                            date: ts.format('YYYY-MM-DD'),
-                                            time: ts.format('hh:mm:ss'),
-                                            meridiem: ts.format('A')
-                                        };
+                            if (!column.getInputDisabled(context.appContext)) {
+                                // if column.default == undefined, the second condition would be true so we need to check if column.default is defined
+                                // only want to set values in the input fields so make sure it isn't a function
+                                // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
+                                if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
+                                    if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
+                                        if (column.default !== null) {
+                                            var ts = moment(column.default);
+                                            recordEditModel.rows[0][column.name] = {
+                                                date: ts.format('YYYY-MM-DD'),
+                                                time: ts.format('hh:mm:ss'),
+                                                meridiem: ts.format('A')
+                                            };
+                                        } else {
+                                            recordEditModel.rows[0][column.name] = {
+                                                date: null,
+                                                time: null,
+                                                meridiem: 'AM'
+                                            };
+                                        }
                                     } else {
-                                        recordEditModel.rows[0][column.name] = {
-                                            date: null,
-                                            time: null,
-                                            meridiem: 'AM'
-                                        };
+                                        recordEditModel.rows[0][column.name] = column.default;
                                     }
-                                } else {
-                                    recordEditModel.rows[0][column.name] = column.default;
+                                } else if ((column.type.name === 'timestamp' || column.type.name === 'timestamptz')) {
+                                    // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
+                                    recordEditModel.rows[0][column.name] = {
+                                        date: null,
+                                        time: null,
+                                        meridiem: 'AM'
+                                    };
                                 }
-                            } else if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
-                                // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
-                                recordEditModel.rows[0][column.name] = {
-                                    date: null,
-                                    time: null,
-                                    meridiem: 'AM'
-                                };
                             }
                         });
 

--- a/test/e2e/specs/recordedit/data-independent/edit-multi-col-types/09-recordedit.types.spec.js
+++ b/test/e2e/specs/recordedit/data-independent/edit-multi-col-types/09-recordedit.types.spec.js
@@ -193,7 +193,7 @@ describe('When editing a record', function() {
 
                             timeInput.clear().then(function() {
                                 if (newValue !== null) {
-                                    return timeInput.sendKeys('010000');
+                                    return timeInput.sendKeys('01:00:00');
                                 };
                             }).catch(function(error) {
                                 console.log(error);

--- a/test/e2e/specs/recordedit/helpers.js
+++ b/test/e2e/specs/recordedit/helpers.js
@@ -137,16 +137,15 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                             expect(dateInput.isEnabled()).toBe(false);
                             expect(timeInput.isEnabled()).toBe(false);
                             expect(meridiemBtn.isEnabled()).toBe(false);
-                        } else {
-                            chaisePage.recordEditPage.getInputForAColumn(column.name, recordIndex).then(function(input) {
-                                expect(input.isEnabled()).toBe(false);
-                                if (!tableParams.keys) {
-                                    expect(input.getAttribute('placeholder')).toBe('Automatically generated');
-                                }
-                            }).catch(function(e) {
-                                console.log(e);
-                            });
                         }
+                        chaisePage.recordEditPage.getInputForAColumn(column.name, recordIndex).then(function(input) {
+                            expect(input.isEnabled()).toBe(false);
+                            if (!tableParams.keys) {
+                                expect(input.getAttribute('placeholder')).toBe('Automatically generated');
+                            }
+                        }).catch(function(e) {
+                            console.log(e);
+                        });
                     });
                 }
             });
@@ -586,7 +585,7 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
 
                         // If user enters an invalid time an error msg should appear
                         timeInput.clear();
-                        timeInput.sendKeys('00:00:00'); // this is invalid because we're only accepting 12-hr time formats
+                        timeInput.sendKeys('24:12:00'); // this is invalid because we're only accepting 24-hr time formats from 0-23
                         chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
                             if (error) {
                                 expect(true).toBe(true);
@@ -597,6 +596,56 @@ exports.testPresentationAndBasicValidation = function(tableParams) {
                         // If user enters a valid time, then error msg should disappear
                         timeInput.clear();
                         timeInput.sendKeys('12:00:00');
+                        chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
+                            if (error) {
+                                expect('An error message was not supposed to appear.').toBe('But one was found.');
+                            } else {
+                                expect(true).toBe(true);
+                            }
+                        });
+                        timeInput.clear();
+                        // users can enter 1 digit in any place
+                        timeInput.sendKeys('2:00:00');
+                        chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
+                            if (error) {
+                                expect('An error message was not supposed to appear.').toBe('But one was found.');
+                            } else {
+                                expect(true).toBe(true);
+                            }
+                        });
+                        timeInput.clear();
+                        // users can enter just the hours
+                        timeInput.sendKeys('08');
+                        chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
+                            if (error) {
+                                expect('An error message was not supposed to appear.').toBe('But one was found.');
+                            } else {
+                                expect(true).toBe(true);
+                            }
+                        });
+                        timeInput.clear();
+                        // users can enter less than the full string
+                        timeInput.sendKeys('2:10');
+                        chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
+                            if (error) {
+                                expect('An error message was not supposed to appear.').toBe('But one was found.');
+                            } else {
+                                expect(true).toBe(true);
+                            }
+                        });
+                        timeInput.clear();
+                        // users can enter time in 24 hr format
+                        timeInput.sendKeys('20:00:00');
+                        chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
+                            if (error) {
+                                expect('An error message was not supposed to appear.').toBe('But one was found.');
+                            } else {
+                                expect(true).toBe(true);
+                            }
+                        });
+                        timeInput.clear();
+                        // users can enter 0 for the time
+                        timeInput.sendKeys('00:00:00');
                         chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'time').then(function(error) {
                             if (error) {
                                 expect('An error message was not supposed to appear.').toBe('But one was found.');


### PR DESCRIPTION
This PR fixes 2 issues, #1115 and #1116. 

The error reported in #1115 was happening because the value in another field (the disabled last modified field) was not being formatted properly for data submission. This has been addressed by not pre-formatting the view model for disabled timestamp fields (this is how issue #1116 was resolved). The other requested changes to the time input have been made as well.

The time input no longer limits the hour value from being restricted to 1-12. It allows the user to type a number from 0-23 for the hour. The time input no longer restricts the user to typing in `hh:mm:ss` format. They can enter in 1 OR 2 digits for each time field (hours, minutes, seconds). They can also leave off the seconds or even the minutes (`hh:mm` or `hh`).

