### PR TITLE
Remove Duplicated Parser Logic

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -182,9 +182,34 @@
             }
             return url;
         }
+        
+        
+        /**
+         * Return query params
+         * @param  {Object} location window.location object
+         * @return {Object} key-value pairs of query params
+         */
+        function getQueryParams(location) {
+            var queryParams = {}, 
+                modifierPath = location.hash,
+                q_parts, i;
+
+            if (modifierPath.indexOf("?") !== -1) {
+                var queries = modifierPath.match(/\?(.+)/)[1].split("&");
+                for (i = 0; i < queries.length; i++) {
+                    q_parts = queries[i].split("=");
+                    queryParams[decodeURIComponent(q_parts[0])] = decodeURIComponent(q_parts[1]);
+                }
+            }
+            return queryParams;
+        }
 
         /**
+         * NOTE: DO NOT USE THIS FUNCTION, EMRESTJS will take care of parsing.
+         * old apps is using are, that's why we should still keep this function.
+         * 
          * @function
+         * @deprecated
          * @param {Object} location should be $window.location object
          * @param {context} context object; can be null
          * Parses the URL to create the context object
@@ -524,7 +549,8 @@
             setOrigin: setOrigin,
             parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
             setLocationChangeHandling: setLocationChangeHandling,
-            isBrowserIE: isBrowserIE
+            isBrowserIE: isBrowserIE,
+            getQueryParams: getQueryParams
         }
     }])
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -49,13 +49,11 @@
 
         var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
 
-        context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
+        $rootScope.context = context;
 
         // The context object won't change unless the app is reloaded
         context.appName = "record";
         context.pageId = MathUtils.uuid();
-
-        DataUtils.verify(context.filter, 'No filter was defined. Cannot find a record without a filter.');
 
         ERMrest.appLinkFn(UriUtils.appTagToURL);
 
@@ -66,6 +64,8 @@
             Session.unsubscribeOnChange(subId);
 
             ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
+                DataUtils.verify(reference.location.filter, 'No filter was defined. Cannot find a record without a filter.');
+                
                 // if the user can fetch the reference, they can see the content for the rest of the page
                 // set loading to force the loading text to appear and to prevent the on focus from firing while code is initializing
                 session = Session.getSessionValue();

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -51,10 +51,7 @@
         };
 
         vm.permalink = function getPermalink() {
-            if (!$rootScope.reference) {
-                return $window.location.href;
-            }
-            return $rootScope.context.mainURI;
+            return $window.location.href;
         };
 
         vm.toRecordSet = function(ref) {

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -62,8 +62,19 @@
         }
 
         var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
-
-        context = $rootScope.context = UriUtils.parseURLFragment($window.location, context);
+        
+        $rootScope.context = context;
+        
+        // we are using filter to determine app mode, the logic for getting filter
+        // should be in the parser and we should not duplicate it in here
+        // NOTE: we might need to change this line (we're parsing the whole url just for fidinig if there's filter)
+        context.filter = ERMrest.parse(ermrestUri).filter;
+        
+        // will be used to determine the app mode (edit, create, or copy)
+        // We are not passing the query parameters that are used for app mode,
+        // so we cannot use the queryParams that parser is returning.
+        context.queryParams = UriUtils.getQueryParams($window.location);
+        
         context.appName = "recordedit";
         context.pageId = MathUtils.uuid();
         context.MAX_ROWS_TO_ADD = 201;

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -79,14 +79,6 @@
         $scope.navbarBrandImage = (chaiseConfig['navbarBrandImage'] !== undefined? chaiseConfig.navbarBrandImage : "");
         $scope.navbarBrandText = (chaiseConfig['navbarBrandText'] !== undefined? chaiseConfig.navbarBrandText : "Chaise");
 
-        $scope.login = function() {
-            Session.login($window.location.href);
-        };
-
-        $scope.logout = function() {
-            Session.logout();
-        };
-
         // row data updated from directive
         // update permalink, address bar without reload
         $scope.$on('recordset-update', function() {
@@ -160,23 +152,10 @@
 
             $rootScope.alerts = AlertsService.alerts;
 
-            // parse the URL
-            var p_context = UriUtils.parseURLFragment($window.location);
-
             $rootScope.location = $window.location.href;
             recordsetModel.hasLoaded = false;
             $rootScope.context = context;
 
-            context.mainURI = p_context.mainURI;
-
-            // only allowing single column sort here
-            if (p_context.sort) {
-                recordsetModel.sortby = p_context.sort[0].column;
-                recordsetModel.sortOrder = (p_context.sort[0].descending ? "desc" : "asc");
-            }
-
-            context.catalogID = p_context.catalogID;
-            context.tableName = p_context.tableName;
             context.pageId = MathUtils.uuid();
 
             var ermrestUri = UriUtils.chaiseURItoErmrestURI($window.location);
@@ -192,6 +171,16 @@
 
                 ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
                     session = Session.getSessionValue();
+                    
+                    var location = reference.location;
+                    
+                    // only allowing single column sort here
+                    if (reference.sortObject) {
+                        recordsetModel.sortby = location.sortObject[0].column;
+                        recordsetModel.sortOrder = (location.sortObject[0].descending ? "desc" : "asc");
+                    }
+                    context.catalogID = reference.table.schema.catalog.id;
+                    context.tableName = reference.table.name;
 
                     recordsetModel.reference = reference.contextualize.compact;
                     recordsetModel.context = "compact";
@@ -199,17 +188,18 @@
 
                     $log.info("Reference:", recordsetModel.reference);
 
-                    if (p_context.queryParams.limit)
-                        recordsetModel.pageLimit = parseInt(p_context.queryParams.limit);
-                    else if (recordsetModel.reference.display.defaultPageSize)
+                    if (location.queryParams.limit) {
+                        recordsetModel.pageLimit = parseInt(location.queryParams.limit);
+                    } else if (recordsetModel.reference.display.defaultPageSize) {
                         recordsetModel.pageLimit = recordsetModel.reference.display.defaultPageSize;
-                    else
+                    } else {
                         recordsetModel.pageLimit = 25;
+                    }
                     recordsetModel.tableDisplayName = recordsetModel.reference.displayname;
 
                      // the additional provided name
-                    if (p_context.queryParams && p_context.queryParams.subset) {
-                        recordsetModel.subTitle = p_context.queryParams.subset;
+                    if (location.queryParams && location.queryParams.subset) {
+                        recordsetModel.subTitle = location.queryParams.subset;
                     }
 
                     recordsetModel.columns = recordsetModel.reference.columns;


### PR DESCRIPTION
I didn't completely remove the `parseURLFragment` function because viewer app is still using it. But we should avoid using this function.

The reason that recordedit is calling parser directly is that it is using filter to determine the app mode (create, edit, or copy) and the controller expects this decision to be made by page load (not after reference is resolved).

Needs [ermrest#445](https://github.com/informatics-isi-edu/ermrestjs/pull/445) changes.