### PR TITLE
Recordedit delete spinner

### DIFF
--- a/common/delete-link.js
+++ b/common/delete-link.js
@@ -47,10 +47,12 @@
             link: function(scope) {
                 scope.deleteFn = function deleteFn() {
                     if (!CONFIRM_DELETE) {
+                        scope.$root.showSpinner = true;
                         return scope.callback();
                     }
                     var modalInstance = createModal();
                     modalInstance.result.then(function success() {
+                        scope.$root.showSpinner = true;
                         return scope.callback();
                     });
                 }

--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -9,7 +9,7 @@
         };
     }])
 
-    .directive('ellipses', ['$sce', '$timeout', 'AlertsService', 'ErrorService', '$uibModal', '$log', 'MathUtils', 'messageMap', 'UriUtils', '$window', 'UiUtils', 'modalBox', function($sce, $timeout, AlertsService, ErrorService, $uibModal, $log, MathUtils, messageMap, UriUtils, $window, UiUtils, modalBox) {
+    .directive('ellipses', ['AlertsService', 'ErrorService', 'MathUtils', 'messageMap', 'modalBox', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$sce', '$timeout', '$uibModal', '$window', function(AlertsService, ErrorService, MathUtils, messageMap, modalBox, UiUtils, UriUtils, $log, $rootScope, $sce, $timeout, $uibModal, $window) {
 
         function deleteReference(scope, reference) {
             if (chaiseConfig.confirmDelete === undefined || chaiseConfig.confirmDelete) {
@@ -19,13 +19,16 @@
                     controllerAs: "ctrl",
                     size: "sm"
                 }).result.then(function success() {
+                    scope.$root.showSpinner = true;
                     // user accepted prompt to delete
                     return reference.delete();
                 }).then(function deleteSuccess() {
+                    scope.$root.showSpinner = false;
                     // tell parent controller data updated
                     scope.$emit('record-deleted');
 
                 }, function deleteFailure(response) {
+                    scope.$root.showSpinner = false;
                     if (typeof response !== "string") {
                         throw response;
                     }
@@ -33,13 +36,14 @@
                     throw error;
                 });
             } else {
-
+                scope.$root.showSpinner = true;
                 reference.delete().then(function deleteSuccess() {
-
+                    scope.$root.showSpinner = false;
                     // tell parent controller data updated
                     scope.$emit('record-deleted');
 
                 }, function deleteFailure(response) {
+                    scope.$root.showSpinner = false;
                     throw response;
                 }).catch(function (error) {
                     throw error;

--- a/common/table.js
+++ b/common/table.js
@@ -616,6 +616,7 @@
 
                 scope.vm.backgroundSearchPendingTerm = null;
                 scope.vm.currentPageSelected = false;
+                scope.$root.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
                 //TODO this is forced here
                 scope.vm.showFaceting = false;
                 
@@ -812,7 +813,7 @@
     }])
     
     //TODO This is used in recrodset app, eventually it should be used everywhere
-    .directive('recordsetWithFaceting', ['recordTableUtils', '$window', '$cookies', 'DataUtils', 'MathUtils', 'UriUtils','$timeout', 'AlertsService', '$log', function(recordTableUtils, $window, $cookies, DataUtils, MathUtils, UriUtils, $timeout, AlertsService, $log) {
+    .directive('recordsetWithFaceting', ['recordTableUtils', '$window', '$cookies', 'DataUtils', 'MathUtils', 'UriUtils', '$timeout', 'AlertsService', '$log', function(recordTableUtils, $window, $cookies, DataUtils, MathUtils, UriUtils, $timeout, AlertsService, $log) {
         var MAX_LENGTH = 2000;
         
         return {
@@ -824,12 +825,12 @@
                 allowCreate: '=?'       // if undefined, assume false
             },
             link: function (scope, elem, attr) {
-                console.log(scope.vm.config);
                 var addRecordRequests = {}; // table refresh used by add record implementation with cookie (old method)
                 var updated = false; // table refresh used by ellipses' edit action (new method)
 
                 scope.pageLimits = [10, 25, 50, 75, 100, 200];
                 scope.$root.alerts = AlertsService.alerts;
+                scope.$root.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
                 scope.vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
 
                 scope.vm.isIdle = true;

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -1,5 +1,5 @@
 <div class="recordset-container without-faceting">
-    <loading-spinner ng-show="!vm.hasLoaded && !vm.backgroundSearch"></loading-spinner>
+    <loading-spinner ng-show="(!vm.hasLoaded && !vm.backgroundSearch) || showSpinner"></loading-spinner>
     <div class="main-container">
         <div ng-show="vm.initialized" class="row" style="margin-bottom: 10px;">
             <div ng-if="vm.config.selectMode == 'multi-select' && !vm.config.hideSelectedRows" class="row total-filters selected-rows">

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -1,5 +1,5 @@
 <div class="recordset-container" ng-class="vm.config.showFaceting ? 'row with-faceting':'without-faceting'">
-    <loading-spinner ng-show="!vm.initialized"></loading-spinner>
+    <loading-spinner ng-show="!vm.initialized || $root.showSpinner"></loading-spinner>
     <div class="faceting-resizable" resizable r-directions=["right"] r-flex="true" ng-if="vm.config.showFaceting" ng-class="{'initializing': !vm.initialized}">
         <faceting vm="vm"></faceting>
     </div>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -45,7 +45,7 @@
             </div>
         </div>
     </div>
-    <loading-spinner ng-show="!displayReady"></loading-spinner>
+    <loading-spinner ng-show="!displayReady || showSpinner"></loading-spinner>
     <div id="main-content" class="container-fluid" style="overflow-y: auto;">
         <div class="main-container">
             <alerts alerts="ctrl.alerts"></alerts>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -49,6 +49,7 @@
             context = {};
         $rootScope.displayReady = false;
         $rootScope.recDisplayReady = false;
+        $rootScope.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
 
         UriUtils.setOrigin();
         headInjector.setupHead();

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -47,8 +47,10 @@
             $rootScope.reference.delete().then(function deleteSuccess() {
                 // Get an appLink from a reference to the table that the existing reference came from
                 var unfilteredRefAppLink = $rootScope.reference.table.reference.contextualize.compact.appLink;
+                $rootScope.showSpinner = false;
                 $window.location.href = unfilteredRefAppLink;
             }, function deleteFail(error) {
+                $rootScope.showSpinner = false;
                 throw error;
             });
         };

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -304,10 +304,12 @@
                 uri = "../search/#" + location.catalog + '/' + location.schemaName + ':' + location.tableName;
             }
 
+            vm.submissionButtonDisabled = false;
             $window.location.href = uri;
         }
 
         function deleteRecord() {
+            vm.submissionButtonDisabled = true;
             if (chaiseConfig.confirmDelete === undefined || chaiseConfig.confirmDelete) {
                 $uibModal.open({
                     templateUrl: "../common/templates/delete-link/confirm_delete.modal.html",
@@ -318,6 +320,7 @@
                     // user accepted prompt to delete
                     return $rootScope.reference.delete();
                 }).then(onDelete, function deleteFailure(response) {
+                    vm.submissionButtonDisabled = false;
                     if (typeof response !== "string") {
                         throw response;
                     }
@@ -326,6 +329,7 @@
                 });
             } else {
                 $rootScope.reference.delete().then(onDelete, function deleteFailure(response) {
+                    vm.submissionButtonDisabled = false;
                     throw response;
                 }).catch(function (exception) {
                     AlertsService.addAlert(exception.message, 'error');

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -309,7 +309,6 @@
         }
 
         function deleteRecord() {
-            vm.submissionButtonDisabled = true;
             if (chaiseConfig.confirmDelete === undefined || chaiseConfig.confirmDelete) {
                 $uibModal.open({
                     templateUrl: "../common/templates/delete-link/confirm_delete.modal.html",
@@ -317,6 +316,7 @@
                     controllerAs: "ctrl",
                     size: "sm"
                 }).result.then(function success() {
+                    vm.submissionButtonDisabled = true;
                     // user accepted prompt to delete
                     return $rootScope.reference.delete();
                 }).then(onDelete, function deleteFailure(response) {
@@ -328,6 +328,7 @@
                     AlertsService.addAlert(exception.message, 'error');
                 });
             } else {
+                vm.submissionButtonDisabled = true;
                 $rootScope.reference.delete().then(onDelete, function deleteFailure(response) {
                     vm.submissionButtonDisabled = false;
                     throw response;

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -304,7 +304,7 @@
                 uri = "../search/#" + location.catalog + '/' + location.schemaName + ':' + location.tableName;
             }
 
-            vm.submissionButtonDisabled = false;
+            $rootScope.showSpinner = false;
             $window.location.href = uri;
         }
 
@@ -316,11 +316,11 @@
                     controllerAs: "ctrl",
                     size: "sm"
                 }).result.then(function success() {
-                    vm.submissionButtonDisabled = true;
+                    $rootScope.showSpinner = true;
                     // user accepted prompt to delete
                     return $rootScope.reference.delete();
                 }).then(onDelete, function deleteFailure(response) {
-                    vm.submissionButtonDisabled = false;
+                    $rootScope.showSpinner = false;
                     if (typeof response !== "string") {
                         throw response;
                     }
@@ -328,9 +328,9 @@
                     AlertsService.addAlert(exception.message, 'error');
                 });
             } else {
-                vm.submissionButtonDisabled = true;
+                $rootScope.showSpinner = true;
                 $rootScope.reference.delete().then(onDelete, function deleteFailure(response) {
-                    vm.submissionButtonDisabled = false;
+                    $rootScope.showSpinner = false;
                     throw response;
                 }).catch(function (exception) {
                     AlertsService.addAlert(exception.message, 'error');

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -26,7 +26,7 @@
         <div ng-if="reference && (reference.canCreate || reference.canUpdate)">
             <div ng-controller="FormController as form" class="row">
                 <div ng-show="!form.resultset">
-                    <loading-spinner ng-show="form.submissionButtonDisabled"></loading-spinner>
+                    <loading-spinner ng-show="form.submissionButtonDisabled || showSpinner"></loading-spinner>
                     <div class="col-xs-12">
                         <div class="row main-container">
                             <!-- Alerts section -->

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -28,17 +28,17 @@
                 <div ng-show="!form.resultset">
                     <loading-spinner ng-show="form.submissionButtonDisabled"></loading-spinner>
                     <div class="col-xs-12">
-                        <!-- Alerts section -->
-                        <div ng-repeat="alert in form.alerts" class="row">
-                            <div class="col-xs-12">
-                                <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
-                                    <button type="button" class="close" ng-click="::form.closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                                    <strong>{{alert.type | toTitleCase}}</strong> {{alert.message}}
+                        <div class="row main-container">
+                            <!-- Alerts section -->
+                            <div ng-repeat="alert in form.alerts" class="row">
+                                <div class="col-xs-12">
+                                    <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
+                                        <button type="button" class="close" ng-click="::form.closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                        <strong>{{alert.type | toTitleCase}}</strong> {{alert.message}}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <!-- Form section -->
-                        <div class="row main-container">
+                            <!-- Form section -->
                             <div class="col-xs-12">
                                 <div class="row">
                                     <div ng-if="displayname" class="col-xs-7">

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -51,6 +51,7 @@
             context = { booleanValues: ['', true, false] };
 
         $rootScope.displayReady = false;
+        $rootScope.showSpinner = false;
 
         UriUtils.setOrigin();
         headInjector.setupHead();


### PR DESCRIPTION
This PR adds a spinner (really is just changing the conditions for when to show a spinner) to `recordedit`, `record`, and `recordset` when a delete action is taken. This is true for when you select the delete action from a table on `recordset`/`record` and the delete link in the sub-navbar on `record` and the delete button on `recordedit`.

This PR is for issues #1342 and #1362. 