### PR TITLE
add $fkeys support to domain_filter_pattern

### DIFF
--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -125,10 +125,14 @@
 
         vm.addRelatedRecord = function(ref) {
             // 1. Pluck required values from the ref into cookie obj by getting the values of the keys that form this FK relationship
-
+            // Another option is just passing the column name,
+            // but if the column is not in the list of visible columns in entry/create that can cause problems.
+            // This will work even if the column is not visible in the create mode.
             var cookie = {
-                rowname: $rootScope.recordDisplayname,
-                constraintName: ref.origColumnName
+                rowname: $rootScope.recordDisplayname, // used for display value
+                columnName: ref.origColumnName, // used to find the column that this blongs to
+                constraintName: ref.origFKR.name, // used for attaching the foreignkey data
+                origUrl: $rootScope.reference.uri // used for getting foreignkey data
             };
             var mapping = ref.contextualize.entryCreate.origFKR.mapping;
 

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -55,11 +55,11 @@
                                 <div class="row padding-right-15" ng-show="::!form.editMode">
                                     <div class="btn-group pull-right">
                                         <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button"
-                                            tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
+                                            ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
                                             <span class="glyphicon glyphicon-plus"></span>
                                         </button>
                                         <button id="copy-x-rows-btn" class="btn btn-primary btn-inverted center-block" ng-click="::(form.showMultiInsert = !form.showMultiInsert)" type="button"
-                                            tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
+                                            ng-disabled="!form.canAddMore" tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
                                             <span class="glyphicon glyphicon-chevron-down"></span>
                                         </button>
                                     </div>
@@ -158,6 +158,9 @@
                                                             ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                         <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px', 'pointer-events': 'all'}">
                                                             <span class="glyphicon glyphicon-remove coltooltiptext foreignkey-remove" ng-click="::form.clearForeignKey(rowIndex, column)" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+                                                        </div>
+                                                        <div class="form-control-feedback" ng-show="showColumnSpinner[rowIndex][column.name]" ng-style="{'right': '60px', 'pointer-events': 'all', 'color': '#C3C3C3'}">
+                                                            <span class="glyphicon glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
                                                         </div>
                                                         <span class="input-group-addon" ng-show="::!form.isDisabled(column);">
                                                             <button ng-focus="::form.blurElement($event);" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-button" class="btn btn-primary btn-inverted modal-popup-btn" type="button" ng-click="::form.searchPopup(rowIndex, column)" ng-disabled="::form.isDisabled(column);" tooltip-placement="bottom" uib-tooltip="Choose from an existing value.">

--- a/recordedit/model.js
+++ b/recordedit/model.js
@@ -8,6 +8,7 @@
         table: {},
         rows: [{}], // rows of data in the form, not the table from ERMrest
         oldRows: [{}], // Keep a copy of the initial rows data so that we can see if user has made any changes later
-        submissionRows: [{}] // rows of data converted to raw data for submission
+        submissionRows: [{}], // rows of data converted to raw data for submission
+        foreignKeyData: [{}] // the linkedData that we get from tuple object (data from outbound foreign keys)
     });
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -38,7 +38,7 @@
     .config(['$uibTooltipProvider', function($uibTooltipProvider) {
         $uibTooltipProvider.options({appendToBody: true});
     }])
-    
+
     //  Enable log system, if in debug mode
     .config(['$logProvider', function($logProvider) {
         $logProvider.debugEnabled(chaiseConfig.debug === true);
@@ -49,7 +49,7 @@
 
         var session,
             context = { booleanValues: ['', true, false] };
-        
+
         $rootScope.showColumnSpinner = [{}];
 
         $rootScope.displayReady = false;
@@ -118,13 +118,13 @@
 
             // On resolution
             ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
-                
-                
+
+
                 // we are using filter to determine app mode, the logic for getting filter
                 // should be in the parser and we should not duplicate it in here
                 // NOTE: we might need to change this line (we're parsing the whole url just for fidinig if there's filter)
                 var location = ERMrest.parse(ermrestUri);
-                
+
                 // Mode can be any 3 with a filter
                 if (location.filter || location.facets) {
                     // prefill always means create
@@ -153,17 +153,23 @@
                     // get the cookie with the prefill value
                     var cookie = $cookies.getObject(context.queryParams.prefill);
                     var newRow = recordEditModel.rows.length - 1;
-                    $rootScope.cookieObj = cookie;
-                    if (cookie) {
+
+                    // make sure cookie is correct
+                    var hasAllKeys = cookie && ["constraintName", "columnName", "origUrl", "rowname"].every(function (k) {
+                        return cookie.hasOwnProperty(k);
+                    });
+                    if (hasAllKeys) {
+                        $rootScope.cookieObj = cookie;
+
                         // Update view model
                         recordEditModel.rows[newRow][cookie.columnName] = cookie.rowname.value;
-                        
+
                         // the foreignkey data that we already have
                         recordEditModel.foreignKeyData[newRow][cookie.constraintName] = cookie.keys;
-                        
+
                         // show the spinner that means we're waiting for data.
                         $rootScope.showColumnSpinner[newRow][cookie.columnName] = true;
-                        
+
                         // get the actual foreignkey data
                         ERMrest.resolve(cookie.origUrl, {cid: context.appName}).then(function (ref) {
                             getForeignKeyData(newRow, cookie.columnName, cookie.constraintName, ref);
@@ -209,7 +215,7 @@
                             }
 
                             var column, value;
-                        
+
 
                             // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
                             $rootScope.tuples = [];
@@ -223,7 +229,7 @@
 
                                 var tuple = page.tuples[j],
                                     values = tuple.values;
-                                
+
                                 // attach the foreign key data of the tuple
                                 recordEditModel.foreignKeyData[j] = tuple.linkedData;
 
@@ -358,10 +364,10 @@
                                 if (defaultSet) {
                                     initialModelValue =  column.default;
                                     recordEditModel.foreignKeyData[0][column.foreignKey.name] = column.defaultValues;
-                                    
+
                                     // get the actual foreign key data
                                     getForeignKeyData(0, column.name, column.foreignKey.name, column.defaultReference);
-                                    
+
                                 }
                             } else {
                                 // all other column types
@@ -386,8 +392,8 @@
                 throw response;
             });
         });
-        
-        
+
+
         function getForeignKeyData (rowIndex, colName, fkName, fkRef) {
             fkRef.contextualize.compactSelect.read(1).then(function (page) {
                 $rootScope.showColumnSpinner[rowIndex][colName] = true;

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -394,6 +394,15 @@
         });
 
 
+        /**
+         * In case of prefill and default we only have a reference to the foreignkey,
+         * we should do extra reads to get the actual data.
+         *
+         * @param  {int} rowIndex The row index that this data is for (it's usually zero, first row)
+         * @param  {string} colName The name of the foreignkey pseudo column.
+         * @param  {string} fkName  The constraint name of the foreign key
+         * @param  {ERMrest.Refernece} fkRef   Reference to the foreign key table
+         */
         function getForeignKeyData (rowIndex, colName, fkName, fkRef) {
             fkRef.contextualize.compactSelect.read(1).then(function (page) {
                 $rootScope.showColumnSpinner[rowIndex][colName] = true;

--- a/test/e2e/data_setup/data/fk-filter-pattern/main-entity-table.json
+++ b/test/e2e/data_setup/data/fk-filter-pattern/main-entity-table.json
@@ -1,1 +1,3 @@
-[]
+[
+    {"id": 1, "fk1": 1, "fk_constrained_col":1, "position_fixed_col":1, "position_text_col": 1, "col_w_default": 6}
+]

--- a/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
+++ b/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
@@ -124,6 +124,71 @@
                             "column_name": "id"
                         }
                     ]
+                },
+                {
+                    "comment": "Foreign key that its constituent columns have default value.",
+                    "names": [["fk-filter-pattern", "fk_w_default"]],
+                    "foreign_key_columns": [
+                        {
+                            "table_name": "main-entity-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "col_w_default"
+                        }
+                    ],
+                    "annotations": {},
+                    "referenced_columns": [
+                        {
+                            "table_name": "fk-constrained-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "id"
+                        }
+                    ]
+                },
+                {
+                    "comment": "Foreign key with domain_filter_pattern using fk_w_default values.",
+                    "names": [["fk-filter-pattern", "fk_w_fkeys_default"]],
+                    "foreign_key_columns": [
+                        {
+                            "table_name": "main-entity-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "col_w_fkeys_default"
+                        }
+                    ],
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:foreign-key": {
+                            "domain_filter_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_default}}"
+                        }
+                    },
+                    "referenced_columns": [
+                        {
+                            "table_name": "fk-constrained-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "id"
+                        }
+                    ]
+                },
+                {
+                    "comment": "Foreign key that its constituent columns have default value.",
+                    "names": [["fk-filter-pattern", "fk_w_fkeys"]],
+                    "foreign_key_columns": [
+                        {
+                            "table_name": "main-entity-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "col_w_fkeys"
+                        }
+                    ],
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:foreign-key": {
+                            "domain_filter_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_fkeys_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_fkeys_default}}"
+                        }
+                    },
+                    "referenced_columns": [
+                        {
+                            "table_name": "fk-constrained-table",
+                            "schema_name": "fk-filter-pattern",
+                            "column_name": "id"
+                        }
+                    ]
                 }
             ],
             "table_name": "main-entity-table",
@@ -182,6 +247,28 @@
                     "comment": "Column constrained by 2 values.",
                     "name": "multi_constrained_col",
                     "nullok": true,
+                    "type": {
+                        "typename": "int4"
+                    }
+                },
+                {
+                    "comment": "foreign key column with default value",
+                    "name": "col_w_default",
+                    "default": 4,
+                    "type": {
+                        "typename": "int4"
+                    }
+                },
+                {
+                    "comment": "foreign key column",
+                    "name": "col_w_fkeys_default",
+                    "type": {
+                        "typename": "int4"
+                    }
+                },
+                {
+                    "comment": "foreign key column",
+                    "name": "col_w_fkeys",
                     "type": {
                         "typename": "int4"
                     }

--- a/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
+++ b/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
@@ -45,7 +45,7 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "fk2={{{fk1}}}"
+                            "domain_filter_pattern": "fk2={{{_fk1}}}"
                         }
                     },
                     "referenced_columns": [
@@ -91,7 +91,7 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "position_type_col={{{position_text_col}}}"
+                            "domain_filter_pattern": "position_type_col={{{_position_text_col}}}"
                         }
                     },
                     "referenced_columns": [
@@ -114,7 +114,7 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "fk2={{{fk1}}}&position_col={{{position_text_col}}}"
+                            "domain_filter_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}"
                         }
                     },
                     "referenced_columns": [

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -195,10 +195,12 @@ describe('Record Add', function() {
                 // Write a dummy cookie for creating a record in Accommodation table
                 testCookie = {
                     constraintName: 'product-add_fk_category', // A FK that Accommodation table has with Category table
+                    columnName: 'product-add_fk_category',
                     rowname: {
                         value: chance.sentence()
                     },
-                    keys: {id: 1}
+                    keys: {id: 1},
+                    origUrl: browser.params.url + "/record/#" + browser.params.catalogId + "/product-add:category/id=1"
                 };
                 browser.manage().addCookie({name: 'test', value: JSON.stringify(testCookie)});
             });

--- a/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
+++ b/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
@@ -8,6 +8,54 @@ describe("Domain filter pattern support,", function() {
     var EC = protractor.ExpectedConditions,
         sleepTimer = 200;
 
+    var testModalCount = function (colName, expectedCount, done, choose) {
+        var errorCB = function (err) {
+            console.log(err);
+            done.fail();
+        };
+        var successCB = function () {
+            done();
+        };
+
+        var fk,modal, rows;
+
+        fk = chaisePage.recordEditPage.getForeignKeyInputDisplay(colName, 0);
+        browser.wait(EC.elementToBeClickable(fk));
+        fk.click().then(function () {
+            modal = chaisePage.recordEditPage.getModalTitle();
+            browser.wait(EC.visibilityOf(modal), browser.params.defaultTimeout);
+
+            return modal.getText();
+        }).then(function(text) {
+            expect(text.indexOf("Choose")).toBeGreaterThan(-1);
+
+            browser.wait(function () {
+                return chaisePage.recordsetPage.getRows().count().then(function (ct) {
+                    return (ct > 0);
+                });
+            });
+
+            rows = chaisePage.recordsetPage.getRows();
+            return rows.count();
+        }).then(function(ct) {
+            expect(ct).toBe(expectedCount, "count missmatch.");
+
+            var promise;
+            if (!choose) {
+                chaisePage.recordEditPage.getModalCloseBtn().click().then(function () {
+                    successCB();
+                }).catch(errorCB);
+            } else {
+                rows.get(0).all(by.css(".select-action-button")).then(function(selectButtons) {
+                    // select the row
+                    return selectButtons[0].click();
+                }).then(function () {
+                    successCB();
+                }).catch(errorCB);
+            }
+        }).catch(errorCB);
+    };
+
     describe("For table " + testParams.table_name + ',', function() {
 
         var rows, modalTitle,
@@ -15,13 +63,10 @@ describe("Domain filter pattern support,", function() {
             colWFkeys = "col_w_fkeys",
             colWFkeysDefault = "col_w_fkeys_default";
 
-        beforeAll(function () {
-            browser.ignoreSynchronization = true;
-        });
-
         describe("In create mode, ", function() {
 
             beforeAll(function() {
+                browser.ignoreSynchronization = true;
                 browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/fk-filter-pattern:" + testParams.table_name);
 
                 // the copy btn will be disabled while data is loading.
@@ -32,166 +77,50 @@ describe("Domain filter pattern support,", function() {
                 modalTitle = chaisePage.recordEditPage.getModalTitle();
             });
 
-            it("with a domain filter with a static value.", function() {
-                var colName = "position_fixed_col";
-
-                chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
-                    return chaisePage.recordEditPage.getForeignKeyInputButton(colName, 0).click();
-                }).then(function () {
-                    browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                    return modalTitle.getText();
-                }).then(function(text) {
-                    expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                    rows = chaisePage.recordsetPage.getRows();
-
-                    return rows.count();
-                }).then(function(ct) {
-                    // set is size 7, verifies set is limited by existing domain filter pattern
-                    expect(ct).toBe(3);
-
-                    return rows.get(1).all(by.css(".select-action-button"));
-                }).then(function(selectButtons) {
-                    selectButtons[0].click();
-                    browser.sleep(sleepTimer);
-                }).catch(function (err) {
-                    console.log(err);
-                });
+            it("with a domain filter with a static value.", function(done) {
+                testModalCount("position_fixed_col", 3, done, true);
             });
 
-            it("should not limit the fk set before setting either values for multi constrained fk.", function() {
-                chaisePage.recordEditPage.getForeignKeyInputButton(multiColName, 0).click().then(function () {
-                    browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                    return modalTitle.getText();
-                }).then(function(text) {
-                    expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                    rows = chaisePage.recordsetPage.getRows();
-
-                    return rows.count();
-                }).then(function(ct) {
-                    // set is size 7, domain filter should have evaluated to null
-                    expect(ct).toBe(7);
-
-                    chaisePage.recordEditPage.getModalCloseBtn().click();
-                    browser.sleep(sleepTimer);
-                }).catch(function (err) {
-                    console.log(err);
-                });
+            it("should not limit the fk set before setting either values for multi constrained fk.", function(done) {
+                testModalCount(multiColName, 7, done);
             });
 
             describe("with a domain filter with a dynamic value from a text entry box", function() {
-                var fkColName = "position_fk_col"
+                var fkColName = "position_fk_col";
 
-                it("that isn't set should have the full set.", function() {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(fkColName, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                        rows = chaisePage.recordsetPage.getRows();
-
-                        return rows.count();
-                    }).then(function(ct) {
-                        // set is size 7, domain filter should have evaluated to null
-                        expect(ct).toBe(7);
-
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
-                        browser.sleep(sleepTimer);
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
+                it("that isn't set should have the full set.", function(done) {
+                    testModalCount(fkColName, 7, done);
                 });
 
-                it("should limit the set.", function() {
+                it("should limit the set.", function(done) {
                     var textColName = "position_text_col",
                         textInputVal = "relative";
 
                     var textInput = chaisePage.recordEditPage.getInputById(0, textColName);
                     textInput.sendKeys(textInputVal);
 
-                    chaisePage.recordEditPage.getForeignKeyInputButton(fkColName, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                        rows = chaisePage.recordsetPage.getRows();
-
-                        return rows.count();
-                    }).then(function(ct) {
-                        // set is size 7, verifies set is limited by existing domain filter pattern and user input
-                        expect(ct).toBe(1);
-
-                        return rows.get(0).all(by.css(".select-action-button"));
-                    }).then(function(selectButtons) {
-                        selectButtons[0].click();
-                        browser.sleep(sleepTimer);
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
+                    testModalCount(fkColName, 1, done, true);
                 });
             });
 
-            it("should not limit the fk set before setting the 2nd value for multi constrained fk.", function() {
-                chaisePage.recordEditPage.getForeignKeyInputButton(multiColName, 0).click().then(function () {
-                    browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                    return modalTitle.getText();
-                }).then(function(text) {
-                    expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                    rows = chaisePage.recordsetPage.getRows();
-
-                    return rows.count();
-                }).then(function(ct) {
-                    // set is size 7, domain filter should have evaluated to null
-                    expect(ct).toBe(7);
-
-                    chaisePage.recordEditPage.getModalCloseBtn().click();
-                    browser.sleep(sleepTimer);
-                }).catch(function (err) {
-                    console.log(err);
-                });
+            it("should not limit the fk set before setting the 2nd value for multi constrained fk.", function(done) {
+                testModalCount(multiColName, 7, done);
             });
 
             describe("with a domain filter with a dynamic value from a fk selector ", function() {
                 var fkColName = "fk_constrained_col";
 
-                it("that isn't set should have the full set.", function() {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(fkColName, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
+                it("that isn't set should have the full set.", function(done) {
+                    testModalCount(fkColName, 7, done);
 
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-                        rows = chaisePage.recordsetPage.getRows();
-                        return rows.count();
-                    }).then(function(ct) {
-                        // set is size 7, domain filter should have evaluated to null
-                        expect(ct).toBe(7);
-
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
-                        browser.sleep(sleepTimer);
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
                 });
 
-                it("should limit the set.", function() {
+                it("should limit the set.", function(done) {
                     var constraintColName = "fk1";
-
-                    chaisePage.recordEditPage.getForeignKeyInputButton(constraintColName, 0).click().then(function () {
+                    var currFk;
+                    currFk = chaisePage.recordEditPage.getForeignKeyInputDisplay(constraintColName, 0);
+                    browser.wait(EC.elementToBeClickable(currFk));
+                    currFk.click().then(function () {
                         browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
                         return modalTitle.getText();
                     }).then(function(text) {
@@ -202,13 +131,10 @@ describe("Domain filter pattern support,", function() {
 
                         return selectButtons[0].click();
                     }).then(function() {
-                        // this browser.wait triggers before the formTitle is actually visible (to the eyes). It appears to
-                        // trigger regardless because the title is visible on the document even with the modal open. Need a
-                        // wait clause based around a modal closing
-                        // browser.wait(EC.visibilityOf(chaisePage.recordEditPage.getFormTitle()), browser.params.defaultTimeout);
-                        browser.sleep(sleepTimer);
+                        currFk = chaisePage.recordEditPage.getForeignKeyInputButton(fkColName, 0);
+                        browser.wait(EC.elementToBeClickable(currFk));
 
-                        return chaisePage.recordEditPage.getForeignKeyInputButton(fkColName, 0).click();
+                        return currFk.click();
                     }).then(function() {
                         browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
 
@@ -220,115 +146,38 @@ describe("Domain filter pattern support,", function() {
 
                         return rows.count();
                     }).then(function(ct) {
-                        expect(ct).toBe(3);
+                        expect(ct).toBe(3, "count missmatch");
 
                         return rows.get(0).all(by.css(".select-action-button"));
                     }).then(function(selectButtons) {
-                        selectButtons[0].click();
-                        browser.sleep(sleepTimer);
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
-                });
-            });
-
-            it("with a domain filter with a conjunction, should limit the set.", function() {
-                chaisePage.recordEditPage.getForeignKeyInputButton(multiColName, 0).click().then(function () {
-                    browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                    return modalTitle.getText();
-                }).then(function(text) {
-                    expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                    rows = chaisePage.recordsetPage.getRows();
-
-                    return rows.count();
-                }).then(function(ct) {
-                    expect(ct).toBe(1);
-
-                    return rows.get(0).all(by.css(".select-action-button"));
-                }).then(function(selectButtons) {
-                    selectButtons[0].click();
-                    browser.sleep(sleepTimer);
-                });
-            });
-
-            describe("with a domain filter with a dynamic value from other foreignkey tables.", function () {
-                // open col_w_fkeys
-                it ("should not limit the set before setting the value for other foreignkey in absence of default value.", function () {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeys, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-                        rows = chaisePage.recordsetPage.getRows();
-                        return rows.count();
-                    }).then(function(ct) {
-                        expect(ct).toBe(7, "count missmatch.");
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
-                        browser.sleep(sleepTimer);
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
-                });
-
-                // open col_w_fkeys_default, select something.
-                it ("should limit the set before setting the value if other foreignkey has default value.", function () {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeysDefault, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-
-                        rows = chaisePage.recordsetPage.getRows();
-                        return rows.count();
-                    }).then(function(ct) {
-                        // this is filtered to be two rows
-                        expect(ct).toBe(2, "count missmatch.");
-
-                        return rows.get(0).all(by.css(".select-action-button"));
-                    }).then(function(selectButtons) {
-                        // select the row
-                        selectButtons[0].click();
-                    }).catch(function (err) {
-                        console.log(err);
-                    });
-                });
-
-                //open col_w_fkeys again
-                it ("should limit the set after choosing a foreign key.", function (done) {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeys, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-                        return chaisePage.recordsetPage.getRows().count();
-                    }).then(function(ct) {
-                        expect(ct).toBe(2, "count missmatch.");
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
+                        return selectButtons[0].click();
+                    }).then(function () {
                         done();
                     }).catch(function (err) {
                         console.log(err);
                         done.fail();
                     });
+                });
+            });
+
+            it("with a domain filter with a conjunction, should limit the set.", function(done) {
+                testModalCount(multiColName, 1, done, true);
+            });
+
+            describe("with a domain filter with a dynamic value from other foreignkey tables.", function () {
+                // open col_w_fkeys
+                it ("should not limit the set before setting the value for other foreignkey in absence of default value.", function (done) {
+                    testModalCount(colWFkeys, 7, done);
+                });
+
+                // open col_w_fkeys_default, select something.
+                it ("should limit the set before setting the value if other foreignkey has default value.", function (done) {
+                    testModalCount(colWFkeysDefault, 2, done, true);
+                });
+
+                //open col_w_fkeys again
+                it ("should limit the set after choosing a foreign key.", function (done) {
+                    testModalCount(colWFkeys, 2, done);
                 });
 
 
@@ -352,7 +201,8 @@ describe("Domain filter pattern support,", function() {
                         return chaisePage.recordsetPage.getRows().count();
                     }).then(function(ct) {
                         expect(ct).toBe(7);
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
+                        return chaisePage.recordEditPage.getModalCloseBtn().click();
+                    }).then(function () {
                         done();
                     }).catch(function (err) {
                         console.log(err);
@@ -366,59 +216,20 @@ describe("Domain filter pattern support,", function() {
 
         describe("In edit mode, ", function () {
             beforeAll(function() {
+                browser.ignoreSynchronization=true;
                 browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/fk-filter-pattern:" + testParams.table_name + "/id=1");
-
-                browser.wait(EC.elementToBeClickable(element(by.id("submit-record-button"))));
+                chaisePage.waitForElement(element(by.id("submit-record-button")));
             });
 
             describe("with a domain filter with a dynamic value from other foreignkey tables.", function () {
                 it ("if foreign key has value, the foreignkey that is using its value should be limited.", function (done) {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeysDefault, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-                        return chaisePage.recordsetPage.getRows().count();
-                    }).then(function(ct) {
-                        expect(ct).toBe(1, "count missmatch.");
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
-                        done();
-                    }).catch(function (err) {
-                        console.log(err);
-                        done.fail();
-                    });
+                    testModalCount(colWFkeysDefault, 1, done);
                 });
 
                 it ("otherwise it should not be limited.", function (done) {
-                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeys, 0).click().then(function () {
-                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
-
-                        return modalTitle.getText();
-                    }).then(function(text) {
-                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
-
-                        browser.wait(function () {
-                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                return (ct > 0);
-                            });
-                        });
-                        return chaisePage.recordsetPage.getRows().count();
-                    }).then(function(ct) {
-                        expect(ct).toBe(7, "count missmatch.");
-                        chaisePage.recordEditPage.getModalCloseBtn().click();
-                        done();
-                    }).catch(function (err) {
-                        console.log(err);
-                        done.fail();
-                    });
+                    testModalCount(colWFkeys, 7, done);
                 });
+
             });
         });
     });

--- a/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
+++ b/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
@@ -271,6 +271,7 @@ describe("Domain filter pattern support,", function() {
                     }).then(function(ct) {
                         expect(ct).toBe(7, "count missmatch.");
                         chaisePage.recordEditPage.getModalCloseBtn().click();
+                        browser.sleep(sleepTimer);
                     }).catch(function (err) {
                         console.log(err);
                     });
@@ -361,6 +362,64 @@ describe("Domain filter pattern support,", function() {
 
             });
 
+        });
+
+        describe("In edit mode, ", function () {
+            beforeAll(function() {
+                browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/fk-filter-pattern:" + testParams.table_name + "/id=1");
+
+                browser.wait(EC.elementToBeClickable(element(by.id("submit-record-button"))));
+            });
+
+            describe("with a domain filter with a dynamic value from other foreignkey tables.", function () {
+                it ("if foreign key has value, the foreignkey that is using its value should be limited.", function (done) {
+                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeysDefault, 0).click().then(function () {
+                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
+
+                        return modalTitle.getText();
+                    }).then(function(text) {
+                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
+
+                        browser.wait(function () {
+                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
+                                return (ct > 0);
+                            });
+                        });
+                        return chaisePage.recordsetPage.getRows().count();
+                    }).then(function(ct) {
+                        expect(ct).toBe(1, "count missmatch.");
+                        chaisePage.recordEditPage.getModalCloseBtn().click();
+                        done();
+                    }).catch(function (err) {
+                        console.log(err);
+                        done.fail();
+                    });
+                });
+
+                it ("otherwise it should not be limited.", function (done) {
+                    chaisePage.recordEditPage.getForeignKeyInputButton(colWFkeys, 0).click().then(function () {
+                        browser.wait(EC.visibilityOf(modalTitle), browser.params.defaultTimeout);
+
+                        return modalTitle.getText();
+                    }).then(function(text) {
+                        expect(text.indexOf("Choose")).toBeGreaterThan(-1);
+
+                        browser.wait(function () {
+                            return chaisePage.recordsetPage.getRows().count().then(function (ct) {
+                                return (ct > 0);
+                            });
+                        });
+                        return chaisePage.recordsetPage.getRows().count();
+                    }).then(function(ct) {
+                        expect(ct).toBe(7, "count missmatch.");
+                        chaisePage.recordEditPage.getModalCloseBtn().click();
+                        done();
+                    }).catch(function (err) {
+                        console.log(err);
+                        done.fail();
+                    });
+                });
+            });
         });
     });
 });

--- a/test/e2e/specs/default-config/recordedit/immutable-inputs.spec.js
+++ b/test/e2e/specs/default-config/recordedit/immutable-inputs.spec.js
@@ -11,8 +11,8 @@ var testParams = {
         text_disabled_value: "Disabled input",
         markdown_value: "**bold**",
         markdown_disabled_value: "*italics*",
-        foreign_key_value: "2",
-        foreign_key_disabled_value: "5",
+        foreign_key_value: "Default for foreign_key column", // rowname of the fk
+        foreign_key_disabled_value: "Default for foreign_key_disabled column", // rowname of the fk
         int_value: "25",
         int_disabled_value: "20",
         float_value: "1.6478",
@@ -141,7 +141,7 @@ describe('Record Add with defaults', function() {
             expect(jsonInputDisabled.getAttribute("value")).toBe(values.json_disabled_value, "JSON disabled input default is incorrect");
 
         });
-        
+
         //JOSN columns
         it("should initialize json columns properly if they are disabled without a default.", function() {
             jsonDisabledNoDefaultInput = chaisePage.recordEditPage.getInputById(0, "json_disabled_no_default");
@@ -149,7 +149,7 @@ describe('Record Add with defaults', function() {
             expect(jsonDisabledNoDefaultInput.getAttribute("value")).toBe("", "The disabled json value is incorrect");
             expect(jsonDisabledNoDefaultInput.getAttribute("placeholder")).toBe(values.json_disabled_no_default_value, "The disabled json placeholder is incorrect");
         });
-        
+
         // Timestamp columns
         it("should intialize timestamp columns properly with a default value.", function() {
             timestampInputs = chaisePage.recordEditPage.getTimestampInputsForAColumn("timestamp", 0);
@@ -188,13 +188,16 @@ describe('Record Add with defaults', function() {
 
         // Foreign key columns
         it("should initialize foreign key inputs with their default value.", function() {
+            // the copy btn will be disabled while data is loading.
+            browser.wait(EC.elementToBeClickable(element(by.id("copy-record-btn"))));
+
             foreignKeyInput = chaisePage.recordEditPage.getForeignKeyInputDisplay("foreign_key", 0);
             foreignKeyDisabledInput = chaisePage.recordEditPage.getForeignKeyInputDisplay("foreign_key_disabled", 0);
 
             expect(foreignKeyInput.getText()).toBe(values.foreign_key_value, "Foreign key input default is incorrect");
             expect(foreignKeyDisabledInput.getText()).toBe(values.foreign_key_disabled_value, "Foreign key disabled default is incorrect");
         });
-        
+
         // TODO write tests for default values for composite foreign keys when implemented
 
         describe("Submit the form", function() {


### PR DESCRIPTION
This include changes to add $fkeys support to domain_filter_pattern. 

The changes that I made for each scenario are:

1. For edit/copy mode: Attach `linkedData` (data from foreignkeys) to `vm.foreignKeyData`. So it can be used for `filteredRef`.

2. For create mode: Generate extra requests to get the actual value of foreign keys that have default value (Show spinner and also make the add multiple button disabled).

3. For pre-fill mode: Pass extra information so we can get the actual value of the foreignkey, instead of passing all the values of that table (Show spinner and also make the add multiple button disabled).

4. changing the foreignkey: Update the `foreignKeyData`. If foreign key data is loading (default or pre-fill) ignore that and just use the user-selected value.

5. clearing a foreign key: Update the `foreignKeyData`.

Test Cases:
I had to update some testcases based on the changes that I made. I also added extra test cases to the `domain-filter.spec.js` for create and edit mode.

_You need [ermrestjs#565](https://github.com/informatics-isi-edu/ermrestjs/pull/565) for testing this._
