### PR TITLE
Renamed canCreate to canInsert for reference

### DIFF
--- a/common/record.js
+++ b/common/record.js
@@ -69,7 +69,7 @@
         * @param {string} relatedTableRefDisplay: Related table ref. display type
         * @param {string} tabModelDisplay: Display type of individual model
         * @param {callback} canEditRelated: function to check canEdit()
-        * @param {callback} canCreateRelated: function to check canCreate()
+        * @param {callback} canCreateRelated: function to check canInsert()
         * @param {callback} addRelatedRecord: function to check add feature
         * @param {callback} toRecordSet:view more record function
         */

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -71,7 +71,7 @@
             
             <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 pull-right" align="right">
                 <!-- add record -->
-                <button id="add-record-btn" type="button" class="btn btn-primary btn-inverted" ng-if="vm.reference.canCreate && allowCreate" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
+                <button id="add-record-btn" type="button" class="btn btn-primary btn-inverted" ng-if="vm.reference.canInsert && allowCreate" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
                     <span class="glyphicon glyphicon-plus"></span>
                 </button>
             </div>

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -72,7 +72,7 @@
             
             <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 pull-right" align="right">
                 <!-- add record -->
-                <button id="add-record-btn" type="button" class="btn btn-primary btn-inverted" ng-if="vm.reference.canCreate && allowCreate" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
+                <button id="add-record-btn" type="button" class="btn btn-primary btn-inverted" ng-if="vm.reference.canInsert && allowCreate" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
                     <span class="glyphicon glyphicon-plus"></span>
                 </button>
             </div>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -21,7 +21,7 @@
                 </h3>
             </div>
             <div class="pull-right">
-                <a id="create-record" ng-click="::ctrl.createRecord()" ng-if="::ctrl.canCreate()" uib-tooltip="Click here to create a record." tooltip-placement="bottom">
+                <a id="create-record" ng-click="::ctrl.createRecord()" ng-if="::ctrl.canInsert()" uib-tooltip="Click here to create a record." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-plus"></span> <strong>Create</strong>
                 </a>&nbsp;&nbsp;
                 <a id="edit-record" ng-click="::ctrl.editRecord()" ng-if="::ctrl.canEdit()" uib-tooltip="Click here to edit this record." tooltip-placement="bottom">

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -202,7 +202,7 @@
                         allInbFKCols[i].reference = allInbFKCols[i].reference.contextualize.compactBriefInline;
                         var ifkPageSize = getPageSize(allInbFKCols[i].reference);
                         (function(i) {
-                            if (allInbFKCols[i].reference.canCreate && $rootScope.modifyRecord && !$rootScope.showEmptyRelatedTables) {
+                            if (allInbFKCols[i].reference.canInsert && $rootScope.modifyRecord && !$rootScope.showEmptyRelatedTables) {
                                 $rootScope.showEmptyRelatedTables = true;
                             }
                             getRelatedTableData(allInbFKCols[i].reference, true, "compact/brief/inline", function(model){
@@ -228,7 +228,7 @@
                     $rootScope.relatedReferences[i] = $rootScope.relatedReferences[i].contextualize.compactBrief;
                     var pageSize = getPageSize($rootScope.relatedReferences[i]);
                     (function(i) {
-                        if ($rootScope.relatedReferences[i].canCreate && $rootScope.modifyRecord && !$rootScope.showEmptyRelatedTables) {
+                        if ($rootScope.relatedReferences[i].canInsert && $rootScope.modifyRecord && !$rootScope.showEmptyRelatedTables) {
                             $rootScope.showEmptyRelatedTables = true;
                         }
                         getRelatedTableData($rootScope.relatedReferences[i], boolIsOpen, "compact/brief", function(model){

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -15,8 +15,8 @@
         vm.alerts = AlertsService.alerts;
         vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
 
-        vm.canCreate = function() {
-            return ($rootScope.reference && $rootScope.reference.canCreate && $rootScope.modifyRecord);
+        vm.canInsert = function() {
+            return ($rootScope.reference && $rootScope.reference.canInsert && $rootScope.modifyRecord);
         };
 
         vm.createRecord = function() {
@@ -111,7 +111,7 @@
             if(angular.isUndefined(relatedRef))
             return false;
            var ref = (relatedRef.derivedAssociationReference ? relatedRef.derivedAssociationReference : relatedRef);
-           return (ref.canCreate && $rootScope.modifyRecord);
+           return (ref.canInsert && $rootScope.modifyRecord);
         };
 
         // Send user to RecordEdit to create a new row in this related table

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -23,7 +23,7 @@
     <div class="container-fluid">
         <navbar></navbar>
         <loading-spinner ng-show="!displayReady"></loading-spinner>
-        <div ng-if="reference && (reference.canCreate || reference.canUpdate)">
+        <div ng-if="reference && (reference.canInsert || reference.canUpdate)">
             <div ng-controller="FormController as form" class="row">
                 <div ng-show="!form.resultset">
                     <loading-spinner ng-show="form.submissionButtonDisabled"></loading-spinner>

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -280,7 +280,7 @@
                         throw notAuthorizedError;
                     }
                 } else if (context.mode == context.modes.CREATE) {
-                    if ($rootScope.reference.canCreate) {
+                    if ($rootScope.reference.canInsert) {
                         $rootScope.displayname = $rootScope.reference.displayname;
 
                         // populate defaults

--- a/recordset/recordset.html
+++ b/recordset/recordset.html
@@ -14,7 +14,7 @@
                 </h3>
             </div>
             <div class="pull-right">
-                <a id="create-link" ng-if="vm.reference.canCreate && vm.config.editable" ng-href="{{create()}}" uib-tooltip="Click here to create a record." tooltip-placement="bottom">
+                <a id="create-link" ng-if="vm.reference.canInsert && vm.config.editable" ng-href="{{create()}}" uib-tooltip="Click here to create a record." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-plus"></span> <strong>Create</strong>
                 </a>&nbsp;&nbsp;
                 <!-- edit -->


### PR DESCRIPTION
This PR renames  `canCreate` to `canInsert` as it has changed ermrestjs. The renaming issue is [here](https://github.com/informatics-isi-edu/ermrestjs/issues/487).

This PR should be merged immediately after merging ermrestjs PR for the same changes https://github.com/informatics-isi-edu/ermrestjs/pull/518