### PR TITLE
Tests for system column defaults in recordedit

### DIFF
--- a/test/e2e/data_setup/schema/recordedit/defaults.json
+++ b/test/e2e/data_setup/schema/recordedit/defaults.json
@@ -326,11 +326,35 @@
                     "type": {
                         "typename": "text"
                     }
+                }, {
+                    "name": "RID",
+                    "default": "someFunc()",
+                    "type": { "typename": "text" }
+                },
+                {
+                    "name": "RCB",
+                    "default": "someFunc()",
+                    "type": { "typename": "text" }
+                },
+                {
+                    "name": "RMB",
+                    "default": "someFunc()",
+                    "type": { "typename": "text" }
+                },
+                {
+                    "name": "RCT",
+                    "default": "",
+                    "type": { "typename": "timestamptz" }
+                },
+                {
+                    "name": "RMT",
+                    "default": "",
+                    "type": { "typename": "timestamptz" }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns": {
-                    "entry/create": ["text", "text_disabled", "markdown", "markdown_disabled", ["defaults", "fk_text"], ["defaults", "fk_text_disabled"], "int", "int_disabled", "float", "float_disabled", "boolean_true", "boolean_false", "boolean_disabled", "date", "date_disabled", "timestamp", "timestamp_disabled", "timestamp_disabled_no_default", "timestamptz", "timestamptz_disabled", "timestamptz_disabled_no_default", "json", "json_disabled", "json_disabled_no_default"],
+                    "entry/create": ["text", "text_disabled", "markdown", "markdown_disabled", ["defaults", "fk_text"], ["defaults", "fk_text_disabled"], "int", "int_disabled", "float", "float_disabled", "boolean_true", "boolean_false", "boolean_disabled", "date", "date_disabled", "timestamp", "timestamp_disabled", "timestamp_disabled_no_default", "timestamptz", "timestamptz_disabled", "timestamptz_disabled_no_default", "json", "json_disabled", "json_disabled_no_default", "RID", "RCB", "RMB", "RCT", "RMT"],
                     "entry/edit": ["text", "text_disabled", "markdown_disabled", ["defaults", "fk_text_disabled"], "int_disabled", "float_disabled", "boolean_disabled", "date_disabled", "timestamp_disabled", "timestamptz_disabled", "json_disabled", "asset_disabled"],
                     "detailed": ["text", "text_disabled", "markdown", "markdown_disabled", ["defaults", "fk_text"], ["defaults", "fk_text_disabled"], "int", "int_disabled", "float", "float_disabled", "boolean_true", "boolean_false", "boolean_disabled", "date", "date_disabled", "timestamp", "timestamp_disabled", "timestamp_disabled_no_default", "timestamptz", "timestamptz_disabled", "timestamptz_disabled_no_default", "json", "json_disabled", "json_disabled_no_default"]
                 }

--- a/test/e2e/specs/default-config/recordedit/immutable-inputs.spec.js
+++ b/test/e2e/specs/default-config/recordedit/immutable-inputs.spec.js
@@ -34,7 +34,12 @@ var testParams = {
         timestamptz_disabled_no_default_value: "Automatically generated",
         json_value:JSON.stringify({"name":"testing_json"}),
         json_disabled_value:JSON.stringify(98.786),
-        json_disabled_no_default_value: "Automatically generated"
+        json_disabled_no_default_value: "Automatically generated",
+        rid_disabled_value: "Automatically generated",
+        rcb_disabled_value: "Automatically generated",
+        rmb_disabled_value: "Automatically generated",
+        rct_disabled_value: "Automatically generated",
+        rmt_disabled_value: "Automatically generated"
     },
     record_column_values: {
     // data values
@@ -196,6 +201,21 @@ describe('Record Add with defaults', function() {
 
             expect(foreignKeyInput.getText()).toBe(values.foreign_key_value, "Foreign key input default is incorrect");
             expect(foreignKeyDisabledInput.getText()).toBe(values.foreign_key_disabled_value, "Foreign key disabled default is incorrect");
+        });
+
+        // System columns
+        it("should initialize system column inputs with 'Automatically Generated'.", function() {
+            var ridDisabledInput = chaisePage.recordEditPage.getInputById(0, "RID"),
+                rcbDisabledInput = chaisePage.recordEditPage.getInputById(0, "RCB"),
+                rmbDisabledInput = chaisePage.recordEditPage.getInputById(0, "RMB"),
+                rctDisabledInput = chaisePage.recordEditPage.getInputById(0, "RCT"),
+                rmtDisabledInput = chaisePage.recordEditPage.getInputById(0, "RMT");
+
+            expect(ridDisabledInput.getAttribute("placeholder")).toBe(values.rid_disabled_value, "RID disabled input default is incorrect");
+            expect(rcbDisabledInput.getAttribute("placeholder")).toBe(values.rcb_disabled_value, "RCB disabled input default is incorrect");
+            expect(rmbDisabledInput.getAttribute("placeholder")).toBe(values.rmb_disabled_value, "RMB disabled input default is incorrect");
+            expect(rctDisabledInput.getAttribute("placeholder")).toBe(values.rct_disabled_value, "RCT disabled input default is incorrect");
+            expect(rmtDisabledInput.getAttribute("placeholder")).toBe(values.rmt_disabled_value, "RMT disabled input default is incorrect");
         });
 
         // TODO write tests for default values for composite foreign keys when implemented


### PR DESCRIPTION
This PR adds tests to the immutable-inputs spec. This is to verify that even when a default is set, `recordedit` still shows "Automatically generated". This resolves issue [#562](https://github.com/informatics-isi-edu/ermrestjs/issues/562) in `ermrestJS`.