### PR TITLE
added support for setting the wid and pid for each server request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ testrecordadd:
 #Rule to run recordset app tests
 .PHONY: testrecordset
 testrecordset:
-	$(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDrecordsetEdit)
+	$(BIN)/protractor $(E2EDrecordset) #&& $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDrecordsetEdit)
 
 # Rule to run record edit app tests
 .PHONY: testrecordedit

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ testrecordadd:
 #Rule to run recordset app tests
 .PHONY: testrecordset
 testrecordset:
-	$(BIN)/protractor $(E2EDrecordset) #&& $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDrecordsetEdit)
+	$(BIN)/protractor $(E2EDrecordset) && $(BIN)/protractor $(E2ErecordsetAdd) && $(BIN)/protractor $(E2EDrecordsetEdit)
 
 # Rule to run record edit app tests
 .PHONY: testrecordedit

--- a/common/utils.js
+++ b/common/utils.js
@@ -793,8 +793,21 @@
             return Math.floor(Math.random() * (max - min)) + min;
         }
 
+        /**
+         * Generates a unique uuid
+         * @returns {String} a string of length 24
+         */
+        function uuid() {
+            // gets a string of a deterministic length of 4
+            function s4() {
+                return Math.floor((1 + Math.random()) * 0x10000).toString(36);
+            }
+            return s4() + s4() + s4() + s4() + s4() + s4();
+        }
+
         return {
-            getRandomInt: getRandomInt
+            getRandomInt: getRandomInt,
+            uuid: uuid
         }
     }])
 
@@ -879,14 +892,14 @@
         };
     }])
 
-    .service('headInjector', function() {
+    .service('headInjector', ['$window', 'MathUtils', function($window, MathUtils) {
         function addCustomCSS() {
             if (chaiseConfig['customCSS'] !== undefined) {
-            	var fileref = document.createElement("link");
-            	fileref.setAttribute("rel", "stylesheet");
-            	fileref.setAttribute("type", "text/css");
-            	fileref.setAttribute("href", chaiseConfig['customCSS']);
-            	document.getElementsByTagName("head")[0].appendChild(fileref);
+                var fileref = document.createElement("link");
+                fileref.setAttribute("rel", "stylesheet");
+                fileref.setAttribute("type", "text/css");
+                fileref.setAttribute("href", chaiseConfig['customCSS']);
+                document.getElementsByTagName("head")[0].appendChild(fileref);
             }
         }
 
@@ -895,9 +908,25 @@
                 document.getElementsByTagName('head')[0].getElementsByTagName('title')[0].innerHTML = chaiseConfig.headTitle;
             }
         }
+
+        // sets the WID if it doesn't already exist
+        function setWindowName() {
+            if (!$window.name) {
+                $window.name = MathUtils.uuid();
+            }
+        }
+
+        function setupHead() {
+            addCustomCSS();
+            addTitle();
+            setWindowName();
+        }
+
         return {
             addCustomCSS: addCustomCSS,
-            addTitle: addTitle
+            addTitle: addTitle,
+            setWindowName: setWindowName,
+            setupHead: setupHead
         };
-    });
+    }]);
 })();

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -33,15 +33,14 @@
         $uibTooltipProvider.options({appendToBody: true});
     }])
 
-    .run(['constants', 'DataUtils', 'ERMrest', 'ErrorService', 'headInjector', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window',
-        function runApp(constants, DataUtils, ERMrest, ErrorService, headInjector, Session, UiUtils, UriUtils, $log, $rootScope, $window) {
+    .run(['constants', 'DataUtils', 'ERMrest', 'ErrorService', 'headInjector', 'MathUtils', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window',
+        function runApp(constants, DataUtils, ERMrest, ErrorService, headInjector, MathUtils, Session, UiUtils, UriUtils, $log, $rootScope, $window) {
 
         var session,
             context = {};
 
         UriUtils.setOrigin();
-        headInjector.addTitle();
-        headInjector.addCustomCSS();
+        headInjector.setupHead();
 
         $rootScope.modifyRecord = chaiseConfig.editRecord === false ? false : true;
         $rootScope.showDeleteButton = chaiseConfig.deleteRecord === true ? true : false;
@@ -52,6 +51,7 @@
 
         // The context object won't change unless the app is reloaded
         context.appName = "record";
+        context.pageId = MathUtils.uuid();
 
         DataUtils.verify(context.filter, 'No filter was defined. Cannot find a record without a filter.');
 
@@ -63,7 +63,7 @@
             // Unsubscribe onchange event to avoid this function getting called again
             Session.unsubscribeOnChange(subId);
 
-            ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+            ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
                 // if the user can fetch the reference, they can see the content for the rest of the page
                 // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
                 session = Session.getSessionValue();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -35,8 +35,8 @@
         $uibTooltipProvider.options({appendToBody: true});
     }])
 
-    .run(['AlertsService', 'ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
-        function runRecordEditApp(AlertsService, ERMrest, errorNames, ErrorService, headInjector, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
+    .run(['AlertsService', 'ERMrest', 'errorNames', 'ErrorService', 'headInjector', 'MathUtils', 'recordEditModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', '$cookies',
+        function runRecordEditApp(AlertsService, ERMrest, errorNames, ErrorService, headInjector, MathUtils, recordEditModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, $cookies) {
 
         var session,
             context = { booleanValues: ['', true, false] };
@@ -44,8 +44,7 @@
         $rootScope.displayReady = false;
 
         UriUtils.setOrigin();
-        headInjector.addTitle();
-        headInjector.addCustomCSS();
+        headInjector.setupHead();
 
         // This is to allow the dropdown button to open at the top/bottom depending on the space available
         UiUtils.setBootstrapDropdownButtonBehavior();
@@ -64,6 +63,7 @@
 
         context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
         context.appName = "recordedit";
+        context.pageId = MathUtils.uuid();
         context.MAX_ROWS_TO_ADD = 201;
 
         // modes = create, edit, copy
@@ -100,7 +100,7 @@
             Session.unsubscribeOnChange(subId);
 
             // On resolution
-            ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+            ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
 
                 //contextualize the reference based on the mode (determined above) recordedit is in
                 if (context.mode == context.modes.EDIT) {

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -138,14 +138,13 @@
     }])
 
     // Register work to be performed after loading all modules
-    .run(['AlertsService', 'context', 'DataUtils', 'ERMrest', 'ErrorService', 'headInjector', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window',
-        function(AlertsService, context, DataUtils, ERMrest, ErrorService, headInjector, recordsetModel, Session, UiUtils, UriUtils, $log, $rootScope, $window) {
+    .run(['AlertsService', 'context', 'DataUtils', 'ERMrest', 'ErrorService', 'headInjector', 'MathUtils', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window',
+        function(AlertsService, context, DataUtils, ERMrest, ErrorService, headInjector, MathUtils, recordsetModel, Session, UiUtils, UriUtils, $log, $rootScope, $window) {
 
         try {
             var session;
 
-            headInjector.addTitle();
-            headInjector.addCustomCSS();
+            headInjector.setupHead();
 
             UriUtils.setOrigin();
 
@@ -178,6 +177,7 @@
 
             context.catalogID = p_context.catalogID;
             context.tableName = p_context.tableName;
+            context.pageId = MathUtils.uuid();
 
             var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
 
@@ -190,7 +190,7 @@
                 // Unsubscribe onchange event to avoid this function getting called again
                 Session.unsubscribeOnChange(subId);
 
-                ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+                ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
                     session = Session.getSessionValue();
 
                     recordsetModel.reference = reference.contextualize.compact;

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -839,6 +839,12 @@ function chaisePage() {
             expect(ele.getAttribute('class')).toContain(className);
         }
     };
+    this.getWindowName = function() {
+        return browser.executeScript("return window.name;");
+    };
+    this.getPageId = function() {
+        return browser.executeScript("return angular.element('body').scope().$root.context.pageId");
+    };
     this.setAuthCookie = function(url, authCookie) {
         if (url && authCookie) {
             // Visit the default page and set the authorization cookie if required


### PR DESCRIPTION
This PR addresses issue #1105.

`Record`, `Recordset`, and `Recordedit` now set these properties when making requests to the server. e2e test cases pass locally for me.