### PR TITLE
Disable Existing Associative entities in Multi Add

### DIFF
--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -57,7 +57,8 @@
                 config: '=',    // {viewable, editable, deletable, selectMode}
                 onRowClickBind: '=?',
                 fromTuple: '=?',
-                selected: '='
+                selected: '=',
+                selectDisabled: "=?"
             },
             link: function (scope, element) {
 
@@ -73,8 +74,9 @@
 
                     var editLink = null;
 
-                    if (scope.fromTuple)
+                    if (scope.fromTuple) {
                         scope.associationRef = scope.tuple.getAssociationRef(scope.fromTuple.data);
+                    }
 
                     if (scope.config.viewable)
                         scope.viewLink = scope.tuple.reference.contextualize.detailed.appLink;

--- a/common/modal.js
+++ b/common/modal.js
@@ -76,6 +76,7 @@
         vm.ok = ok;
         vm.cancel = cancel;
         vm.submit = submitMultiSelection;
+        vm.getDisabledTuples = params.getDisabledTuples ? params.getDisabledTuples : undefined;
 
         vm.hasLoaded = false;
         var reference = vm.reference = params.reference;
@@ -100,17 +101,32 @@
 
         var fetchRecords = function() {
             // TODO this should not be a hardcoded value, either need a pageInfo object across apps or part of user settings
+            // The new recordset (recordsetWithFaceting) doesn't require read first. It will take care of this.
             reference.read(limit).then(function getPseudoData(page) {
-                vm.tableModel.hasLoaded = true;
-                vm.tableModel.initialized = true;
-                vm.tableModel.page = page;
-                vm.tableModel.rowValues = DataUtils.getRowValuesFromPage(page);
-
-                $scope.$broadcast('data-modified');
-            }, function(exception) {
+                var afterRead = function () {
+                    vm.tableModel.hasLoaded = true;
+                    vm.tableModel.initialized = true;
+                    vm.tableModel.page = page;
+                    vm.tableModel.rowValues = DataUtils.getRowValuesFromPage(page);
+                    $scope.$broadcast('data-modified');
+                };
+                
+                // get disabled tuple.
+                if (vm.getDisabledTuples) {
+                    vm.getDisabledTuples(page, vm.tableModel.pageLimit).then(function (rows) {
+                        vm.tableModel.disabledRows = rows;
+                        afterRead();
+                    }).catch(function (err) {
+                        throw err;
+                    });
+                } else {
+                    afterRead();
+                }
+                
+            }).catch(function(exception) {
                 throw exception;
             });
-        }
+        };
 
         fetchRecords();
     

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -59,9 +59,22 @@ span[uib-tooltip] {
     background-color: white;
 }
 
-.btn.btn-primary.btn-inverted[disabled] {
-    color: #f1f1f1;
-    border-color: #f1f1f1;
+.btn.btn-primary.btn-inverted[disabled],
+.chaise-checkbox input[disabled][type="checkbox"] + label:before {
+    color: #f1f1f1 !important;
+    border-color: #f1f1f1 !important;
+}
+
+.chaise-checkbox input[disabled][type="checkbox"]:checked + label:after {
+    color: #ccc !important;
+}
+
+.disabled-row {
+    color: #ccc;
+}
+
+.disabled-row * {
+    color: inherit;
 }
 
 /**************** SPINNER **************/

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -17,7 +17,7 @@
         </button>
     </div>
     <div ng-if="config.selectMode == multiSelect" class="chaise-checkbox">
-        <input type="checkbox" ng-checked="selected" ng-click="onSelect()">
+        <input type="checkbox" ng-checked="selected || selectDisabled" ng-click="onSelect()" ng-disabled="selectDisabled">
         <label />
     </div>
 </td>

--- a/common/templates/searchPopup.modal.html
+++ b/common/templates/searchPopup.modal.html
@@ -10,5 +10,5 @@
     <span ng-if="ctrl.tableModel.config.selectMode=='multi-select'">
         <button class="btn btn-primary btn-inverted pull-right multi-select-submit-btn" type="button" ng-click="ctrl.submit()" ng-disabled="ctrl.tableModel.selectedRows.length < 1">Submit</button>
     </span>
-    <recordset vm="ctrl.tableModel" on-row-click="ctrl.ok" allow-create="true"></recordset>
+    <recordset vm="ctrl.tableModel" on-row-click="ctrl.ok" allow-create="true" get-disabled-tuples="getDisabledTuples"></recordset>
 </div>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -29,7 +29,9 @@
 
         <!-- rows -->
         <tbody>
-            <tr class="table-row" ellipses ng-repeat="row in vm.rowValues track by $index" tuple="vm.page.tuples[$index]" from-tuple="vm.fromTuple" row-values="row" config="vm.config" context="vm.context" on-row-click-bind="onSelect" selected="isSelected(vm.page.tuples[$index].uniqueId)">
+            <tr class="table-row" ng-class="{'disabled-row': isDisabled(vm.page.tuples[$index].uniqueId)}"
+                ellipses ng-repeat="row in vm.rowValues track by $index" tuple="vm.page.tuples[$index]" from-tuple="vm.fromTuple" row-values="row" 
+                config="vm.config" context="vm.context" on-row-click-bind="onSelect" selected="isSelected(vm.page.tuples[$index].uniqueId)" select-disabled="isDisabled(vm.page.tuples[$index].uniqueId)">
             </tr>
             <tr ng-if="vm.rowValues.length < 1">
                 <td id="no-results-row" colspan="{{vm.columns.length + 1}}" style="text-align: center;">No Results Found</td>

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -751,6 +751,14 @@ var recordPage = function() {
     this.getErrorModalOkButton = function(){
         return browser.executeScript("return $('button')[1]");
     };
+    
+    this.getModalDisabledRows = function () {
+        return browser.executeScript("return $('.modal-body tr.disabled-row')");
+    };
+    
+    this.getSuccessAlert = function () {
+        return element(by.css(".alert-success"));
+    };
 };
 
 var recordsetPage = function() {
@@ -788,6 +796,10 @@ var recordsetPage = function() {
 
     this.getRows = function() {
         return element.all(by.css('.table-row'));
+    };
+    
+    this.getModalRows = function () {
+        return element.all(by.css('.modal-body .table-row'));
     };
 
     this.getNoResultsRow = function() {


### PR DESCRIPTION
This PR will add the feature of disabling already selected entities in the pure and binary association multi add modal. For that I have to add a new callback to the table directive called `getDisabledRows` which will return a promise resolved with an array of tuples.

I made an attempt to refactor the addPopup to use it in recordedit as well as record, but I couldn't make it work and didn't want to spend more time on this issue. I added some comments so we can refactor it later.

[ermrestjs#534](https://github.com/informatics-isi-edu/ermrestjs/pull/534) is needed for testing this branch.