### PR TITLE
Rs aggregate count

### DIFF
--- a/common/modal.js
+++ b/common/modal.js
@@ -94,7 +94,7 @@
                 vm.tableModel.page = page;
                 vm.tableModel.rowValues = DataUtils.getRowValuesFromPage(page);
 
-                $scope.$broadcast('get-table-aggregate-count', true);
+                $scope.$broadcast('recordset-update');
             }, function(exception) {
                 throw exception;
             });

--- a/common/modal.js
+++ b/common/modal.js
@@ -93,6 +93,8 @@
                 vm.tableModel.initialized = true;
                 vm.tableModel.page = page;
                 vm.tableModel.rowValues = DataUtils.getRowValuesFromPage(page);
+
+                $scope.$broadcast('get-table-aggregate-count', true);
             }, function(exception) {
                 throw exception;
             });

--- a/common/table.js
+++ b/common/table.js
@@ -342,6 +342,17 @@
                 window.updated = function() {
                     updated = true;
                 }
+
+                // get the total row count to display above the table
+                scope.$on('recordset-loaded', function($event, hasLoaded) {
+                    if (hasLoaded) {
+                        scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
+                            scope.vm.totalRowsCnt = response[0];
+                        }, function error(response) {
+                            throw response;
+                        });
+                    }
+                });
             }
         };
     }]);

--- a/common/table.js
+++ b/common/table.js
@@ -344,7 +344,7 @@
                 }
 
                 // get the total row count to display above the table
-                scope.$on('recordset-loaded', function($event, hasLoaded) {
+                scope.$on('get-table-aggregate-count', function($event, hasLoaded) {
                     if (hasLoaded) {
                         scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
                             scope.vm.totalRowsCnt = response[0];

--- a/common/table.js
+++ b/common/table.js
@@ -351,6 +351,13 @@
                 scope.$on('recordset-update', function($event) {
                     if(scope.vm.search == scope.vm.reference.location.searchTerm) {
                         scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
+                            // NOTE: scenario: A user triggered a foreground search. Once it returns the aggregate count request is queued.
+                            // While that request is running, the user triggers another foreground search.
+                            // How do we avoid one aggregate count query to not show when it isn't relevant to the displayed data?
+                            // Maybe comparing reference.location.searchTerm and vm.search here instead and if they don't match,
+                            // set the value to null so the count displayed is just the count of the shown rows until the latter
+                            // aggregate count request returns. If the latter one never returns (because of a server error or something),
+                            // at least the UI doesn't show any misleading information.
                             scope.vm.totalRowsCnt = response[0];
                         }, function error(response) {
                             throw response;

--- a/common/table.js
+++ b/common/table.js
@@ -346,8 +346,6 @@
 
                 // get the total row count to display above the table
                 scope.$on('recordset-update', function($event) {
-                    console.log("Search term: ", scope.vm.search);
-                    console.log(scope.vm.reference.location.searchTerm);
                     if(scope.vm.search == scope.vm.reference.location.searchTerm) {
                         scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
                             scope.vm.totalRowsCnt = response[0];

--- a/common/table.js
+++ b/common/table.js
@@ -131,7 +131,9 @@
                 }, 200);
 
                 // tell parent controller data updated
-                scope.$emit('recordset-update');
+                if (!scope.vm.foregroundSearch) {
+                    scope.$emit('recordset-update');
+                }
 
             }, function error(exception) {
                 scope.vm.hasLoaded = true;
@@ -344,14 +346,12 @@
                 }
 
                 // get the total row count to display above the table
-                scope.$on('get-table-aggregate-count', function($event, hasLoaded) {
-                    if (hasLoaded) {
-                        scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
-                            scope.vm.totalRowsCnt = response[0];
-                        }, function error(response) {
-                            throw response;
-                        });
-                    }
+                scope.$on('recordset-update', function($event) {
+                    scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
+                        scope.vm.totalRowsCnt = response[0];
+                    }, function error(response) {
+                        throw response;
+                    });
                 });
             }
         };

--- a/common/table.js
+++ b/common/table.js
@@ -110,6 +110,7 @@
             if (isBackground) {
                 if (!scope.vm.foregroundSearch) {
                     scope.vm.backgroundSearch = true;
+                    scope.vm.totalRowsCnt = null;
                 } else {
                     scope.vm.backgroundSearchPendingTerm = null;
                     scope.vm.backgroundSearch = false;
@@ -132,7 +133,9 @@
                 }, 200);
 
                 // tell parent controller data updated
-                scope.$emit('recordset-update');
+                if (!isBackground) {
+                    scope.$emit('recordset-update');
+                }
 
             }, function error(exception) {
                 scope.vm.hasLoaded = true;

--- a/common/table.js
+++ b/common/table.js
@@ -100,6 +100,7 @@
         */
         function read(scope, isBackground) {
 
+            if (scope.vm.search == '') scope.vm.search = null;
             var searchTerm = scope.vm.search;
 
             scope.vm.hasLoaded = false;
@@ -131,9 +132,7 @@
                 }, 200);
 
                 // tell parent controller data updated
-                if (!scope.vm.foregroundSearch) {
-                    scope.$emit('recordset-update');
-                }
+                scope.$emit('recordset-update');
 
             }, function error(exception) {
                 scope.vm.hasLoaded = true;
@@ -347,11 +346,15 @@
 
                 // get the total row count to display above the table
                 scope.$on('recordset-update', function($event) {
-                    scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
-                        scope.vm.totalRowsCnt = response[0];
-                    }, function error(response) {
-                        throw response;
-                    });
+                    console.log("Search term: ", scope.vm.search);
+                    console.log(scope.vm.reference.location.searchTerm);
+                    if(scope.vm.search == scope.vm.reference.location.searchTerm) {
+                        scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
+                            scope.vm.totalRowsCnt = response[0];
+                        }, function error(response) {
+                            throw response;
+                        });
+                    }
                 });
             }
         };

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -50,6 +50,7 @@
 
 <!-- record table -->
 <div ng-if="vm.hasLoaded">
+    <h4>Displaying {{vm.rowValues.length}}{{vm.totalRowsCnt ? " of " + vm.totalRowsCnt : ''}} Records</h4>
     <record-table id="rs-{{vm.makeSafeIdAttr(vm.tableDisplayName.value)}}" vm="vm" on-row-click-bind="onRowClick"></record-table>
 </div>
 

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -50,7 +50,7 @@
 
 <!-- record table -->
 <div ng-if="vm.hasLoaded">
-    <h4>Displaying {{vm.rowValues.length}}{{vm.totalRowsCnt ? " of " + vm.totalRowsCnt : ''}} Records</h4>
+    <h4 id="rs-total-count">Displaying {{vm.rowValues.length}}{{vm.totalRowsCnt ? " of " + vm.totalRowsCnt : ''}} Records</h4>
     <record-table id="rs-{{vm.makeSafeIdAttr(vm.tableDisplayName.value)}}" vm="vm" on-row-click-bind="onRowClick"></record-table>
 </div>
 

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -215,7 +215,7 @@
                     recordsetModel.initialized = true;
                     recordsetModel.hasLoaded = true;
 
-                    $rootScope.$broadcast('get-table-aggregate-count', true);
+                    $rootScope.$broadcast('recordset-update');
 
                 }, function error(response) {
                     throw response;

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -172,9 +172,9 @@
 
                 ERMrest.resolve(ermrestUri, {cid: context.appName, pid: context.pageId, wid: $window.name}).then(function getReference(reference) {
                     session = Session.getSessionValue();
-                    
+
                     var location = reference.location;
-                    
+
                     // only allowing single column sort here
                     if (reference.sortObject) {
                         recordsetModel.sortby = location.sortObject[0].column;
@@ -214,6 +214,9 @@
                     recordsetModel.rowValues = DataUtils.getRowValuesFromPage(page);
                     recordsetModel.initialized = true;
                     recordsetModel.hasLoaded = true;
+
+                    $rootScope.$broadcast('recordset-loaded', true);
+
                 }, function error(response) {
                     throw response;
                 }).catch(function genericCatch(exception) {

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -215,7 +215,7 @@
                     recordsetModel.initialized = true;
                     recordsetModel.hasLoaded = true;
 
-                    $rootScope.$broadcast('recordset-loaded', true);
+                    $rootScope.$broadcast('get-table-aggregate-count', true);
 
                 }, function error(response) {
                     throw response;

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -140,21 +140,21 @@ describe('View existing record,', function() {
             })
         });
     });
-    
+
     describe("For multiple records fetched for particular filters", function() {
-        
+
         beforeAll(function() {
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name +  "/luxurious=true";
             browser.get(url);
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));
         });
-        
+
         it('A error modal window should appear with multiple records found error with correct title', function(){
             var modalTitle = chaisePage.recordPage.getErrorModalTitle();
             expect(modalTitle).toBe(testParams.multipleData.title, "The title of multiple record error pop is not correct");
-            
+
         });
-        
+
         it('On click of OK button the page should redirect to recordset page', function(){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
                 return btn.click();
@@ -164,7 +164,7 @@ describe('View existing record,', function() {
                 expect(currentUrl).toContain("recordset", "The redirection from record page to recordset in case of multiple records failed");
             }).catch( function(err) {
                 console.log(error);
-            }); 
+            });
         });
     });
 

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -16,7 +16,7 @@ var testParams = {
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
             { name: "title", title: "Name of Accommodation", type: "text", nullok: false},
             { name: "website", title: "Website", type: "text", comment: "A valid url of the accommodation"},
-            { name: "category", title: "Category", type: "text", nullok: false, isForeignKey: true,  count: 5, table_title: "Categories", comment: "Type of accommodation ('Resort/Hotel/Motel')"},
+            { name: "category", title: "Category", type: "text", nullok: false, isForeignKey: true,  count: 5, totalCount: 5, table_title: "Categories", comment: "Type of accommodation ('Resort/Hotel/Motel')"}, // the total count is the total number of rows in the category.json data file
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", type: "longtext", nullok: false},
             { name: "description", title: "Description", type: "markdown"},

--- a/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
@@ -1,6 +1,6 @@
 /**
  * This test case is for testing editing a single record
- * 
+ *
  */
 var testConfiguration = browser.params.configuration;
 var chaisePage = require('../../../utils/chaise.page.js');
@@ -20,7 +20,7 @@ var testParams = {
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
             { name: "title", title: "<strong>Name of Accommodation</strong>", type: "text", nullok: false},
             { name: "website", title: "Website", type: "text", comment: "A valid url of the accommodation"},
-            { name: "category",  title: "Category", type: "text", isForeignKey: true, count: 5, table_title: "Categories", comment: "Type of accommodation ('Resort/Hotel/Motel')", nullok: false},
+            { name: "category",  title: "Category", type: "text", isForeignKey: true, count: 5, totalCount: 5, table_title: "Categories", comment: "Type of accommodation ('Resort/Hotel/Motel')", nullok: false}, // the total count is the total number of rows in the category.json data file
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", nullok: false, type: "longtext"},
             { name: "description", title: "Description", type: "markdown"},
@@ -38,16 +38,16 @@ var testParams = {
             }
         ],
         inputs: [
-            {"title": "new title 1", "website": "https://example1.com", "category": {index: 1, value: "Ranch"}, 
-             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1", 
+            {"title": "new title 1", "website": "https://example1.com", "category": {index: 1, value: "Ranch"},
+             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1",
              "no_of_rooms": "1", "opened_on": moment("2017-01-01 01:01:01", "YYYY-MM-DD hh:mm:ss"), "date_col": "2017-01-01", "luxurious": false},
         ],
         result_columns: [
             "title", "website", "product-edit_fk_category", "rating", "summary", "description", "no_of_rooms", "opened_on", "date_col", "luxurious"
         ],
         results: [
-            ["new title 1",  {"link":"https://example1.com/", "value":"Link to Website"}, 
-            {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-edit:category/id=10004", "value":"Ranch"}, 
+            ["new title 1",  {"link":"https://example1.com/", "value":"Link to Website"},
+            {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-edit:category/id=10004", "value":"Ranch"},
             "1.0000", "This is the summary of this column 1.", "Description 1", "1", "2017-01-01 01:01:01", "2017-01-01", "false"]
         ],
         files: []
@@ -93,7 +93,7 @@ describe('Edit existing record,', function() {
     for (var i=0; i< testParams.tables.length; i++) {
 
         (function(tableParams, index) {
-            
+
             if (!process.env.TRAVIS && tableParams.files.length > 0) {
                 beforeAll(function() {
                     // create files that will be uploaded
@@ -107,7 +107,7 @@ describe('Edit existing record,', function() {
                 var record;
 
                 beforeAll(function () {
-                
+
                     var keys = [];
                     keys.push(tableParams.key.name + tableParams.key.operator + tableParams.key.value);
                     browser.ignoreSynchronization=true;
@@ -135,7 +135,7 @@ describe('Edit existing record,', function() {
                 describe("Submitting an existing record,", function() {
                     recordEditHelpers.testSubmission(tableParams, true);
                 });
-                
+
                 if (!process.env.TRAVIS && tableParams.files.length > 0) {
                     afterAll(function(done) {
                         recordEditHelpers.deleteFiles(tableParams.files);

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -100,7 +100,13 @@ describe('View recordset,', function() {
                 browser.wait(EC.presenceOf(e), browser.params.defaultTimeout);
                 chaisePage.recordsetPage.getCustomPageSize().then(function(text) {
                     expect(text).toBe("15 (Custom)");
-                })
+                });
+            });
+
+            it("should display the proper row count and total row count.", function () {
+                chaisePage.recordsetPage.getTotalCount().getText().then(function(text) {
+                    expect(text).toBe("Displaying 15 of 50 Records");
+                });
             });
 
             it("should show correct table rows", function() {

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -103,12 +103,6 @@ describe('View recordset,', function() {
                 });
             });
 
-            it("should display the proper row count and total row count.", function () {
-                chaisePage.recordsetPage.getTotalCount().getText().then(function(text) {
-                    expect(text).toBe("Displaying 15 of 50 Records");
-                });
-            });
-
             it("should show correct table rows", function() {
                 chaisePage.recordsetPage.getRows().then(function(rows) {
                     expect(rows.length).toBe(4);
@@ -410,6 +404,12 @@ describe('View recordset,', function() {
                 return chaisePage.recordsetPage.getRows().count();
             }).then(function(ct) {
                 expect(ct).toBe(fileParams.custom_page_size);
+            });
+        });
+
+        it("should display the proper row count and total row count.", function () {
+            chaisePage.recordsetPage.getTotalCount().getText().then(function(text) {
+                expect(text).toBe("Displaying 5 of 14 Records");
             });
         });
 

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -170,6 +170,7 @@ describe('View recordset,', function() {
                     return chaisePage.recordsetPage.getRows()
                 }).then(function(rows) {
                     expect(rows.length).toBe(1);
+                    expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying 1 of 1 Records", "Display total count for 'Super 8 North Hollywood Motel' search is incorrect");
                     // clear search
                     return clearSearchButton.click();
                 }).then(function() {
@@ -178,6 +179,7 @@ describe('View recordset,', function() {
                     return chaisePage.recordsetPage.getRows();
                 }).then(function(rows) {
                     expect(rows.length).toBe(4);
+                    expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying 4 of 4 Records", "Display total count for no search term is incorrect");
 
                     // apply conjunctive search words
                     searchBox.sendKeys('"Super 8" motel "North Hollywood"');
@@ -189,6 +191,7 @@ describe('View recordset,', function() {
                     return chaisePage.recordsetPage.getRows();
                 }).then(function(rows) {
                     expect(rows.length).toBe(1);
+                    expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying 1 of 1 Records", "Display total count for '\"Super 8\" motel \"North Hollywood\"' search is incorrect");
                     // clear search
                     return clearSearchButton.click();
                 }).then(function() {
@@ -204,6 +207,7 @@ describe('View recordset,', function() {
                     return chaisePage.recordsetPage.getRows();
                 }).then(function(rows) {
                     expect(rows.length).toBe(0);
+                    expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying 0 Records", "Display total count for 'asdfghjkl' search is incorrect");
 
                     return chaisePage.recordsetPage.getNoResultsRow().getText();
                 }).then(function(text) {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -765,6 +765,10 @@ var recordsetPage = function() {
         return browser.executeScript("return $('#custom-page-size').text().trim();");
     };
 
+    this.getTotalCount = function() {
+        return element(by.id('rs-total-count'));
+    };
+
     this.getColumnNames = function() {
         return element.all(by.css(".table-column-displayname > span"));
     };

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -68,7 +68,7 @@ var JSONTestParams=[
         stringVal:JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2),
         expectedValue:true
     }
-    
+
 ];
 
 
@@ -304,7 +304,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                     txtArea.sendKeys(text);
 
                                     expect(txtArea.getAttribute('value')).toEqual(text, colError(c.name, "Couldn't change the value."));
-                                 
+
                             });
                         });
                     });
@@ -340,7 +340,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                     });
                 });
             }
-            
+
             if (jsonCols.length > 0) {
                 describe("JSON fields, ", function () {
                     it("should show textarea input for JSON datatype and then set the value", function() {
@@ -348,7 +348,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                         chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
                             expect(jsonTxtArea.isDisplayed()).toBeTruthy();
                             jsonTxtArea.column = c;
-                                
+
                             JSONDataTypeFields.push(jsonTxtArea);
                             var value = getRecordValue(c.name);
 
@@ -358,7 +358,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                         });
                     });
                  });
-                 
+
                  it("should only allow valid JSON values", function(){
                      jsonCols.forEach(function(c) {
                          chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
@@ -369,15 +369,15 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                      jsonTxtArea.sendKeys(input);
                                      chaisePage.recordEditPage.getJSONInputErrorMessage(jsonTxtArea, 'json').then(function(error){
                                          expect(error).toBe(null, colError(c.name , "Some Valid JSON Values were not accepted"));
-                                     });                                        
+                                     });
                                  })(JSONTestParams[i].stringVal);
-                             }//for 
+                             }//for
                          });
                      });
                  });
              });
          }
-            
+
             if (markdownCols.length > 0) {
                 describe("Markdown fields, ", function () {
                     it('should have the correct value.', function () {
@@ -479,7 +479,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
                                     dropdowns.push(dropdown);
                                     booleanDataTypeFields.push(dropdown);
-                                
+
                             });
                         });
                     });
@@ -613,6 +613,9 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                     }).then(function(ct) {
                                         expect(ct).toBe(col.count, colError(col.name, "number of foreign key rows are not as expected."));
 
+                                        return chaisePage.recordsetPage.getTotalCount().getText();
+                                    }).then(function(text) {
+                                        expect(text).toBe("Displaying 5 of " + col.count + " Records", "The total count display in the foreign key popup is incorrect");
 
                                         return rows.get(fkSelectedValue.index).all(by.css(".select-action-button"));
                                     }).then(function(selectButtons) {
@@ -895,7 +898,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                             timeInput.sendKeys('12:00:00');
                             chaisePage.recordEditPage.getTimestampInputErrorMessage(timeInput, 'timestampDate').then(function(error) {
                                 expect(error.isDisplayed()).toBeTruthy(colError(column.name, "Accepted an invalid date."));
-                                
+
                                 // Good date + good time = no error
                                 // Now, if user enters a valid date, then no error message should appear
                                 return dateInput.sendKeys('2016-01-01');

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -613,9 +613,10 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                     }).then(function(ct) {
                                         expect(ct).toBe(col.count, colError(col.name, "number of foreign key rows are not as expected."));
 
+                                        browser.sleep(10);
                                         return chaisePage.recordsetPage.getTotalCount().getText();
                                     }).then(function(text) {
-                                        expect(text).toBe("Displaying 5 of " + col.count + " Records", "The total count display in the foreign key popup is incorrect");
+                                        expect(text).toBe("Displaying " + col.count + " of " + col.totalCount + " Records", colError(col.name, "The total count display in the foreign key popup is incorrect"));
 
                                         return rows.get(fkSelectedValue.index).all(by.css(".select-action-button"));
                                     }).then(function(selectButtons) {


### PR DESCRIPTION
This PR adds functionality to the `recordset` directive to put a full entity count for the current reference at the top of the table. This can be seen in the `recordset` app and the `recordedit` foreign key popup selector.

This addresses issue #878.