### PR TITLE
redirectlink missing in recordedit app

### DIFF
--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -211,7 +211,8 @@
 
                             if (page.tuples.length < 1) {
                                 // TODO: understand the filter that was used and relate that information to the user (it oucld be a facet filter now)
-                                throw new Errors.noRecordError();
+                                var recordSetLink = page.reference.unfilteredReference.contextualize.compact.appLink;
+                                throw new Errors.noRecordError({}, recordSetLink);
                             }
 
                             var column, value;

--- a/test/e2e/data_setup/config/errors/config.json
+++ b/test/e2e/data_setup/config/errors/config.json
@@ -1,0 +1,15 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "product-record",
+        "createNew": true,
+        "path": "test/e2e/data_setup/schema/record/product.json"
+    },
+    "tables": {
+        "createNew": true
+    },
+    "entities": {
+        "createNew": true,
+        "path": "test/e2e/data_setup/data/product"
+    }
+}

--- a/test/e2e/data_setup/config/errors/dev.json
+++ b/test/e2e/data_setup/config/errors/dev.json
@@ -1,0 +1,9 @@
+{
+    "setup": {
+        "schemaConfigurations": [
+            "errors/config.json"
+        ],
+        "schema": "product-record"
+    },
+    "cleanup": true
+}

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -23,11 +23,9 @@ describe('Error related to Record App,', function() {
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));
         });
 
-        it('A error modal window should appear with Record Not Found title', function(){
+        it('An error modal window should appear with Record Not Found title', function(){
             var modalTitle = chaisePage.recordPage.getErrorModalTitle();
-
             expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
-
         });
 
         it('On click of OK button the page should redirect to recordset/search page', function(){
@@ -36,7 +34,40 @@ describe('Error related to Record App,', function() {
             }).then (function (){
                 return browser.driver.getCurrentUrl();
             }).then (function(currentUrl) {
-                var recordsetUrl = url.replace("record", "recordset") + "@sort(id)";
+              var newapplink = url.replace("record", "recordset"),
+                  lastSlash = newapplink.lastIndexOf("/"),
+                  recordsetUrl = newapplink.slice(0, lastSlash);
+                expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+            }).catch( function(err) {
+                console.log(error);
+                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
+            });
+        });
+    });
+
+    describe("For no record found in RecordEdit app", function() {
+
+        beforeAll(function() {
+          browser.ignoreSynchronization=true;
+            url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
+            browser.get(url);
+            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
+        });
+
+        it('An error modal window should appear with Record Not Found title', function(){
+            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
+            expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
+        });
+
+        it('On click of OK button the page should redirect to recordset/search page', function(){
+            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                return btn.click();
+            }).then (function (){
+                return browser.driver.getCurrentUrl();
+            }).then (function(currentUrl) {
+                var newapplink = url.replace("recordedit", "recordset"),
+                    lastSlash = newapplink.lastIndexOf("/"),
+                    recordsetUrl = newapplink.slice(0, lastSlash);
                 expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
             }).catch( function(err) {
                 console.log(error);

--- a/test/e2e/specs/all-features-confirmation/errors/protractor.conf.js
+++ b/test/e2e/specs/all-features-confirmation/errors/protractor.conf.js
@@ -1,7 +1,7 @@
 var pConfig = require('./../../../utils/protractor.configuration.js');
 
 var config = pConfig.getConfig({
-    configFileName: 'parallel-configs/all-features-confirmation.dev.json',
+    configFileName: 'errors/dev.json',
     specs: [
         "errors.spec.js"
     ],


### PR DESCRIPTION
This PR addresses #1405 .
- Recordset redirect link was missing in `recordedit` app and has been fixed in this PR.
- Test cases for redirect links have been fixed.