### PR TITLE
Removed filters from add link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ testdefaultconfig: test-DEFAULT_CONFIG_PARALLEL_TESTS
 
 #Rule to run the default chaise configuration tests in parallel
 .PHONY: testfooter
-testfooter: test-FOOTER_TESTS	
+testfooter: test-FOOTER_TESTS
 
 # Rule to run tests
 .PHONY: test

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.record')
 
-    .controller('RecordController', ['AlertsService', 'DataUtils', 'ErrorService', 'MathUtils', 'messageMap', 'modalBox', 'recordCreate', 'UiUtils', 'UriUtils', '$cookies', '$document', '$log', '$rootScope', '$scope', '$uibModal', '$window', 
+    .controller('RecordController', ['AlertsService', 'DataUtils', 'ErrorService', 'MathUtils', 'messageMap', 'modalBox', 'recordCreate', 'UiUtils', 'UriUtils', '$cookies', '$document', '$log', '$rootScope', '$scope', '$uibModal', '$window',
         function RecordController(AlertsService, DataUtils, ErrorService, MathUtils, messageMap, modalBox, recordCreate, UiUtils, UriUtils, $cookies, $document, $log, $rootScope, $scope, $uibModal, $window) {
         var vm = this;
         var addRecordRequests = {}; // <generated unique id : reference of related table>
@@ -117,7 +117,7 @@
         };
 
         // Send user to RecordEdit to create a new row in this related table
-        function onSuccess (){    
+        function onSuccess (){
             AlertsService.addAlert("Your data has been submitted. Showing you the result set...","success");
             vm.resultset = true;
             onfocusEventCall(true);
@@ -162,7 +162,7 @@
             addRecordRequests[referrer_id] = ref.uri;
 
             // 3. Get appLink, append ?prefill=[COOKIE_NAME]&referrer=[referrer_id]
-            var appLink = (ref.derivedAssociationReference ? ref.derivedAssociationReference.contextualize.entryCreate.appLink : ref.contextualize.entryCreate.appLink);
+            var appLink = ref.unfilteredReference.contextualize.entryCreate.appLink;
             appLink = appLink + (appLink.indexOf("?") === -1? "?" : "&") +
                 'prefill=' + UriUtils.fixedEncodeURIComponent(COOKIE_NAME) +
                 '&invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);


### PR DESCRIPTION
This PR addresses issue #1398.

There aren't any test cases that look for the url including a filter or facet blob so none of the tests had to be changed. Those tests instead verify the data being displayed on the page instead and that the prefill param worked properly.