### PR TITLE
related tables load after record display

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -48,47 +48,48 @@
             </div>
 
             <!-- defined on $rootScope in run function -->
-            <div ng-if="recordValues && columns">
-                <record-display columns="::columns" values="::recordValues"></record-display>
-            </div>
+            <record-display columns="::columns" values="::recordValues"></record-display>
 
-            <uib-accordion close-others="false">
-                <div uib-accordion-group class="related-table-heading" id="rt-heading-{{::ctrl.makeSafeIdAttr(relatedRef.displayname.value)}}" ng-repeat="relatedRef in relatedReferences track by $index" ng-if="ctrl.showRelatedTable($index)" is-open="tableModels[$index].open">
-                    <uib-accordion-heading>
-                        <i class="pull-left glyphicon" style="margin-right: 5px;" ng-class="{'glyphicon-chevron-down': tableModels[$index].open, 'glyphicon-chevron-right': !tableModels[$index].open}"></i>
-                        <span ng-if="::relatedRef.displayname.isHTML" ng-bind-html="::relatedRef.displayname.value"></span><span ng-if="::!relatedRef.displayname.isHTML" ng-bind="::relatedRef.displayname.value"></span> <span ng-if="tableModels[$index].rowValues.length==0">(no results found)</span><span ng-if="tableModels[$index].rowValues.length!=0">(showing {{::tableModels[$index].hasNext ? 'first' : 'all'}} {{tableModels[$index].rowValues.length}} results)</span>
-                    </uib-accordion-heading>
+            <!-- used to delay empty accordions from displaying before simple record display -->
+            <div ng-if="recordValues">
+                <uib-accordion close-others="false">
+                    <div uib-accordion-group class="related-table-heading" id="rt-heading-{{::ctrl.makeSafeIdAttr(relatedRef.displayname.value)}}" ng-repeat="relatedRef in relatedReferences track by $index" ng-if="ctrl.showRelatedTable($index)" is-open="tableModels[$index].open">
+                        <uib-accordion-heading>
+                            <i class="pull-left glyphicon" style="margin-right: 5px;" ng-class="{'glyphicon-chevron-down': tableModels[$index].open, 'glyphicon-chevron-right': !tableModels[$index].open}"></i>
+                            <span ng-if="::relatedRef.displayname.isHTML" ng-bind-html="::relatedRef.displayname.value"></span><span ng-if="::!relatedRef.displayname.isHTML" ng-bind="::relatedRef.displayname.value"></span> <span ng-if="tableModels[$index].rowValues.length==0">(no results found)</span><span ng-if="tableModels[$index].rowValues.length!=0">(showing {{::tableModels[$index].hasNext ? 'first' : 'all'}} {{tableModels[$index].rowValues.length}} results)</span>
+                        </uib-accordion-heading>
 
-                    <!-- for different elements inside the accordion -->
-                    <div class="pull-right" style="margin-top:-25px;">
-                        <span ng-if="relatedRef.display.type == 'markdown'">
-                            <a class="toggle-display-link" ng-click="::ctrl.toggleRelatedTableDisplayType($index)">
-                                <span ng-show="tableModels[$index].displayType == 'markdown'">
-                                    <span ng-if="::ctrl.canEdit()">Edit</span>
-                                    <span ng-if="::(!ctrl.canEdit())">Table Display</span>
-                                </span>
-                                <span ng-show="tableModels[$index].displayType != 'markdown'">
-                                    <span ng-if="::ctrl.canEdit()">Display</span>
-                                    <span ng-if="::(!ctrl.canEdit())">Revert Display</span>
-                                </span>
-                            </a>&nbsp;|</span>
-                        <span ng-if="::ctrl.canCreateRelated(relatedRef)">
-                            <a class="add-records-link" ng-click="::ctrl.addRelatedRecord(relatedRef)">Add</a>
-                            &nbsp;|</span>
-                        <span><a class="more-results-link" ng-click="::ctrl.toRecordSet(relatedRef)">View More</a></span>
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-12">
-                            <div ng-show="tableModels[$index].displayType == 'markdown'">
-                                <span class="markdown-container" ng-bind-html="::tableModels[$index].page.content | trustedHTML"></span>
-                            </div>
-                            <div ng-show="tableModels[$index].displayType != 'markdown'">
-                                <record-table class="related-table" id="rt-{{::ctrl.makeSafeIdAttr(relatedRef.displayname.value)}}" vm="::tableModels[$index]"></record-table>
+                        <!-- for different elements inside the accordion -->
+                        <div class="pull-right" style="margin-top:-25px;">
+                            <span ng-if="relatedRef.display.type == 'markdown'">
+                                <a class="toggle-display-link" ng-click="::ctrl.toggleRelatedTableDisplayType($index)">
+                                    <span ng-show="tableModels[$index].displayType == 'markdown'">
+                                        <span ng-if="::ctrl.canEdit()">Edit</span>
+                                        <span ng-if="::(!ctrl.canEdit())">Table Display</span>
+                                    </span>
+                                    <span ng-show="tableModels[$index].displayType != 'markdown'">
+                                        <span ng-if="::ctrl.canEdit()">Display</span>
+                                        <span ng-if="::(!ctrl.canEdit())">Revert Display</span>
+                                    </span>
+                                </a>&nbsp;|</span>
+                            <span ng-if="::ctrl.canCreateRelated(relatedRef)">
+                                <a class="add-records-link" ng-click="::ctrl.addRelatedRecord(relatedRef)">Add</a>
+                                &nbsp;|</span>
+                            <span><a class="more-results-link" ng-click="::ctrl.toRecordSet(relatedRef)">View More</a></span>
+                        </div>
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <div ng-show="tableModels[$index].displayType == 'markdown'">
+                                    <span class="markdown-container" ng-bind-html="::tableModels[$index].page.content | trustedHTML"></span>
+                                </div>
+                                <div ng-show="tableModels[$index].displayType != 'markdown'">
+                                    <record-table class="related-table" id="rt-{{::ctrl.makeSafeIdAttr(relatedRef.displayname.value)}}" vm="::tableModels[$index]"></record-table>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            </uib-accordion>
+                </uib-accordion>
+            </div>
             <span id="rt-loading" ng-show="loading">Loading...</span>
         </div>
     </div>

--- a/test/e2e/specs/default-config/record/related-table-link.spec.js
+++ b/test/e2e/specs/default-config/record/related-table-link.spec.js
@@ -29,15 +29,13 @@ describe('View existing record,', function() {
 
     describe("For table " + testParams.table_name + ",", function() {
 
-        beforeAll(function(done) {
+        beforeAll(function() {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
             browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name + "/" + keys.join("&");
             browser.get(url);
-            chaisePage.waitForElement(element(by.id('tblRecord'))).then(function() {
-                done();
-            });
+            chaisePage.waitForElement(element(by.id('rt-accommodation_image')));
         });
 
         describe("Show the related entity tables,", function() {
@@ -109,7 +107,7 @@ describe('View existing record,', function() {
 
             describe("for a related entity without an association table", function() {
                 it('should have an "Add" link for a related table that redirects to that related table in recordedit with a prefill query parameter.', function() {
-                                    
+
                     var EC = protractor.ExpectedConditions, newTabUrl,
                         relatedTableName = testParams.related_regular_table,
                         addRelatedRecordLink = chaisePage.recordPage.getAddRecordLink(relatedTableName);


### PR DESCRIPTION
This PR addresses issue #1082.

Removed the unnecessary `ng-if` around the record display and now force the related tables to load only once the `recordValues` array is defined.