### PR TITLE
Code changes to solve Login confirmation page 'not found' issue #1130

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -21,6 +21,19 @@
             }
         };
         
+        var getDepPathName = function() {
+            var location = window.location;
+            var splits = location.pathname.split('/');
+            splits.splice(0, 1);
+            if(splits[splits.length-1] == ""){
+                splits.splice(splits.length-1, 1);
+            }
+            if(splits[splits.length-1].indexOf('index.html') != -1){
+                splits.splice(splits.length-1, 1);
+            }
+            splits.splice(splits.length-1, 1);
+            return splits.join('/');
+        };
         
         var loginWindowCb = function (params, referrerId, cb, type){
             if(type.indexOf('modal')!== -1){
@@ -102,9 +115,8 @@
         
         var logInHelper = function(logInTypeCb, win, cb, type){
             var referrerId = (new Date().getTime());    
-            var location = window.location;
-            var subUrl =  location.pathname.split('/')[1].indexOf('~')!= -1 ? location.pathname.split('/')[2]: location.pathname.split('/')[1];
-            var url = serviceURL + '/authn/preauth?referrer='+UriUtils.fixedEncodeURIComponent(location.origin+"/"+subUrl + "/login?referrerid=" + referrerId);
+            
+            var url = serviceURL + '/authn/preauth?referrer='+UriUtils.fixedEncodeURIComponent(location.origin+"/"+getDepPathName() + "/login?referrerid=" + referrerId);
             var config = {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/common/authen.js
+++ b/common/authen.js
@@ -101,8 +101,10 @@
         
         
         var logInHelper = function(logInTypeCb, win, cb, type){
-            var referrerId = (new Date().getTime());
-            var url = serviceURL + '/authn/preauth?referrer=' + UriUtils.fixedEncodeURIComponent(window.location.href.substring(0,window.location.href.indexOf('chaise')) + "chaise/login?referrerid=" + referrerId);
+            var referrerId = (new Date().getTime());    
+            var location = window.location;
+            var subUrl =  location.pathname.split('/')[1].indexOf('~')!= -1 ? location.pathname.split('/')[2]: location.pathname.split('/')[1];
+            var url = serviceURL + '/authn/preauth?referrer='+UriUtils.fixedEncodeURIComponent(location.origin+"/"+subUrl + "/login?referrerid=" + referrerId);
             var config = {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/common/authen.js
+++ b/common/authen.js
@@ -21,6 +21,10 @@
             }
         };
         
+        /**
+         * Return deployment specific path name
+         * @return {String} string representation of the path name "~username/chaise", "chaise", "path/to/deployment/data"
+         */
         var getDepPathName = function() {
             var location = window.location;
             var splits = location.pathname.split('/');
@@ -28,7 +32,7 @@
             if(splits[splits.length-1] == ""){
                 splits.splice(splits.length-1, 1);
             }
-            if(splits[splits.length-1].indexOf('index.html') != -1){
+            if(splits[splits.length-1] == 'index.html'){
                 splits.splice(splits.length-1, 1);
             }
             splits.splice(splits.length-1, 1);


### PR DESCRIPTION
When using the new modal login window for the OAuth login flow, at the end you should see a login confirmation page, but instead, the URL is wrong and therefore the page is 'not found'.

This PR addresses this issue and now the path is framed dynamically using the `window.location` and the hard coding of `chaise` has been removed