### PR TITLE
Fix for the spinner issue

### DIFF
--- a/record/record.app.js
+++ b/record/record.app.js
@@ -171,9 +171,11 @@
                         });
                     })(i);
                 }
+                $rootScope.displayReady = true;
             }).catch(function genericCatch(exception) {
                 throw exception;
             });
+            
         })
 
 


### PR DESCRIPTION
For a record which does not have related entities, the spinner was never set to off, as the spinner was set to off inside the for loop of related entities.

Now, the spinner display is set to off outside the for loop for related references, so that it works fine for the record which does not have any related references.