### PR TITLE
Related tables show up properly when they are empty

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -22,11 +22,11 @@
                     <span class="glyphicon glyphicon-copy"></span> <strong>Copy</strong>
                 </a>&nbsp;&nbsp;
                 <delete-link id="delete-record" callback="::ctrl.deleteRecord()" ng-if="::ctrl.canDelete()" label="Delete" uib-tooltip="Click here to delete this record." tooltip-placement="bottom" icon="true"></delete-link>&nbsp;&nbsp;
-                <a id="show-all-related-tables" ng-click="::ctrl.toggleRelatedTables();" uib-tooltip="{{'Click here to ' + ((ctrl.showEmptyRelatedTables) ? 'hide empty related entities.' : 'show empty related entities too.')}}" tooltip-placement="bottom">
-                    <span class="glyphicon" ng-class="{'glyphicon-resize-full': !ctrl.showEmptyRelatedTables, 'glyphicon-resize-small': ctrl.showEmptyRelatedTables}"></span>
+                <a id="show-all-related-tables" ng-click="::ctrl.toggleRelatedTables();" uib-tooltip="{{'Click here to ' + ((showEmptyRelatedTables) ? 'hide empty related entities.' : 'show empty related entities too.')}}" tooltip-placement="bottom">
+                    <span class="glyphicon" ng-class="{'glyphicon-resize-full': !showEmptyRelatedTables, 'glyphicon-resize-small': showEmptyRelatedTables}"></span>
                     <strong>
-                        <span ng-show="!ctrl.showEmptyRelatedTables">Show All</span>
-                        <span ng-show="ctrl.showEmptyRelatedTables">Hide Empty</span>
+                        <span ng-show="!showEmptyRelatedTables">Show All</span>
+                        <span ng-show="showEmptyRelatedTables">Hide Empty</span>
                          Related Records
                     </strong>
                 </a>&nbsp;&nbsp;

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -42,6 +42,7 @@
         UriUtils.setOrigin();
         headInjector.setupHead();
 
+        $rootScope.showEmptyRelatedTables = false;
         $rootScope.modifyRecord = chaiseConfig.editRecord === false ? false : true;
         $rootScope.showDeleteButton = chaiseConfig.deleteRecord === true ? true : false;
 
@@ -121,6 +122,9 @@
                     }
 
                     (function(i) {
+                        if ($rootScope.relatedReferences[i].canCreate && $rootScope.modifyRecord && !$rootScope.showEmptyRelatedTables) {
+                            $rootScope.showEmptyRelatedTables = true;
+                        }
                         $rootScope.relatedReferences[i].read(pageSize).then(function (page) {
                             var model = {
                                 reference: $rootScope.relatedReferences[i],

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -10,7 +10,6 @@
         var updated = {};
 
         vm.alerts = AlertsService.alerts;
-        vm.showEmptyRelatedTables = false;
         vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
 
         vm.canCreate = function() {
@@ -97,7 +96,7 @@
                     $rootScope.loading = false;
                 }
 
-                if (vm.showEmptyRelatedTables) {
+                if ($rootScope.showEmptyRelatedTables) {
                     return isFirst || prevTableHasLoaded;
                 }
 
@@ -118,15 +117,11 @@
         };
 
         vm.toggleRelatedTables = function() {
-            vm.showEmptyRelatedTables = !vm.showEmptyRelatedTables;
+            $rootScope.showEmptyRelatedTables = !$rootScope.showEmptyRelatedTables;
         };
 
         vm.canCreateRelated = function(relatedRef) {
-            var canCreate = (relatedRef.canCreate && $rootScope.modifyRecord);
-            if (canCreate && !vm.showEmptyRelatedTables) {
-                vm.showEmptyRelatedTables = canCreate;
-            }
-            return canCreate;
+            return (relatedRef.canCreate && $rootScope.modifyRecord);
         };
 
         // Send user to RecordEdit to create a new row in this related table

--- a/test/e2e/data_setup/data/product/accommodation.json
+++ b/test/e2e/data_setup/data/product/accommodation.json
@@ -63,8 +63,6 @@
  "rating": 4.2,
  "summary": "Great Hotel. We've got the best prices out of anyone. Stay here to make America great again. Located near shopping areas with easy access to parking. Professional staff and clean rooms. Poorly-maintained rooms.",
  "description": "** CARING. SHARING. DARING.**\nRadisson^®^ is synonymous with outstanding levels of service and comfort delivered with utmost style. And today, we deliver even more to make sure we maintain our position at the forefront of the hospitality industry now and in the future.\nOur hotels are service driven, responsible, socially and locally connected and demonstrate a modern friendly attitude in everything we do. Our aim is to deliver our outstanding `Yes I Can!` ^SM^ service, comfort and style where you need us.\n\n**THE RADISSON^®^ WAY** Always positive, always smiling and always professional, Radisson people set Radisson apart. Every member of the team has a dedication to `Yes I Can!` ^SM^ hospitality – a passion for ensuring the total wellbeing and satisfaction of each individual guest. Imaginative, understanding and truly empathetic to the needs of the modern traveler, they are people on a special mission to deliver exceptional Extra Thoughtful Care.",
- "thumbnail": 3003,
- "cover": 3011,
  "opened_on": "2013-06-11T00:00:00-07:00",
  "luxurious": true
 }]

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -119,17 +119,17 @@ describe('View existing record,', function() {
             }, browser.params.defaultTimeout);
 
             chaisePage.recordPage.getRelatedTables().count().then(function(count) {
-                expect(count).toBe(testParams.no_related_data.tables_order.length);
+                expect(count).toBe(testParams.no_related_data.tables_order.length, "Number of related tables is not correct");
 
                 return chaisePage.recordPage.getRelatedTableTitles();
             }).then(function(headings) {
-                expect(headings).toEqual(testParams.no_related_data.tables_order);
+                expect(headings).toEqual(testParams.no_related_data.tables_order, "Related tables in the wrong order or the name is wrong");
 
-                expect(showAllRTButton.getText()).toBe("Hide Empty Related Records");
+                expect(showAllRTButton.getText()).toBe("Hide Empty Related Records", "Sow all Related tables button has wrong text");
                 return showAllRTButton.click();
             }).then(function() {
-                expect(chaisePage.recordPage.getRelatedTables().count()).toBe(0);
-                expect(chaisePage.recordPage.getRelatedTables().count()).not.toBe(testParams.no_related_data.tables_order.length);
+                expect(chaisePage.recordPage.getRelatedTables().count()).toBe(0, "Not all the related tables were hidden");
+                expect(chaisePage.recordPage.getRelatedTables().count()).not.toBe(testParams.no_related_data.tables_order.length, "The full set of related tables were not properly hidden");
             })
         });
     });

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -58,7 +58,7 @@ var testParams = {
             value: "4004",
             operator: "="
         },
-        tables_order: ["booking (Showing first 0 result)", "accommodation_image (Showing first 0 result)", "media (Showing first 0 result)"]
+        tables_order: ["booking (no results found)", "accommodation_image (no results found)", "media (no results found)"]
     }
 };
 

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -51,14 +51,20 @@ var testParams = {
         { title: "Thumbnail", value: null, type: "int4"},
         { title: "Operational Since", value: "2008-12-09 00:00:00", type: "timestamptz" },
         { title: "Is Luxurious", value: "true", type: "boolean" }
-    ]
+    ],
+    no_related_data: {
+        key: {
+            name: "id",
+            value: "4004",
+            operator: "="
+        },
+        tables_order: ["booking (Showing first 0 result)", "accommodation_image (Showing first 0 result)", "media (Showing first 0 result)"]
+    }
 };
 
 describe('View existing record,', function() {
 
     describe("For table " + testParams.table_name + ",", function() {
-
-        var table, record;
 
         beforeAll(function() {
             var keys = [];
@@ -66,7 +72,6 @@ describe('View existing record,', function() {
             browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name + "/" + keys.join("&");
             browser.get(url);
-            table = browser.params.defaultSchema.content.tables[testParams.table_name];
             var start = (new Date()).getTime();
             chaisePage.waitForElement(element(by.id('tblRecord'))).then(function() {
                 console.log((new Date()).getTime() - start);
@@ -91,5 +96,41 @@ describe('View existing record,', function() {
             var params = recordHelpers.testPresentation(testParams);
         });
 
+    });
+
+    describe("For a record with all of it's related tables as empty", function() {
+
+        beforeAll(function() {
+            var keys = [];
+            keys.push(testParams.no_related_data.key.name + testParams.no_related_data.key.operator + testParams.no_related_data.key.value);
+            browser.ignoreSynchronization=true;
+            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name + "/" + keys.join("&");
+            browser.get(url);
+            chaisePage.waitForElement(element(by.id('tblRecord')));
+        });
+
+        it("should show all of the related tables in the correct order.", function() {
+            var showAllRTButton = chaisePage.recordPage.getShowAllRelatedEntitiesButton();
+
+            browser.wait(function() {
+                return chaisePage.recordPage.getRelatedTables().count().then(function(ct) {
+                    return (ct=testParams.no_related_data.tables_order.length);
+                });
+            }, browser.params.defaultTimeout);
+
+            chaisePage.recordPage.getRelatedTables().count().then(function(count) {
+                expect(count).toBe(testParams.no_related_data.tables_order.length);
+
+                return chaisePage.recordPage.getRelatedTableTitles();
+            }).then(function(headings) {
+                expect(headings).toEqual(testParams.no_related_data.tables_order);
+
+                expect(showAllRTButton.getText()).toBe("Hide Empty Related Records");
+                return showAllRTButton.click();
+            }).then(function() {
+                expect(chaisePage.recordPage.getRelatedTables().count()).toBe(0);
+                expect(chaisePage.recordPage.getRelatedTables().count()).not.toBe(testParams.no_related_data.tables_order.length);
+            })
+        });
     });
 });

--- a/test/e2e/specs/default-config/record/related-table-actions.spec.js
+++ b/test/e2e/specs/default-config/record/related-table-actions.spec.js
@@ -83,6 +83,7 @@ describe('View existing record,', function() {
                 var deleteButton;
                 var relatedTableName = testParams.related_regular_table;
                 var count, rowCells, oldValue;
+                var relatedTableHeading = chaisePage.recordPage.getRelatedTableHeadingTitle(relatedTableName);
 
                 var EC = protractor.ExpectedConditions;
                 var e = element(by.id('rt-' + relatedTableName));
@@ -111,6 +112,7 @@ describe('View existing record,', function() {
                     return confirmButton.click();
                 }).then(function() {
                     browser.wait(EC.stalenessOf(rowCells[1]), browser.params.defaultTimeout);
+                    expect(relatedTableHeading.getText()).toBe("booking (showing all 5 results)");
                 });
             });
 
@@ -118,6 +120,7 @@ describe('View existing record,', function() {
                 var deleteButton;
                 var relatedTableName = testParams.related_associate_table;
                 var count, rowCells, oldValue;
+                var relatedTableHeading = chaisePage.recordPage.getRelatedTableHeadingTitle(relatedTableName);
 
                 var table = chaisePage.recordPage.getRelatedTable(relatedTableName);
 
@@ -142,7 +145,8 @@ describe('View existing record,', function() {
                     return confirmButton.click();
                 }).then(function() {
                     browser.wait(function() {return rowCells[1].getAttribute('innerHTML') !== oldValue}, browser.params.defaultTimeout);
-                })
+                    expect(relatedTableHeading.getText()).toBe("accommodation_image (showing first 2 results)");
+                });
             });
         });
     });

--- a/test/e2e/specs/default-config/record/related-table-actions.spec.js
+++ b/test/e2e/specs/default-config/record/related-table-actions.spec.js
@@ -112,7 +112,7 @@ describe('View existing record,', function() {
                     return confirmButton.click();
                 }).then(function() {
                     browser.wait(EC.stalenessOf(rowCells[1]), browser.params.defaultTimeout);
-                    expect(relatedTableHeading.getText()).toBe("booking (showing all 5 results)");
+                    expect(relatedTableHeading.getText()).toBe("booking (showing all 5 results)", "Booking related table heading did not update");
                 });
             });
 
@@ -145,7 +145,7 @@ describe('View existing record,', function() {
                     return confirmButton.click();
                 }).then(function() {
                     browser.wait(function() {return rowCells[1].getAttribute('innerHTML') !== oldValue}, browser.params.defaultTimeout);
-                    expect(relatedTableHeading.getText()).toBe("accommodation_image (showing first 2 results)");
+                    expect(relatedTableHeading.getText()).toBe("accommodation_image (showing first 2 results)", "Accomodation image related table heading did not update");
                 });
             });
         });

--- a/test/e2e/specs/default-config/record/related-table-link.spec.js
+++ b/test/e2e/specs/default-config/record/related-table-link.spec.js
@@ -176,7 +176,8 @@ describe('View existing record,', function() {
                         relatedTableName = testParams.related_regular_table,
                         relatedTableSubtitle = testParams.related_regular_subtitle,
                         relatedTableLink = chaisePage.recordPage.getMoreResultsLink(relatedTableName),
-                        relatedUnfilteredLink = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + relatedTableName;
+                        relatedUnfilteredLink = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + relatedTableName,
+                        relatedTableHeading = chaisePage.recordPage.getRelatedTableHeadingTitle(relatedTableName);
 
                     browser.wait(EC.visibilityOf(relatedTableLink), browser.params.defaultTimeout).then(function() {
                         // waits until the count is what we expect, so we know the refresh occured
@@ -189,6 +190,7 @@ describe('View existing record,', function() {
                         return chaisePage.recordPage.getRelatedTableRows(relatedTableName).count();
                     }).then(function(count) {
                         expect(count).toBe(testParams.booking_count + 1);
+                        expect(relatedTableHeading.getText()).toBe("booking (showing all 7 results)");
                         expect(relatedTableLink.isDisplayed()).toBeTruthy();
                         return relatedTableLink.click();
                     }).then(function() {

--- a/test/e2e/specs/default-config/record/related-table-link.spec.js
+++ b/test/e2e/specs/default-config/record/related-table-link.spec.js
@@ -190,7 +190,7 @@ describe('View existing record,', function() {
                         return chaisePage.recordPage.getRelatedTableRows(relatedTableName).count();
                     }).then(function(count) {
                         expect(count).toBe(testParams.booking_count + 1);
-                        expect(relatedTableHeading.getText()).toBe("booking (showing all 7 results)");
+                        expect(relatedTableHeading.getText()).toBe("booking (showing all 7 results)", "Booking related table heading did not update");
                         expect(relatedTableLink.isDisplayed()).toBeTruthy();
                         return relatedTableLink.click();
                     }).then(function() {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -621,6 +621,11 @@ var recordPage = function() {
         return element(by.id("rt-heading-" + displayName));
     };
 
+    this.getRelatedTableHeadingTitle = function(displayname) {
+        displayName = makeSafeIdAttr(displayname);
+        return element(by.id("rt-heading-" + displayName)).element(by.css('.panel-title'))
+    };
+
     this.getRelatedTableColumnNamesByTable = function(displayName) {
         displayName = makeSafeIdAttr(displayName);
         return element(by.id("rt-" + displayName)).all(by.css(".table-column-displayname > span"));

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -185,16 +185,16 @@ exports.testPresentation = function (tableParams) {
                         expect(rowCount).toBe(relatedTables[i].data.length);
 
                         // Because this spec is reused in multiple recordedit tests, this if-else branching just ensures the correct expectation is used depending on which table is encountered
-												if (displayName == tableParams.related_table_name_with_page_size_annotation) {
-             // The annotation_image table has more rows than the page_size, so its heading will have a + after the row count
-             expect(headings[i]).toBe(title + " (showing first " + rowCount + " results)");
-           } else if (rowCount == 0) {
-             // All other tables should not have the + at the end its heading
-             expect(headings[i]).toBe(title + " (no results found)");
-           } else {
-             expect(headings[i]).toBe(title + " (showing all " + rowCount + " results)");
-           }
-         });
+                        if (displayName == tableParams.related_table_name_with_page_size_annotation) {
+                            // The annotation_image table has more rows than the page_size, so its heading will have a + after the row count
+                            expect(headings[i]).toBe(title + " (showing first " + rowCount + " results)");
+                        } else if (rowCount == 0) {
+                            // All other tables should not have the + at the end its heading
+                            expect(headings[i]).toBe(title + " (no results found)");
+                        } else {
+                            expect(headings[i]).toBe(title + " (showing all " + rowCount + " results)");
+                        }
+                    });
                 })(i, displayName, title);
             }
         });


### PR DESCRIPTION
This PR fixes issue #1161.

The related tables were not showing up by default when the user could add/edit the entities in them if those tables were empty. This is fixed by moving the logic to the `run` block. How it was defined before, it was relying on `formController.canCreateRelated()` being called. When none of the related tables had entities in them, this function was never executed in the html and therefore never updated the state for the page.