### PR TITLE
Default values in recordedit show up properly if the input is disabled

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -224,8 +224,8 @@
                                             value = (!isNaN(floatVal) ? floatVal : null);
                                             break;
                                         default:
-                                            if (column.isAsset) {                                            
-                                                value = { url: values[i] || "" }; 
+                                            if (column.isAsset) {
+                                                value = { url: values[i] || "" };
                                             } else {
                                                 value = values[i];
                                             }
@@ -265,37 +265,43 @@
 
                         // populate defaults
                         angular.forEach($rootScope.reference.columns, function(column) {
-                            if (!column.getInputDisabled(context.appContext)) {
-                                // if column.default == undefined, the second condition would be true so we need to check if column.default is defined
-                                // only want to set values in the input fields so make sure it isn't a function
-                                // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
-                                if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
-                                    if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
-                                        if (column.default !== null) {
-                                            var ts = moment(column.default);
-                                            recordEditModel.rows[0][column.name] = {
-                                                date: ts.format('YYYY-MM-DD'),
-                                                time: ts.format('hh:mm:ss'),
-                                                meridiem: ts.format('A')
-                                            };
-                                        } else {
-                                            recordEditModel.rows[0][column.name] = {
-                                                date: null,
-                                                time: null,
-                                                meridiem: 'AM'
-                                            };
-                                        }
-                                    } else if (column.isAsset) {
+                            // if column.default == undefined, the second condition would be true so we need to check both if column.default is defined and it's not a function
+                            // only want to set values in the input fields so make sure it isn't a function
+                            // check the recordEditModel to make sure a value wasn't already set based on the prefill condition
+                            if (column.default !== undefined && typeof column.default !== "function" && !recordEditModel.rows[0][column.name]) {
+                                // default value is present, figure out what type the column is and set it's default obj appropriately
+                                if (column.type.name === 'timestamp' || column.type.name === 'timestamptz') {
+                                    if (column.default !== null) {
+                                        var ts = moment(column.default);
                                         recordEditModel.rows[0][column.name] = {
-                                            url: column.default
-                                        }
+                                            date: ts.format('YYYY-MM-DD'),
+                                            time: ts.format('hh:mm:ss'),
+                                            meridiem: ts.format('A')
+                                        };
                                     } else {
-                                        recordEditModel.rows[0][column.name] = (column.default !== null ? column.default : null);
+                                        recordEditModel.rows[0][column.name] = {
+                                            date: null,
+                                            time: null,
+                                            meridiem: 'AM'
+                                        };
                                     }
                                 } else if (column.isAsset) {
                                     recordEditModel.rows[0][column.name] = {
+                                        url: column.default
+                                    }
+                                } else {
+                                    recordEditModel.rows[0][column.name] = (column.default !== null ? column.default : null);
+                                }
+                            // no default is set or default is a function
+                            // we don't want to populate the model with empty objects that are just going to get set to null
+                            } else if (!column.getInputDisabled(context.appContext)) {
+                                // setup if column is type asset
+                                if (column.isAsset) {
+                                    // If there are no defaults, initialize asset column with the app's default obj
+                                    recordEditModel.rows[0][column.name] = {
                                         url: ""
                                     }
+                                    // setup if column is type timestamp[tz]
                                 } else if ((column.type.name === 'timestamp' || column.type.name === 'timestamptz')) {
                                     // If there are no defaults, then just initialize timestamp[tz] columns with the app's default obj
                                     recordEditModel.rows[0][column.name] = {

--- a/test/e2e/data_setup/schema/recordedit/defaults.json
+++ b/test/e2e/data_setup/schema/recordedit/defaults.json
@@ -64,11 +64,21 @@
                     "type": {
                         "typename": "boolean"
                     }
+                }, {
+                    "name": "text_disabled",
+                    "default": "Disabled input",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:generated": null
+                    }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["id", "text", "int", "boolean_true", "boolean_false"]
+                    "*": ["id", "text", "int", "boolean_true", "boolean_false", "text_disabled"]
                 }
             }
         }

--- a/test/e2e/specs/default-config/recordedit/add-defaults.spec.js
+++ b/test/e2e/specs/default-config/recordedit/add-defaults.spec.js
@@ -6,7 +6,8 @@ var testParams = {
     text_value: "default",
     int_value: "25",
     boolean_true_value: "true",
-    boolean_false_value: "false"
+    boolean_false_value: "false",
+    disabled_text_value: "Disabled input"
 };
 
 describe('Record Add with defaults', function() {
@@ -14,7 +15,7 @@ describe('Record Add with defaults', function() {
     describe("for when the user creates an entity with default values, ", function() {
         var EC = protractor.ExpectedConditions,
             textDisplayname = "<strong>text</strong>",
-            textInput, intInput, booleanTrueInput, booleanFalseInput;
+            textInput, intInput, booleanTrueInput, booleanFalseInput, textDisabledInput;
 
         beforeAll(function () {
             browser.ignoreSynchronization=true;
@@ -40,9 +41,11 @@ describe('Record Add with defaults', function() {
             intInput = chaisePage.recordEditPage.getInputById(0, "int");
             booleanTrueInput = chaisePage.recordEditPage.getInputById(0, "boolean_true");
             booleanFalseInput = chaisePage.recordEditPage.getInputById(0, "boolean_false");
+            textDisabledInput = chaisePage.recordEditPage.getInputById(0, "text_disabled");
 
             expect(textInput.getAttribute("value")).toBe(testParams.text_value);
             expect(intInput.getAttribute("value")).toBe(testParams.int_value);
+            expect(textDisabledInput.getAttribute("value")).toBe(testParams.disabled_text_value);
 
             expect(chaisePage.recordEditPage.getDropdownText(booleanTrueInput)).toBe(testParams.boolean_true_value);
             expect(chaisePage.recordEditPage.getDropdownText(booleanFalseInput)).toBe(testParams.boolean_false_value);


### PR DESCRIPTION
This PR addresses issue #1128. The default values show properly in `recordedit` inputs when those values are defined and not a function, i.e. those values are most likely primitives (strings are primitives in JS).

We can discuss the logic tomorrow and decide whether that should be reorganized to make more sense. I had to add a bunch of comments because I had to re-understood the reasoning behind what was there.