### PR TITLE
Added context header pid and wid back in the params

### DIFF
--- a/record/record.app.js
+++ b/record/record.app.js
@@ -134,7 +134,7 @@
             // Unsubscribe onchange event to avoid this function getting called again
             Session.unsubscribeOnChange(subId);
 
-            ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+            ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
                 context.filter = reference.location.filter;
 
                 DataUtils.verify(context.filter, 'No filter was defined. Cannot find a record without a filter.');

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -115,7 +115,7 @@
             Session.unsubscribeOnChange(subId);
 
             // On resolution
-            ERMrest.resolve(ermrestUri, { cid: context.appName }).then(function getReference(reference) {
+            ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
                 
                 
                 // we are using filter to determine app mode, the logic for getting filter

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -275,7 +275,7 @@
                 // Unsubscribe onchange event to avoid this function getting called again
                 Session.unsubscribeOnChange(subId);
 
-                ERMrest.resolve(ermrestUri, {cid: context.appName}).then(function getReference(reference) {
+                ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
                     session = Session.getSessionValue();
 
                     var location = reference.location;


### PR DESCRIPTION
This PR adds removed context parameters like `pid` and `wid` back to the params passed to resolve. 

Now you will find them passed in the header names as `Deriva-Client-Contexteriva` 

https://dev.isrd.isi.edu/~chirag/chaise/recordset/#1/isa:dataset@sort(release_date::desc::,id)

This PR is dependent on https://github.com/informatics-isi-edu/ermrestjs/pull/556.