### PR TITLE
Catalogs not deleted after tests end

### DIFF
--- a/test/e2e/utils/protractor.configuration.js
+++ b/test/e2e/utils/protractor.configuration.js
@@ -47,6 +47,15 @@ exports.getConfig = function(options) {
 
   var dataSetup = require('./protractor.parameterize.js');
 
+  // Look through schemaConfigurations, if any are strings (filenames), grab the json file and insert into the schemaConfigs array
+  var schemaConfigs = testConfiguration.setup.schemaConfigurations;
+  for (var i = 0; i < schemaConfigs.length; i++) {
+      var schemaConfig = schemaConfigs[i];
+      if (typeof schemaConfig === 'string') {
+          schemaConfigs[i] = require(process.env.PWD + "/test/e2e/data_setup/config/" + schemaConfig);
+      }
+  }
+
   var dateSetupOptions = {
     testConfiguration: testConfiguration
   };

--- a/test/e2e/utils/protractor.import.js
+++ b/test/e2e/utils/protractor.import.js
@@ -94,9 +94,6 @@ var importSchemas = function(configs, defer, authCookie, catalogId) {
     }
 
     var config = configs.shift();
-    if (typeof config === 'string') {
-        config = require(process.env.PWD + "/test/e2e/data_setup/config/" + config);
-    }
 
     if (catalogId) config.catalog.id = catalogId;
     else delete config.catalog.id;


### PR DESCRIPTION
This PR addresses issue #1150.

The schema configuration objects were refactored into their JSON documents and are represented by their file path in the test configuration object. When the test configuration is read in, it checks whether the schema configurations are strings (filenames) and reads in the contents of that file.