### PR TITLE
Media print rules added in CSS

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -1444,7 +1444,7 @@ input[type=number]::-moz-placeholder {
 
     .entity-key {
         width: auto;
-        max-width: 100px;
+        max-width: 120px;
     }
 
     .entity-value {

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -1428,3 +1428,26 @@ input[type=number]::-moz-placeholder {
 .selected-rows {
     min-height: 45px;
 }
+
+@media print {
+    #main-content {
+        height: auto !important;
+    }
+
+    #footer {
+        display: none;
+    }
+
+    a[href]:after {
+        content: none !important;
+    }
+
+    .entity-key {
+        width: auto;
+        max-width: 100px;
+    }
+
+    .entity-value {
+        width: auto;
+    }
+}

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -82,8 +82,8 @@
                     </div>
                 </uib-accordion>
             </div>
+            <span id="rt-loading" ng-show="loading">Loading...</span>
         </div>
-        <span id="rt-loading" ng-show="loading">Loading...</span>
     </div>
     <footer></footer>
 </body>

--- a/record/record.css
+++ b/record/record.css
@@ -11,7 +11,7 @@
 
 .main-container {
     margin-top: 10px;
-    padding-bottom: 20px;
+    padding-bottom: 60px;
     margin-bottom: -50px;
 }
 

--- a/record/record.css
+++ b/record/record.css
@@ -11,7 +11,7 @@
 
 .main-container {
     margin-top: 10px;
-    padding-bottom: 60px;
+    padding-bottom: 30px;
     margin-bottom: -50px;
 }
 


### PR DESCRIPTION
This PR addresses issues #1381 and #1383.

`@media print {...}` was added to change some of the styling when print is used from the browser tools. This should make printing documents look better than before and remove the limitation that bound it to just the first page. 

Extra padding was added to the main container so that the `Loading...` text shows up in a better place now.