### PR TITLE
Facet Not Null Support

### DIFF
--- a/common/ellipses.js
+++ b/common/ellipses.js
@@ -9,7 +9,8 @@
         };
     }])
 
-    .directive('ellipses', ['AlertsService', 'ErrorService', 'MathUtils', 'messageMap', 'modalBox', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$sce', '$timeout', '$uibModal', '$window', function(AlertsService, ErrorService, MathUtils, messageMap, modalBox, UiUtils, UriUtils, $log, $rootScope, $sce, $timeout, $uibModal, $window) {
+    .directive('ellipses', ['AlertsService', 'ErrorService', 'MathUtils', 'messageMap', 'modalBox', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$sce', '$timeout', '$uibModal', '$window', 'defaultDisplayname',
+        function(AlertsService, ErrorService, MathUtils, messageMap, modalBox, UiUtils, UriUtils, $log, $rootScope, $sce, $timeout, $uibModal, $window, defaultDisplayname) {
 
         function deleteReference(scope, reference) {
             if (chaiseConfig.confirmDelete === undefined || chaiseConfig.confirmDelete) {
@@ -75,6 +76,7 @@
                     scope.noSelect = modalBox.noSelect;
                     scope.singleSelect = modalBox.singleSelectMode;
                     scope.multiSelect = modalBox.multiSelectMode;
+                    scope.defaultDisplayname = defaultDisplayname;
 
                     var editLink = null;
 

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -4,7 +4,7 @@
     angular.module('chaise.faceting', ['plotly'])
 
         .directive('faceting', ['recordTableUtils', '$timeout', '$rootScope', function (recordTableUtils, $timeout, $rootScope) {
-            
+
             return {
                 restrict: 'AE',
                 templateUrl: '../common/templates/faceting/faceting.html',
@@ -13,16 +13,16 @@
                 },
                 controller: ['$scope', function ($scope) {
                     var ctrl = this;
-                    
+
                     ctrl.childCtrls = []; // child controllers
-                    
+
                     ctrl.facetingCount = 0;
-                    
+
                     // register a children controller in here
                     ctrl.register = function (childCtrl, facetColumn, index) {
                         ctrl.childCtrls[index] = childCtrl;
                         ctrl.facetingCount++;
-                        
+
                         $scope.vm.facetModels[index] = {
                             initialized: false,
                             isOpen: false,
@@ -32,29 +32,29 @@
                             updateFacet: childCtrl.updateFacet,
                             initializeFacet: childCtrl.initializeFacet
                         };
-                        
+
                         if (ctrl.facetingCount === $scope.vm.reference.facetColumns.length) {
                             $rootScope.facetsLoaded = true;
                         }
                     };
-                    
+
                     ctrl.updateVMReference = function (reference, index) {
                         return $scope.updateReference(reference, index);
                     };
-                    
+
                     ctrl.setInitialized = function () {
                         $scope.vm.facetModels.forEach(function (fm, index) {
                             if (fm.isOpen) fm.initialized = false;
                         });
                     };
-                    
+
                     ctrl.updateFacetColumn = function (index) {
                         var fm = $scope.vm.facetModels[index];
                         fm.processed = false;
                         fm.isLoading = true;
                         recordTableUtils.updatePage($scope.vm);
                     };
-                    
+
                     ctrl.focusOnFacet = function (index) {
                         $scope.focusOnFacet(index);
                     }
@@ -70,12 +70,12 @@
                         scope.$emit('facet-modified');
                         return true;
                     };
-                    
+
                     scope.hasFilter = function (index) {
                         if (!scope.vm.facetModels || (index !== undefined && !scope.vm.facetModels[index])) {
                             return false;
                         }
-                        
+
                         if (typeof index === 'undefined') {
                             return scope.vm.facetModels.some(function (fm) {
                                 return fm.appliedFilters.length > 0;
@@ -93,21 +93,21 @@
                             scope.vm.facetModels.forEach(function (fm) {
                                 fm.appliedFilters = [];
                             });
-                            
+
                             scope.vm.search = null;
                             if (scope.vm.reference.location.searchTerm) {
                                 newRef = newRef.search();
                             }
-                            
+
                         } else {
                             // delete all fitler for one column
                             newRef = scope.vm.reference.facetColumns[index].removeAllFilters();
                             scope.vm.facetModels[index].appliedFilters = [];
-                        } 
-                        
+                        }
+
                         scope.updateReference(newRef, -1);
                     };
-                    
+
                     /**
                      * open or close the facet given its index
                      * @param  {int} index index of facet
@@ -115,23 +115,23 @@
                     scope.toggleFacet = function (index) {
                         $timeout(function() {
                             var fm = scope.vm.facetModels[index];
-                            
+
                             if (!fm.isOpen) {
                                 // make sure to get the result again later
                                 if (fm.isLoading) {
                                     fm.initialized = false;
                                 }
-                                
+
                                 // hide the spinner
                                 fm.isLoading = false;
                             } else if (!fm.initialized) {
                                 // send a request
                                 // TODO should have priority
                                 currentCtrl.updateFacetColumn(index);
-                            } 
+                            }
                         });
                     };
-                    
+
                     scope.scrollToFacet = function (index) {
                         var container = angular.element(document.getElementsByClassName('faceting-container')[0]);
                         var el = angular.element(document.getElementById('fc-'+index));
@@ -144,22 +144,22 @@
                             }, 500);
                         });
                     }
-                    
+
                     scope.focusOnFacet = function (index) {
                         var fm = scope.vm.facetModels[index];
-                        
+
                         if (!fm.isOpen) {
                             fm.isOpen = true;
                             scope.toggleFacet(index);
                         }
-                        
+
                         scope.scrollToFacet(index);
                     };
-                    
+
                     scope.vm.focusOnFacet = function (index) {
                         return scope.focusOnFacet(index);
                     }
-                    
+
                     // TODO I am attaching the removeFilter to the vm here, maybe I shouldn't?
                     scope.vm.hasFilter = function (col) {
                         return scope.hasFilter(col);
@@ -175,7 +175,7 @@
 
         // NOTE This directive has not been used
         .directive('stringPicker', ['$window', 'DataUtils', 'tableConstants', function ($window, DataUtils, tableConstants) {
-            
+
             /**
              * Should be called each time facetColumn has been modified.
              * Will populate the following:
@@ -189,7 +189,7 @@
              *  - scope.searchFetched
              */
             function updateFacetColumn(scope) {
-                
+
                 // update the selectModel reference
                 var ref = scope.facetColumn.column.groupAggregate.entityCounts;
                 if (scope.selectModel.search) {
@@ -198,15 +198,15 @@
                 scope.selectModel.reference = ref;
                 scope.selectModel.columns = ref.columns;
                 scope.selectFetched = false;
-                
+
                 // update the selectred rows
-                scope.selectModel.selectedRows = scope.facetColumn.choiceFilters.map(function (f) { 
+                scope.selectModel.selectedRows = scope.facetColumn.choiceFilters.map(function (f) {
                     return {
                         displayname: f.displayname,
                         uniqueId: f.term
                     };
                 });
-                
+
                 // update the searchModel reference
                 ref = scope.facetColumn.column.groupAggregate.entityValues;
                 if (scope.searchModel.search) {
@@ -216,38 +216,38 @@
                 scope.searchModel.columns = ref.columns;
                 scope.searchFetched = false;
             }
-            
+
             /**
              * Fetch the records for the active tab, if already not fetched
              */
             function fetchRecords(scope) {
                 var isSelect = scope.activeTab === scope.SELECT_TAB;
-    
+
                 // make sure data has not been fetched before.
                 if ( (isSelect && scope.selectFetched) || (!isSelect && scope.searchFetched)) {
                     return;
                 }
-                
+
                 var model = isSelect ? scope.selectModel : scope.searchModel;
-                
+
                 model.reference.read(tableConstants.PAGE_SIZE).then(function getPseudoData(page) {
-                    
+
                     model.hasLoaded = true;
                     model.initialized = true;
                     model.page = page;
                     model.rowValues = DataUtils.getRowValuesFromPage(page);
-                    
+
                     if (isSelect) {
                         scope.selectFetched = true;
                     } else {
                         scope.searchFetched = true;
                     }
-                    
+
                 }, function(exception) {
                     throw exception;
                 });
             }
-            
+
             return {
                 restrict: 'AE',
                 templateUrl: '../common/templates/faceting/string-picker.html',
@@ -259,7 +259,7 @@
                 link: function (scope, element, attr) {
                     scope.SELECT_TAB = 'select';
                     scope.SEARCH_TAB = 'search';
-                    
+
                     // used for the scalar multi-select
                     scope.selectModel = {
                         selectedRows: [],
@@ -286,10 +286,10 @@
                             hideTotalCount: true, hideSelectedRows: true, hidePageSettings: true
                         }
                     }
-                    
+
                     // populate the search and select model reference and selected rows
                     updateFacetColumn(scope);
-                    
+
                     scope.changeFilters = function (tuples, isSelected) {
                         var ref;
                         if (isSelected) {
@@ -301,11 +301,11 @@
                                 return t.uniqueId;
                             }));
                         }
-                        
+
                         scope.vm.reference = ref;
                         scope.$emit("facet-modified");
                     };
-                    
+
                     scope.addSearchFilter = function (term) {
                         var sf = scope.facetColumn.searchFilters.filter(function (f) {
                             return f.term === term;
@@ -316,24 +316,24 @@
                         scope.vm.reference = scope.facetColumn.addSearchFilter(term);
                         scope.$emit("facet-modified");
                     }
-                    
+
                     scope.$on('data-modified', function ($event) {
                         //TODO fix this
                         scope.facetColumn = scope.vm.facetColumns[scope.facetColumn.index];
-                        
+
                         updateFacetColumn(scope);
                         if (scope.isOpen) {
                             fetchRecords(scope);
                         }
                     });
-                    
+
                     scope.$watch("isOpen", function (newValue, oldValue) {
                         if(angular.equals(newValue, oldValue) || !newValue){
                             return;
                         }
                         fetchRecords(scope);
                     });
-                    
+
                     scope.onTabSelected = function (tab) {
                         scope.activeTab = tab;
                         if (scope.isOpen) {
@@ -343,7 +343,7 @@
                 }
             };
         }])
-        
+
         // NOTE This directive has not been used
         .directive('entityPicker', ['$uibModal', function ($uibModal) {
             /**
@@ -353,14 +353,14 @@
              */
             function updateFacetColumn(scope) {
                 // update the selected rows
-                scope.entityModel.selectedRows = scope.facetColumn.choiceFilters.map(function (f) { 
+                scope.entityModel.selectedRows = scope.facetColumn.choiceFilters.map(function (f) {
                     return {
                         displayname: f.displayname,
                         uniqueId: f.term
                     };
                 });
             }
-            
+
             return {
                 restrict: 'AE',
                 templateUrl: '../common/templates/faceting/entity-picker.html',
@@ -420,7 +420,7 @@
                 },
                 controller: ['$scope', function ($scope) {
                     var ctrl = this;
-                    
+
                     // register the update facet callback
                     ctrl.updateFacet = function () {
                         // make sure to sync the selected
@@ -428,7 +428,7 @@
                         $scope.syncSelected();
                         return $scope.updateFacetData();
                     }
-                    
+
                     ctrl.initializeFacet = function () {
                         return $scope.initialRows();;
                     }
@@ -437,11 +437,11 @@
                 link: function (scope, element, attr, ctrls) {
                     var parentCtrl = ctrls[0],
                         currentCtrl = ctrls[1];
-                    
+
                     // register this controller in the parent
                     parentCtrl.register(currentCtrl, scope.facetColumn, scope.index);
                     scope.parentCtrl = parentCtrl;
-                    
+
                     scope.ranges = [];
                     // draw the plot
                     // scope.plot = {
@@ -470,8 +470,8 @@
                     //         bargap: 0
                     //     }
                     // }
-                    
-                    function createChoiceDisplay(filter, selected) { 
+
+                    function createChoiceDisplay(filter, selected) {
                         return {
                             uniqueId: filter.uniqueId,
                             displayname: {value: filter.toString(), isHTML: false},
@@ -482,7 +482,7 @@
                             }
                         };
                     };
-                    
+
                     // convert filter to applied filter (filter has selected, applied filter doesn't)
                     function createAppliedFilter(filter) {
                         return {
@@ -490,7 +490,7 @@
                             displayname: {value: filter.toString(), isHTML: false}
                         }
                     }
-                    
+
                     // callback for the list directive
                     scope.onSelect = function (row, $event) {
                         var res;
@@ -499,9 +499,9 @@
                         } else {
                             res = scope.facetColumn.removeRangeFilter(row.metaData.min, row.metaData.max);
                         }
-                        
+
                         $log.debug("request for facet (index="+scope.facetColumn.index+") range " + (row.selected ? "add" : "remove") + '. min=' + row.metaData.min + ", max=" + row.metaData.max);
-                        
+
                         if (res && !scope.parentCtrl.updateVMReference(res.reference, scope.index)) {
                             $log.debug("rejected because of url length limit.");
                             row.selected != row.selected;
@@ -526,7 +526,7 @@
                         if (!res) {
                             return; // duplicate filter
                         }
-                        
+
                         if (!scope.parentCtrl.updateVMReference(res.reference, scope.index)) {
                             $log.debug("rejected because of url length limit.");
                             return; // uri limit
@@ -535,9 +535,9 @@
                         var rowIndex = scope.ranges.findIndex(function (obj) {
                             return obj.uniqueId == res.filter.uniqueId;
                         });
-                        
+
                         $log.debug("request for facet (index="+scope.facetColumn.index +") range add. min='" + min + ", max=" + max);
-                        
+
                         scope.facetModel.appliedFilters.push(createAppliedFilter(res.filter));
                         if (rowIndex === -1) {
                             //we should create a new filter
@@ -553,7 +553,7 @@
                         var defer = $q.defer();
                         scope.ranges = [];
                         scope.facetModel.appliedFilters = [];
-                        
+
                         for (var i = 0; i < scope.facetColumn.rangeFilters.length; i++) {
                             var filter = scope.facetColumn.rangeFilters[i];
 
@@ -567,11 +567,11 @@
                                 scope.facetModel.appliedFilters.push(createAppliedFilter(filter));
                             }
                         }
-                        
+
                         defer.resolve();
                         return defer.promise;
                     };
-                    
+
                     // some of the facets might have been cleared, this function will unselect those
                     scope.syncSelected = function () {
                         var filterIndex = function (uniqueId) {
@@ -579,7 +579,7 @@
                                 return f.uniqueId = uniqueId;
                             });
                         }
-                        
+
                         for (var i = 0; i < scope.ranges.length; i++) {
                             // if couldn't find the filter, then it should be unselected
                             if (filterIndex(scope.ranges[i].uniqueId) === -1) {
@@ -592,24 +592,24 @@
                     // TODO get the histogram data
                     scope.updateFacetData = function () {
                         var defer = $q.defer();
-                        
+
                         (function (uri) {
                             var agg = scope.facetColumn.column.aggregate;
                             var aggregateList = [
                                 agg.minAgg,
                                 agg.maxAgg
                             ];
-                            
+
                             scope.facetColumn.sourceReference.getAggregates(aggregateList).then(function(response) {
                                 if (scope.facetColumn.sourceReference.uri !== uri) {
                                     defer.resolve(false);
                                 } else {
-                                
+
                                     // console.log("Facet " + scope.facetColumn.displayname.value + " min/max: ", response);
                                     if (scope.facetColumn.column.type.rootName.indexOf("timestamp") > -1) {
                                         // convert and set the values if they are defined.
                                         // if values are null, undefined, false, 0, or '' we don't want to show anything
-                                        if (response[0] && response[1]) { 
+                                        if (response[0] && response[1]) {
                                             var minTs = moment(response[0]);
                                             var maxTs = moment(response[1]);
 
@@ -626,14 +626,14 @@
                                         scope.rangeOptions.absMin = response[0];
                                         scope.rangeOptions.absMax = response[1];
                                     }
-                                    
+
                                     defer.resolve(true);
                                 }
                             }).catch(function (err) {
                                 defer.reject(err);
                             });
-                        })(scope.facetColumn.sourceReference.uri); 
-                        
+                        })(scope.facetColumn.sourceReference.uri);
+
                         return defer.promise;
                     };
 
@@ -645,7 +645,7 @@
                     //             scope.max = Math.ceil(event['xaxis.range[1]']);
                     //         });
                     //     });
-                    // 
+                    //
                     // };
                     scope.rangeOptions = {
                         type: scope.facetColumn.column.type,
@@ -654,12 +654,12 @@
                 }
             };
         }])
-        
+
         .directive('choicePicker', ['$q', '$timeout', '$uibModal', 'tableConstants', "$log", function ($q, $timeout, $uibModal, tableConstants, $log) {
 
             /**
              * Initialzie facet column.
-             * This will take care of getting the displaynames of rows. 
+             * This will take care of getting the displaynames of rows.
              * (If it's a entity picker, the displayname will be different than the value.).
              *
              * NOTE should not be used directly in this directive.
@@ -667,7 +667,7 @@
              */
             function initializeFacetColumn(scope) {
                 var defer = $q.defer();
-                
+
                 if (scope.facetColumn.choiceFilters.length === 0) {
                     defer.resolve();
                 } else {
@@ -675,10 +675,10 @@
                         filters.forEach(function (f) {
                             scope.facetModel.appliedFilters.push({
                                 uniqueId: f.uniqueId,
-                                displayname: f.displayname                                
+                                displayname: f.displayname
                             });
                         });
-                        
+
                         defer.resolve();
                     }).catch(function (error) {
                         throw error;
@@ -686,7 +686,7 @@
                 }
                 return defer.promise;
             }
-            
+
             /**
              * Update facet column rows
              * Will return a promise, which will be resolved with:
@@ -698,36 +698,36 @@
              */
             function updateFacetColumn(scope) {
                 var defer = $q.defer();
-                
+
                 var appliedFilterToRow = function (f) {
                     return {
                         uniqueId: f.uniqueId,
                         displayname: f.displayname,
                         selected: true
-                    }
-                }
-                
+                    };
+                };
+
                 // console.log("updating FACET: " + scope.index);
-                
+
                 // facetColumn has changed so create the new reference
                 if (scope.facetColumn.isEntityMode) {
                     scope.reference = scope.facetColumn.sourceReference.contextualize.compactSelect;
                 } else {
                     scope.reference = scope.facetColumn.column.groupAggregate.entityCounts;
                 }
-                
+
                 // make sure to add the search term
                 if (scope.searchTerm) {
                     scope.reference = scope.reference.search(scope.searchTerm);
                 }
 
-                
+
                 var appliedLen = scope.facetModel.appliedFilters.length;
                 if (appliedLen >= tableConstants.PAGE_SIZE) {
                     scope.checkboxRows = scope.facetModel.appliedFilters.map(appliedFilterToRow);
                     defer.resolve(true);
                 } else {
-                    // read new data if neede                
+                    // read new data if neede
                     (function (uri) {
                         scope.reference.read(appliedLen + tableConstants.PAGE_SIZE).then(function (page) {
                             // if this is not the result of latest facet change
@@ -736,28 +736,28 @@
                             } else {
                                 scope.checkboxRows = scope.facetModel.appliedFilters.map(appliedFilterToRow);
                                 scope.hasMore = page.hasNext;
-                                
+
                                 page.tuples.forEach(function (tuple) {
                                     // if we're showing enough rows
                                     if (scope.checkboxRows.length == tableConstants.PAGE_SIZE) {
                                         scope.hasMore = true;
                                         return;
                                     }
-                                    
+
                                     var value;
                                     if (scope.facetColumn.isEntityMode) {
                                         // the filter might not be on the shortest key,
                                         // therefore the uniqueId is not correct.
-                                        value = tuple.data[scope.facetColumn.column.name];
+                                        value = tuple.data ? tuple.data[scope.facetColumn.column.name] : null;
                                     } else {
                                         // The name of column is value
-                                        value = tuple.data['value'];
+                                        value = tuple.data ? tuple.data['value'] : null;
                                     }
-                                    
+
                                     var i = scope.facetModel.appliedFilters.findIndex(function (row) {
                                         return row.uniqueId == value;
                                     });
-                                    
+
                                     if (i !== -1) {
                                         return;
                                     }
@@ -767,17 +767,17 @@
                                         displayname: value == null ? {value: null, isHTML: false} : tuple.displayname,
                                         uniqueId: value
                                     });
-                                }); 
-                                
+                                });
+
                                 defer.resolve(true);
                             }
-                            
+
                         }).catch(function (err) {
                             defer.reject(err);
                         });
                     })(scope.reference.uri);
                 }
-                
+
                 return defer.promise;
             }
 
@@ -791,12 +791,12 @@
                 },
                 controller: ['$scope', function ($scope) {
                     var ctrl = this;
-                    
+
                     // register the update facet function
                     ctrl.updateFacet = function () {
                         return updateFacetColumn($scope);
                     };
-                    
+
                     // register the initialize facet function
                     ctrl.initializeFacet =  function () {
                         return initializeFacetColumn($scope);
@@ -804,17 +804,17 @@
                 }],
                 require: ['^faceting', 'choicePicker'],
                 link: function (scope, element, attr, ctrls) {
-                    
+
                     var parentCtrl = ctrls[0],
                         currentCtrl = ctrls[1];
-                    
+
                     // register this controller in the parent
                     parentCtrl.register(currentCtrl, scope.facetColumn, scope.index);
                     scope.parentCtrl = parentCtrl;
-                    
+
                     // This can eventually be in the annotation, that's why I created this attribute
                     scope.showSearch = (scope.facetColumn.column.type.name !== "boolean");
-                    
+
                     scope.checkboxRows = [];
 
                     // for the search popup selector
@@ -828,7 +828,7 @@
                         params.selectedRows = scope.checkboxRows.filter(function (row) {
                             return row.selected;
                         });
-                        
+
                         if (!scope.facetColumn.isEntityMode) {
                             params.showNull = true;
                         }
@@ -858,7 +858,7 @@
                                     return t.uniqueId;
                                 }
                             }
-                            
+
                             var ref = scope.facetColumn.replaceAllChoiceFilters(tuples.map(function (t) {
                                 return getTupleValue(t);
                             }));
@@ -867,17 +867,17 @@
                                 // NOTE displayname will always be string, but we want to treat null and empty string differently,
                                 // therefore we have a extra case for null, to just return null.
                                 return {
-                                    uniqueId: val, 
+                                    uniqueId: val,
                                     displayname: (val == null) ? {value: null, isHTML: false} : t.displayname
                                 };
                             });
-                            
+
                             // make sure to update all the opened facets
                             scope.parentCtrl.setInitialized();
-                            
+
                             // update the reference
                             scope.parentCtrl.updateVMReference(ref, -1);
-                            
+
                             // focus on the current facet
                             scope.parentCtrl.focusOnFacet(scope.index);
                         });
@@ -891,9 +891,9 @@
                         } else {
                             ref = scope.facetColumn.removeChoiceFilters([row.uniqueId]);
                         }
-                        
+
                         $log.debug("request for facet (index=" + scope.facetColumn.index + ") choice add. uniqueId='" + row.uniqueId);
-                        
+
                         // if the updateVMReference failed (due to url length limit),
                         // we should revert the change back
                         if (!scope.parentCtrl.updateVMReference(ref, scope.index)) {
@@ -912,7 +912,7 @@
                                     return f.uniqueId !== row.uniqueId;
                                 });
                             }
-                            
+
                         }
                     };
 
@@ -922,18 +922,18 @@
                         var term = null;
                         if (scope.searchTerm) {
                             term = scope.searchTerm.trim();
-                        } 
+                        }
                         var ref = scope.reference.search(term);
                         if (scope.$root.checkReferenceURL(ref)) {
                             scope.searchTerm = term;
-                            
+
                             $log.debug("request for facet (index=" + scope.facetColumn.index + ") update. new search=" + term);
                             scope.parentCtrl.updateFacetColumn(scope.index);
                         }
                     };
-                    
+
                     scope.inputChangedPromise = undefined;
-                    
+
                     scope.inputChanged = function() {
                         // Cancel previous promise for background search that was queued to be called
                         if (scope.inputChangedPromise) {
@@ -976,7 +976,7 @@
                             choicePickerElem.style.height = "";
                         }
                     });
-                    
+
                     scope.$watch(function() {
                         // NOTE initialized = false & isOpen=true -> isLoading must be true
                         return scope.facetModel.isOpen && !scope.facetModel.isLoading;
@@ -992,6 +992,6 @@
                     });
                 }
             };
-            
+
         }]);
 })();

--- a/common/modal.js
+++ b/common/modal.js
@@ -86,6 +86,7 @@
         vm.cancel = cancel;
         vm.submit = submitMultiSelection;
         vm.getDisabledTuples = params.getDisabledTuples ? params.getDisabledTuples : undefined;
+        vm.mode = params.mode;
 
         vm.hasLoaded = false;
         var reference = vm.reference = params.reference;
@@ -103,6 +104,7 @@
             pageLimit:          limit,
             rowValues:          [],
             selectedRows:       params.selectedRows,
+            matchNotNull:       params.matchNotNull,
             search:             reference.location.searchTerm,
             config:             {viewable: false, editable: false, deletable: false, selectMode: params.selectMode, showNull: params.showNull === true},
             context:            params.context
@@ -119,7 +121,7 @@
                     vm.tableModel.rowValues = DataUtils.getRowValuesFromPage(page);
                     $scope.$broadcast('data-modified');
                 };
-                
+
                 // get disabled tuple.
                 if (vm.getDisabledTuples) {
                     vm.getDisabledTuples(page, vm.tableModel.pageLimit).then(function (rows) {
@@ -131,7 +133,7 @@
                 } else {
                     afterRead();
                 }
-                
+
             }).catch(function(exception) {
                 throw exception;
             });
@@ -144,8 +146,17 @@
             if (params.selectMode != modalBox.multiSelectMode) $uibModalInstance.close(tuples[0]);
         }
 
+        /**
+         * Will call the close modal with the appropriate results.
+         * If we had the matchNotNull, then we just need to pass that attribute.
+         */
         function submitMultiSelection() {
-            $uibModalInstance.close(this.tableModel.selectedRows);
+            var res = vm.tableModel.selectedRows;
+            if (!Array.isArray(res)) res = [];
+            if (vm.tableModel.matchNotNull) {
+                res = {matchNotNull: true};
+            }
+            $uibModalInstance.close(res);
         }
 
         function cancel() {

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -1338,7 +1338,7 @@ footer .container1 {
     position: relative;
     /*margin: 10px 0;*/
 }
-.chaise-checkbox:hover {
+li.chaise-checkbox:hover {
     background-color: rgb(241, 241, 241);
 }
 .ellipsis-text label{

--- a/common/table.js
+++ b/common/table.js
@@ -500,7 +500,6 @@
 
             // Facilitates the multi select functionality for multi edit by storing the tuple in the selectedRows array
             scope.onSelect = function(args) {
-                console.log(args);
                 var tuple = args.tuple;
 
                 var rowIndex = scope.vm.selectedRows.findIndex(function (obj) {

--- a/common/table.js
+++ b/common/table.js
@@ -2,9 +2,10 @@
     'use strict';
 
     angular.module('chaise.record.table', ['chaise.ellipses'])
-    
+
     .constant('tableConstants', {
         MAX_CONCURENT_REQUEST: 4,
+        MAX_URL_LENGTH: 2000,
         PAGE_SIZE: 10
     })
 
@@ -24,10 +25,10 @@
      *    <recordset vm="vm" on-row-click="gotoRowLink(tuple)"></recordset>
      *
      * These are recordset and record-table directive parameters:
-     * - onRowClick(tuple, isSelected): 
+     * - onRowClick(tuple, isSelected):
      *   - A callback for when in select mode a row is selected.
      *   - If isSelected is false, that means the row has been deselected.
-     * 
+     *
      * - vm: The table model, should have this format:
      *
      *      { hasLoaded,    // data is ready, loading icon should not be visible
@@ -47,6 +48,9 @@
      *       }
      *
      *      available config options:
+     *          - mode :
+     *              The mode of the recordset, can be any of the following:
+     *                - default TODO
      *          - viewable
      *          - editable
      *          - deletable
@@ -78,7 +82,9 @@
      * 4. `record-modified`: one of the records in the recordset table has been
      * modified. ellipses will fire this event and recordset directive will use it.
      */
-    .factory('recordTableUtils', ['DataUtils', '$timeout','Session', '$q', 'tableConstants', '$rootScope', '$log', function(DataUtils, $timeout, Session, $q, tableConstants, $rootScope, $log) {
+    .factory('recordTableUtils',
+            ['AlertsService', 'modalBox', 'DataUtils', '$timeout','Session', '$q', 'tableConstants', '$rootScope', '$log', '$window', '$cookies', 'defaultDisplayname', 'MathUtils', 'UriUtils',
+            function(AlertsService, modalBox, DataUtils, $timeout, Session, $q, tableConstants, $rootScope, $log, $window, $cookies, defaultDisplayname, MathUtils, UriUtils) {
 
         // This method sets backgroundSearch states depending upon various parameters
         // If it returns true then we should render the data
@@ -152,10 +158,10 @@
 
             scope.vm.reference.read(scope.vm.pageLimit).then(function (page) {
                 if (!setSearchStates(scope, isBackground, searchTerm)) return;
-                
-                var afterRead = function () { 
+
+                var afterRead = function () {
                     scope.vm.page = page;
-                    
+
                     scope.vm.rowValues = DataUtils.getRowValuesFromPage(page);
                     scope.vm.hasLoaded = true;
 
@@ -167,13 +173,13 @@
                         // tell parent controller data modified
                         scope.$emit('reference-modified');
                     }
-                    
+
                     // tell children that data modified
                     if (broadcast) {
                         scope.$broadcast('data-modified');
                     }
                 };
-                
+
                 if (scope.getDisabledTuples) {
                     scope.getDisabledTuples(page, scope.vm.pageLimit).then(function (rows) {
                         if (!setSearchStates(scope, isBackground, searchTerm)) return;
@@ -193,44 +199,7 @@
                 throw exception;
             });
         }
-        
-        function newRead(scope, broadcast) {
-            if (!scope.vm.isIdle) {
-                return;
-            }
-            
-            scope.vm.hasLoaded = false;
-            
-            scope.vm.isIdle = false;
-            (function (uri, send) {
-                scope.vm.reference.read(scope.vm.pageLimit).then(function (page) {
-                    scope.vm.isIdle = true;
-                    if (scope.vm.reference.uri === uri) {
-                        
-                        scope.vm.page = page;
-                        scope.vm.rowValues = DataUtils.getRowValuesFromPage(page);
-                        scope.vm.hasLoaded = true;
-                        
-                        scope.$emit('reference-modified');
-                        
-                        if (send) {
-                            scope.$broadcast('data-modified');
-                        }
-                    } else {
-                        newRead(scope, send);
-                    }
-                }).catch(function (err) {
-                    scope.vm.isIdle = true;
-                    if (scope.vm.reference.uri === uri) {
-                        scope.vm.hasLoaded = true;
-                        throw err; // this is the last request
-                    } else {
-                        newRead(scope, send); // some request are still pending
-                    }
-                })
-            })(scope.vm.reference.uri, broadcast);
-        }
-        
+
         function updateResult (vm) {
             vm.hasLoaded = false;
             var defer = $q.defer();
@@ -258,7 +227,7 @@
             }) (vm.reference.uri);
             return defer.promise;
         }
-        
+
         function updateCount (vm) {
             var  defer = $q.defer();
             (function (uri) {
@@ -280,23 +249,32 @@
             })(vm.reference.uri);
             return defer.promise;
         }
-        
+
         function initialize (vm) {
             vm.search = vm.reference.location.searchTerm;
             vm.initialized = false;
             vm.dirtyResult = true;
             vm.dirtyCount = true;
-            
+
             update(vm);
         }
-        
+
+        /**
+         * Based on the given inputs, it will set the state of different parts
+         * of recordset directive to be updated.
+         *
+         * @param  {Object} vm           table view model
+         * @param  {boolean} updateResult if it's true we will update the table.
+         * @param  {boolean} updateCount  if it's true we will update the displayed total count.
+         * @param  {boolean} updateFacets if it's true we will udpate the opened facets.
+         */
         function update (vm, updateResult, updateCount, updateFacets) {
             if (updateFacets) {
                 vm.facetModels.forEach(function (fm, index) {
                     if (vm.lastActiveFacet === index) {
                         return;
                     }
-                    
+
                     if (fm.isOpen) {
                         fm.processed = false;
                         fm.isLoading = true;
@@ -306,16 +284,23 @@
                     }
                 });
             }
-            
+
             // if it's true change, otherwise don't change.
             vm.dirtyResult = updateResult || vm.dirtyResult;
             vm.dirtyCount = updateCount || vm.dirtyCount;
-            
+
             $timeout(function () {
                 updatePage(vm);
             }, 0);
         }
 
+        /**
+         * Given the viewmodel, it will update the page.
+         * This is behaving as a flow-control system, that allows only a Maximum
+         * number of requests defined.
+         *
+         * @param  {Object} vm The table view model
+         */
         function updatePage(vm) {
             var haveFreeSlot = function () {
                 var res = vm.occupiedSlots < tableConstants.MAX_CONCURENT_REQUEST;
@@ -324,16 +309,16 @@
                 }
                 return res;
             };
-            
+
             if (!haveFreeSlot()) {
                 return;
             }
-            
+
             // update the resultset
             if (vm.dirtyResult) {
                 vm.occupiedSlots++;
                 vm.dirtyResult = false;
-                
+
                 var afterUpdateResult = function (res) {
                     if (res) {
                         // we got the results, let's just update the url
@@ -343,7 +328,7 @@
                     vm.dirtyResult = !res;
                     $log.debug("after result update: " + (res ? "successful." : "unsuccessful."));
                 };
-                
+
                 $log.debug("updating result");
                 updateResult(vm).then(function (res) {
                     afterUpdateResult(res);
@@ -353,27 +338,27 @@
                     throw err;
                 });
             }
-            
+
             // update the facets
             if (vm.facetsToInitialize.length === 0) {
                 vm.facetModels.forEach(function (fm, index) {
                     if (fm.processed || !haveFreeSlot()) {
                         return;
                     }
-                    
+
                     vm.occupiedSlots++;
                     fm.processed = true;
-                    
+
                     var afterFacetUpdate = function (i, res, hasError) {
                         vm.occupiedSlots--;
                         var currFm = vm.facetModels[i];
                         currFm.initialized = res || currFm.initialized;
                         currFm.isLoading = !res;
                         currFm.processed = res || currFm.processed;
-                        
+
                         $log.debug("after facet (index="+i+") update: " + (res ? "successful." : "unsuccessful."));
                     };
-                    
+
                     (function (i) {
                         $log.debug("updating facet (index="+i+")");
                         vm.facetModels[i].updateFacet().then(function (res) {
@@ -385,7 +370,7 @@
                         });
                     })(index);
                 });
-            } 
+            }
             // initialize facets
             else if (haveFreeSlot()){
                 vm.occupiedSlots++;
@@ -401,20 +386,20 @@
                     });
                 })(index);
             }
-            
+
             // update the count
             if (vm.config.hideTotalCount) {
                 vm.totalRowsCnt = null;
             } else if (vm.dirtyCount && haveFreeSlot()) {
                 vm.occupiedSlots++;
                 vm.dirtyCount = false;
-                
+
                 var afterUpdateCount = function (res, hasError) {
                     vm.occupiedSlots--;
                     vm.dirtyCount = !res;
                     $log.debug("after count update: " + (res ? "successful." : "unsuccessful."));
                 };
-                
+
                 $log.debug("updating count");
                 updateCount(vm).then(function (res) {
                     afterUpdateCount(res);
@@ -426,24 +411,336 @@
             }
         }
 
+        function registerTableCallbacks(scope) {
+            var callOnRowClick = function (scope, tuples, isSelected) {
+                if (scope.onRowClickBind) {
+                    scope.onRowClickBind()(tuples, isSelected);
+                } else if (scope.onRowClick) {
+                    scope.onRowClick()(tuples, isSelected);
+                }
+            }
+
+            scope.noSelect = modalBox.noSelect;
+            scope.singleSelect = modalBox.singleSelectMode;
+            scope.multiSelect = modalBox.multiSelectMode;
+
+            scope.sortby = function(column) {
+                if (scope.vm.sortby !== column) {
+                    scope.vm.sortby = column;
+                    scope.vm.sortOrder = "asc";
+                    scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
+                    read(scope);
+                }
+
+            };
+
+            scope.toggleSortOrder = function () {
+                scope.vm.sortOrder = (scope.vm.sortOrder === 'asc' ? scope.vm.sortOrder = 'desc' : scope.vm.sortOrder = 'asc');
+                scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
+                read(scope);
+            };
+
+            scope.isDisabled = function (tuple) {
+                if (!scope.vm.disabledRows || scope.vm.disabledRows.length == 0) {
+                    return false;
+                }
+
+                return scope.vm.disabledRows.findIndex(function (obj) {
+                    return obj.uniqueId == tuple.uniqueId;
+                }) > -1;
+            };
+
+            // verifies whether or not the current key value is in the set of selected rows or not
+            scope.isSelected = function (tuple) {
+                var index = scope.vm.selectedRows.findIndex(function (obj) {
+                    return obj.uniqueId == tuple.uniqueId;
+                });
+                return (index > -1);
+            };
+
+            // this is for the button on the table heading that deselects all currently visible rows
+            scope.selectNone = function() {
+                var tuples = [], tuple;
+                for (var i = 0; i < scope.vm.page.tuples.length; i++) {
+                    tuple = scope.vm.page.tuples[i];
+                    var key = tuple.uniqueId;
+
+                    var index = scope.vm.selectedRows.findIndex(function (obj) {
+                        return obj.uniqueId == key;
+                    });
+
+                    if (index > -1) {
+                        tuples.push(tuple);
+                        scope.vm.selectedRows.splice(index, 1);
+                    }
+                }
+                if (tuples.length > 0) {
+                    callOnRowClick(scope, tuples, false);
+                }
+            };
+
+            // this is for the button on the table heading that selects all currently visible rows
+            scope.selectAll = function() {
+                var tuples = [], tuple;
+                for (var i = 0; i < scope.vm.page.tuples.length; i++) {
+                    var tuple = scope.vm.page.tuples[i];
+
+                    if (scope.isDisabled(tuple)) continue;
+
+                    if (!scope.isSelected(tuple)) {
+                        scope.vm.selectedRows.push(tuple);
+                        tuples.push(tuple);
+                    }
+                }
+                if (tuples.length > 0) {
+                    callOnRowClick(scope, tuples, true);
+                }
+            };
+
+
+            // Facilitates the multi select functionality for multi edit by storing the tuple in the selectedRows array
+            scope.onSelect = function(args) {
+                console.log(args);
+                var tuple = args.tuple;
+
+                var rowIndex = scope.vm.selectedRows.findIndex(function (obj) {
+                    return obj.uniqueId == tuple.uniqueId;
+                });
+
+                // add the tuple to the list of selected rows
+                var isSelected = rowIndex === -1;
+
+                if (isSelected) {
+                    scope.vm.selectedRows.push(tuple);
+                } else {
+                    scope.vm.selectedRows.splice(rowIndex, 1);
+                }
+
+                callOnRowClick(scope, [tuple], isSelected);
+            };
+
+            scope.$on('record-deleted', function() {
+                console.log('catching the record deleted');
+                read(scope);
+            });
+        }
+
+        function registerRecordsetCallbacks(scope) {
+            scope.defaultDisplayname = defaultDisplayname;
+
+            var addRecordRequests = {}; // table refresh used by add record implementation with cookie (old method)
+            var updated = false; // table refresh used by ellipses' edit action (new method)
+
+            scope.pageLimits = [10, 25, 50, 75, 100, 200];
+            scope.vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
+
+            scope.vm.backgroundSearchPendingTerm = null;
+            scope.vm.currentPageSelected = false;
+            scope.$root.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
+            //TODO this is forced here
+            scope.vm.showFaceting = false;
+
+            scope.unfiltered = function () {
+                scope.vm.reference = scope.vm.reference.unfilteredReference.contextualize.compact;
+                scope.vm.filterString = null;
+                read(scope, false, true);
+            };
+
+            scope.setPageLimit = function(limit) {
+                scope.vm.pageLimit = limit;
+                read(scope);
+            };
+
+            scope.before = function() {
+                var previous = scope.vm.page.previous;
+                if (previous) {
+
+                    scope.vm.reference = previous;
+                    read(scope);
+
+                }
+            };
+
+            scope.after = function() {
+                var next = scope.vm.page.next;
+                if (next) {
+
+                    scope.vm.reference = next;
+                    read(scope);
+                }
+
+            };
+
+            var inputChangedPromise;
+
+            /*
+                The search fires at most one active "background"
+                search at a time and, i.e. for opportunistic type-ahead search. It should never send
+                another before the previous terminates. The delay for firing the search is
+                1 second, when the user has stopeed typing.
+            */
+            // On change in user input
+            scope.inputChanged = function() {
+                if (scope.vm.enableAutoSearch) {
+
+                    // Cancel previous promise for background search that was queued to be called
+
+                    if (inputChangedPromise) {
+                        $timeout.cancel(inputChangedPromise);
+                    }
+
+                    // Wait for the user to stop typing for a second and then fire the search
+                    inputChangedPromise = $timeout(function() {
+                        inputChangedPromise = null;
+
+                        // If there is no foregound search going currently
+                        if (!scope.vm.foregroundSearch) {
+                            // If there is a background search going on currently then
+                            // set the search term in the backgroundSearchPendingTerm
+                            // else fire the search and empty the backgroundSearchPendingTerm
+                            if (scope.vm.backgroundSearch) {
+                                scope.vm.backgroundSearchPendingTerm = scope.vm.search
+                            } else {
+                                scope.search(scope.vm.search, true);
+                                scope.vm.backgroundSearchPendingTerm = null;
+                            }
+                        }
+                    }, 1000);
+                }
+            };
+
+            scope.enterPressed = function() {
+                /* If user has pressed enter then foreground search starts,
+                the input is supposed to be frozen w/ a spinner to show that it is busy doing what the user
+                asked for. Any existing background search result completing during that time is to be discarded
+                to avoid confusing the UX.
+                */
+                $timeout.cancel(inputChangedPromise);
+
+                // Set the foregroundSearch to true and empty the backgroundSearchPendingTerm
+                scope.vm.foregroundSearch = true;
+                scope.vm.backgroundSearchPendingTerm = null;
+
+                // Trigger search
+                scope.search(scope.vm.search);
+            };
+
+            scope.search = function(term, isBackground) {
+
+                if (term) term = term.trim();
+
+                scope.vm.search = term;
+                scope.vm.reference = scope.vm.reference.search(term); // this will clear previous search first
+                read(scope, isBackground, true);
+            };
+
+            scope.clearSearch = function() {
+                if (scope.vm.reference.location.searchTerm)
+                    scope.search();
+
+                scope.vm.search = null;
+            };
+
+            scope.addRecord = function() {
+
+                // Generate a unique id for this request
+                // append it to the URL
+                var referrer_id = 'recordset-' + MathUtils.getRandomInt(0, Number.MAX_SAFE_INTEGER);
+                addRecordRequests[referrer_id] = 0;
+
+                // open a new tab
+                var newRef = scope.vm.reference.table.reference.contextualize.entryCreate;
+                var appLink = newRef.appLink;
+                appLink = appLink + (appLink.indexOf("?") === -1 ? "?" : "&") +
+                    'invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);
+
+                // open url in a new tab
+                $window.open(appLink, '_blank');
+            };
+
+            // function for removing a single pill and it's corresponding selected row
+            scope.removePill = function(key) {
+                var index = scope.vm.selectedRows.findIndex(function (obj) {
+                    return obj.uniqueId == key;
+                });
+                scope.vm.selectedRows.splice(index, 1);
+            };
+
+            // function for removing all pills regardless of what page they are on, clears the whole selectedRows array
+            scope.removeAllPills = function() {
+                scope.vm.selectedRows.clear();
+                scope.vm.currentPageSelected = false;
+            };
+
+            // on window focus, if has pending add record requests
+            // check if any are complete 1) delete requests, 2) delete cookies, 3) do a read
+            $window.onfocus = function() {
+
+                var completed = 0; // completed add record requests
+                for (var id in addRecordRequests) {
+                    var cookie = $cookies.getObject(id);
+                    if (cookie) {
+                        delete addRecordRequests[id];
+                        $cookies.remove(id);
+                        completed += 1;
+                    }
+                }
+
+                // read
+                if (completed > 0 || updated) {
+                    updated = false;
+                    read(scope);
+                }
+
+            };
+
+            // allow child window to call to indicate table has been updated
+            // called from form.controller.js to communicate that an entity was just updated
+            window.updated = function() {
+                updated = true;
+            };
+
+            scope.$on('data-modified', function($event) {
+                console.log('data-modified in recordset directive, getting count');
+                if (!scope.vm.config.hideTotalCount && scope.vm.search == scope.vm.reference.location.searchTerm) {
+                    // get the total row count to display above the table
+                    console.log("Data-updated: ", scope.vm);
+                    scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
+                        // NOTE: scenario: A user triggered a foreground search. Once it returns the aggregate count request is queued.
+                        // While that request is running, the user triggers another foreground search.
+                        // How do we avoid one aggregate count query to not show when it isn't relevant to the displayed data?
+                        // Maybe comparing reference.location.searchTerm and vm.search here instead and if they don't match,
+                        // set the value to null so the count displayed is just the count of the shown rows until the latter
+                        // aggregate count request returns. If the latter one never returns (because of a server error or something),
+                        // at least the UI doesn't show any misleading information.
+                        scope.vm.totalRowsCnt = response[0];
+                    }, function error(response) {
+                        //fail silently
+                        scope.vm.totalRowsCn = null;
+                    });
+                }
+            });
+
+            // row data has been modified (from ellipses)
+            // do a read
+            scope.$on('record-modified', function($event) {
+                console.log('record-modified in recordset directive');
+                read(scope, false, true);
+                // $event.stopPropagation();
+            });
+        }
+
         return {
             read: read,
-            newRead: newRead,
             initialize: initialize,
             update: update,
-            updatePage: updatePage
-        }
+            updatePage: updatePage,
+            registerTableCallbacks: registerTableCallbacks,
+            registerRecordsetCallbacks: registerRecordsetCallbacks
+        };
     }])
 
-    .directive('recordTable', ['AlertsService', 'modalBox', 'recordTableUtils', function(AlertsService, modalBox, recordTableUtils) {
-        
-        function callOnRowClick(scope, tuples, isSelected) {
-            if (scope.onRowClickBind) {
-                scope.onRowClickBind()(tuples, isSelected);
-            } else if (scope.onRowClick) {
-                scope.onRowClick()(tuples, isSelected);
-            }
-        }
+    .directive('recordTable', ['recordTableUtils', function(recordTableUtils) {
 
         return {
             restrict: 'E',
@@ -454,116 +751,59 @@
                  * used by the recordset template to pass down on click function
                  * The recordset has a onRowClick which will be passed to this onRowClickBind.
                  */
-                onRowClickBind: '=?',    
+                onRowClickBind: '=?',
                 onRowClick: '&?'      // set row click function
             },
             link: function (scope, elem, attr) {
-                scope.noSelect = modalBox.noSelect;
-                scope.singleSelect = modalBox.singleSelectMode;
-                scope.multiSelect = modalBox.multiSelectMode;
+                recordTableUtils.registerTableCallbacks(scope);
+            }
+        };
+    }])
 
-                scope.sortby = function(column) {
-                    if (scope.vm.sortby !== column) {
-                        scope.vm.sortby = column;
-                        scope.vm.sortOrder = "asc";
-                        scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
-                        recordTableUtils.read(scope);
+    .directive('recordTableSelectFaceting', ['recordTableUtils', function (recordTableUtils) {
+        return {
+            restrict: "E",
+            templateUrl: '../common/templates/table.html',
+            scope: {
+                vm: '=',
+                /*
+                 * used by the recordset template to pass down on click function
+                 * The recordset has a onRowClick which will be passed to this onRowClickBind.
+                 */
+                onRowClickBind: '=?',
+                onRowClick: '&?'      // set row click function
+            },
+            link: function (scope, elem, attr) {
+                recordTableUtils.registerTableCallbacks(scope);
+
+                scope.isSelected = function (tuple) {
+                    if (scope.vm.matchNotNull) {
+                        return false;
                     }
-
+                    var index = scope.vm.selectedRows.findIndex(function (obj) {
+                        return obj.uniqueId == tuple.uniqueId;
+                    });
+                    return (index > -1);
                 };
 
-                scope.toggleSortOrder = function () {
-                    scope.vm.sortOrder = (scope.vm.sortOrder === 'asc' ? scope.vm.sortOrder = 'desc' : scope.vm.sortOrder = 'asc');
-                    scope.vm.reference = scope.vm.reference.sort([{"column":scope.vm.sortby, "descending":(scope.vm.sortOrder === "desc")}]);
-                    recordTableUtils.read(scope);
-                };
-                
-                scope.isDisabled = function (key) {
+                scope.isDisabled = function (tuple) {
+                    if (scope.vm.matchNotNull) {
+                        return true;
+                    }
                     if (!scope.vm.disabledRows || scope.vm.disabledRows.length == 0) {
                         return false;
                     }
 
                     return scope.vm.disabledRows.findIndex(function (obj) {
-                        return obj.uniqueId == key;
+                        return obj.uniqueId == tuple.uniqueId;
                     }) > -1;
                 };
 
-                // verifies whether or not the current key value is in the set of selected rows or not
-                scope.isSelected = function (key) {
-                    var index = scope.vm.selectedRows.findIndex(function (obj) {
-                        return obj.uniqueId == key;
-                    });
-                    return (index > -1);
-                };
-
-                // this is for the button on the table heading that deselects all currently visible rows
-                scope.selectNone = function() {
-                    var tuples = [], tuple;
-                    for (var i = 0; i < scope.vm.page.tuples.length; i++) {
-                        tuple = scope.vm.page.tuples[i];
-                        var key = tuple.uniqueId;
-
-                        var index = scope.vm.selectedRows.findIndex(function (obj) {
-                            return obj.uniqueId == key;
-                        });
-
-                        if (index > -1) {
-                            tuples.push(tuple);
-                            scope.vm.selectedRows.splice(index, 1);
-                        }
-                    }
-                    if (tuples.length > 0) {
-                        callOnRowClick(scope, tuples, false);
-                    }
-                };
-
-                // this is for the button on the table heading that selects all currently visible rows
-                scope.selectAll = function() {
-                    var tuples = [], tuple;
-                    for (var i = 0; i < scope.vm.page.tuples.length; i++) {
-                        var tuple = scope.vm.page.tuples[i];
-
-                        if (!scope.isSelected(tuple.uniqueId)) {
-                            scope.vm.selectedRows.push(tuple);
-                            tuples.push(tuple);
-                        }
-                    }
-                    if (tuples.length > 0) {
-                        callOnRowClick(scope, tuples, true);
-                    }
-                };
-
-
-                // Facilitates the multi select functionality for multi edit by storing the tuple in the selectedRows array
-                scope.onSelect = function(args) {
-                    console.log(args);
-                    var tuple = args.tuple;
-
-                    var rowIndex = scope.vm.selectedRows.findIndex(function (obj) {
-                        return obj.uniqueId == tuple.uniqueId;
-                    });
-
-                    // add the tuple to the list of selected rows
-                    var isSelected = rowIndex === -1;
-                    
-                    if (isSelected) {
-                        scope.vm.selectedRows.push(tuple);
-                    } else {
-                        scope.vm.selectedRows.splice(rowIndex, 1);
-                    }
-                    
-                    callOnRowClick(scope, [tuple], isSelected);
-                };
-
-                scope.$on('record-deleted', function() {
-                    console.log('catching the record deleted');
-                    recordTableUtils.read(scope);
-                });
             }
-        };
+        }
     }])
 
-    .directive('recordList', ['recordTableUtils', '$timeout', function(recordTableUtils, $timeout) {
+    .directive('recordList', ['recordTableUtils', 'defaultDisplayname', '$timeout', function(recordTableUtils, defaultDisplayname, $timeout) {
 
         return {
             restrict: 'E',
@@ -574,6 +814,8 @@
                 rows: '=' // each row: {uniqueId, displayname, count, selected}
             },
             link: function (scope, elem, attr) {
+                scope.defaultDisplayname = defaultDisplayname;
+
                 scope.onSelect = function (row, $event) {
                     row.selected = !row.selected;
                     scope.onRowClick(row, $event);
@@ -598,151 +840,46 @@
         }
     }])
 
-    .directive('recordset', ['recordTableUtils', '$window', '$cookies', 'DataUtils', 'MathUtils', 'UriUtils','$timeout', function(recordTableUtils, $window, $cookies, DataUtils, MathUtils, UriUtils, $timeout) {
+    .directive('recordset', ['recordTableUtils', function(recordTableUtils) {
 
         return {
             restrict: 'E',
-            templateUrl: '../common/templates/recordset.html',
+            templateUrl: "../common/templates/recordset.html",
             scope: {
+                mode: "=?",
                 vm: '=',
                 onRowClick: '&?',       // set row click function
                 allowCreate: '=?',      // if undefined, assume false
                 getDisabledTuples: "=?" // callback to get the disabled tuples
             },
             link: function (scope, elem, attr) {
-                
-                var addRecordRequests = {}; // table refresh used by add record implementation with cookie (old method)
-                var updated = false; // table refresh used by ellipses' edit action (new method)
+                recordTableUtils.registerRecordsetCallbacks(scope);
+            }
+        };
+    }])
 
-                scope.pageLimits = [10, 25, 50, 75, 100, 200];
-                scope.vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
+    .directive('recordsetSelectFaceting', ['recordTableUtils', function(recordTableUtils) {
 
-                scope.vm.backgroundSearchPendingTerm = null;
-                scope.vm.currentPageSelected = false;
-                scope.$root.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
-                //TODO this is forced here
-                scope.vm.showFaceting = false;
-                
-                scope.unfiltered = function () {
-                    scope.vm.reference = scope.vm.reference.unfilteredReference.contextualize.compact;
-                    scope.vm.filterString = null;
-                    recordTableUtils.read(scope, false, true);
-                };
-
-                scope.setPageLimit = function(limit) {
-                    scope.vm.pageLimit = limit;
-                    recordTableUtils.read(scope);
-                };
-
-                scope.before = function() {
-                    var previous = scope.vm.page.previous;
-                    if (previous) {
-
-                        scope.vm.reference = previous;
-                        recordTableUtils.read(scope);
-
-                    }
-                };
-
-                scope.after = function() {
-                    var next = scope.vm.page.next;
-                    if (next) {
-
-                        scope.vm.reference = next;
-                        recordTableUtils.read(scope);
-                    }
-
-                };
-
-                var inputChangedPromise;
-
-                /*
-                    The search fires at most one active "background"
-                    search at a time and, i.e. for opportunistic type-ahead search. It should never send
-                    another before the previous terminates. The delay for firing the search is
-                    1 second, when the user has stopeed typing.
-                */
-                // On change in user input
-                scope.inputChanged = function() {
-                    if (scope.vm.enableAutoSearch) {
-
-                        // Cancel previous promise for background search that was queued to be called
-
-                        if (inputChangedPromise) {
-                            $timeout.cancel(inputChangedPromise);
-                        }
-
-                        // Wait for the user to stop typing for a second and then fire the search
-                        inputChangedPromise = $timeout(function() {
-                            inputChangedPromise = null;
-
-                            // If there is no foregound search going currently
-                            if (!scope.vm.foregroundSearch) {
-                                // If there is a background search going on currently then
-                                // set the search term in the backgroundSearchPendingTerm
-                                // else fire the search and empty the backgroundSearchPendingTerm
-                                if (scope.vm.backgroundSearch) {
-                                    scope.vm.backgroundSearchPendingTerm = scope.vm.search
-                                } else {
-                                    scope.search(scope.vm.search, true);
-                                    scope.vm.backgroundSearchPendingTerm = null;
-                                }
-                            }
-                        }, 1000);
-                    }
-                };
-
-                scope.enterPressed = function() {
-                    /* If user has pressed enter then foreground search starts,
-                    the input is supposed to be frozen w/ a spinner to show that it is busy doing what the user
-                    asked for. Any existing background search result completing during that time is to be discarded
-                    to avoid confusing the UX.
-                    */
-                    $timeout.cancel(inputChangedPromise);
-
-                    // Set the foregroundSearch to true and empty the backgroundSearchPendingTerm
-                    scope.vm.foregroundSearch = true;
-                    scope.vm.backgroundSearchPendingTerm = null;
-
-                    // Trigger search
-                    scope.search(scope.vm.search);
-                };
-
-                scope.search = function(term, isBackground) {
-
-                    if (term) term = term.trim();
-
-                    scope.vm.search = term;
-                    scope.vm.reference = scope.vm.reference.search(term); // this will clear previous search first
-                    recordTableUtils.read(scope, isBackground, true);
-                };
-
-                scope.clearSearch = function() {
-                    if (scope.vm.reference.location.searchTerm)
-                        scope.search();
-
-                    scope.vm.search = null;
-                };
-
-                scope.addRecord = function() {
-
-                    // Generate a unique id for this request
-                    // append it to the URL
-                    var referrer_id = 'recordset-' + MathUtils.getRandomInt(0, Number.MAX_SAFE_INTEGER);
-                    addRecordRequests[referrer_id] = 0;
-
-                    // open a new tab
-                    var newRef = scope.vm.reference.table.reference.contextualize.entryCreate;
-                    var appLink = newRef.appLink;
-                    appLink = appLink + (appLink.indexOf("?") === -1 ? "?" : "&") +
-                        'invalidate=' + UriUtils.fixedEncodeURIComponent(referrer_id);
-
-                    // open url in a new tab
-                    $window.open(appLink, '_blank');
-                };
+        return {
+            restrict: 'E',
+            templateUrl: "../common/templates/recordsetSelectFaceting.html",
+            scope: {
+                mode: "=?",
+                vm: '=',
+                onRowClick: '&?',       // set row click function
+                allowCreate: '=?',      // if undefined, assume false
+                getDisabledTuples: "=?" // callback to get the disabled tuples
+            },
+            link: function (scope, elem, attr) {
+                recordTableUtils.registerRecordsetCallbacks(scope);
 
                 // function for removing a single pill and it's corresponding selected row
                 scope.removePill = function(key) {
+                    if (scope.vm.matchNotNull) {
+                        scope.vm.matchNotNull = false;
+                        scope.vm.selectedRows.clear();
+                        return;
+                    }
                     var index = scope.vm.selectedRows.findIndex(function (obj) {
                         return obj.uniqueId == key;
                     });
@@ -751,74 +888,34 @@
 
                 // function for removing all pills regardless of what page they are on, clears the whole selectedRows array
                 scope.removeAllPills = function() {
+                    if (scope.vm.matchNotNull) {
+                        scope.vm.matchNotNull = false;
+                        scope.vm.selectedRows.clear();
+                        return;
+                    }
                     scope.vm.selectedRows.clear();
                     scope.vm.currentPageSelected = false;
                 };
 
-                // on window focus, if has pending add record requests
-                // check if any are complete 1) delete requests, 2) delete cookies, 3) do a read
-                $window.onfocus = function() {
-
-                    var completed = 0; // completed add record requests
-                    for (var id in addRecordRequests) {
-                        var cookie = $cookies.getObject(id);
-                        if (cookie) {
-                            delete addRecordRequests[id];
-                            $cookies.remove(id);
-                            completed += 1;
-                        }
+                scope.toggleMatchNotNull = function () {
+                    scope.vm.matchNotNull = !scope.vm.matchNotNull;
+                    if (scope.vm.matchNotNull) {
+                        scope.vm.selectedRows = [{
+                            isNotNull: true,
+                            displayname: {"value": scope.defaultDisplayname.notNull, "isHTML": true}
+                        }];
+                    } else {
+                        scope.vm.selectedRows.clear();
                     }
-
-                    // read
-                    if (completed > 0 || updated) {
-                        updated = false;
-                        recordTableUtils.read(scope);
-                    }
-
                 };
-
-                // allow child window to call to indicate table has been updated
-                // called from form.controller.js to communicate that an entity was just updated
-                window.updated = function() {
-                    updated = true;
-                }
-
-                scope.$on('data-modified', function($event) {
-                    console.log('data-modified in recordset directive, getting count');
-                    if (!scope.vm.config.hideTotalCount && scope.vm.search == scope.vm.reference.location.searchTerm) {
-                        // get the total row count to display above the table
-                        console.log("Data-updated: ", scope.vm);
-                        scope.vm.reference.getAggregates([scope.vm.reference.aggregate.countAgg]).then(function getAggregateCount(response) {
-                            // NOTE: scenario: A user triggered a foreground search. Once it returns the aggregate count request is queued.
-                            // While that request is running, the user triggers another foreground search.
-                            // How do we avoid one aggregate count query to not show when it isn't relevant to the displayed data?
-                            // Maybe comparing reference.location.searchTerm and vm.search here instead and if they don't match,
-                            // set the value to null so the count displayed is just the count of the shown rows until the latter
-                            // aggregate count request returns. If the latter one never returns (because of a server error or something),
-                            // at least the UI doesn't show any misleading information.
-                            scope.vm.totalRowsCnt = response[0];
-                        }, function error(response) {
-                            //fail silently
-                            scope.vm.totalRowsCn = null;
-                        });
-                    }
-                });
-                
-                // row data has been modified (from ellipses)
-                // do a read
-                scope.$on('record-modified', function($event) {
-                    console.log('record-modified in recordset directive');
-                    recordTableUtils.read(scope, false, true);
-                    // $event.stopPropagation();
-                });
             }
         };
     }])
-    
+
     //TODO This is used in recrodset app, eventually it should be used everywhere
-    .directive('recordsetWithFaceting', ['recordTableUtils', '$window', '$cookies', 'DataUtils', 'MathUtils', 'UriUtils', '$timeout', 'AlertsService', '$log', function(recordTableUtils, $window, $cookies, DataUtils, MathUtils, UriUtils, $timeout, AlertsService, $log) {
-        var MAX_LENGTH = 2000;
-        
+    .directive('recordsetWithFaceting', ['recordTableUtils', '$window', '$cookies', 'DataUtils', 'MathUtils', 'UriUtils', '$timeout', 'AlertsService', '$log', 'tableConstants', 'defaultDisplayname',
+        function(recordTableUtils, $window, $cookies, DataUtils, MathUtils, UriUtils, $timeout, AlertsService, $log, tableConstants, defaultDisplayname) {
+
         return {
             restrict: 'E',
             templateUrl: '../common/templates/recordsetWithFaceting.html',
@@ -836,15 +933,17 @@
                 scope.$root.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
                 scope.vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
 
+                scope.defaultDisplayname = defaultDisplayname;
+
                 scope.vm.isIdle = true;
                 scope.vm.facetModels = [];
                 scope.vm.dirtyResult = false;
                 scope.vm.occupiedSlots = 0;
                 scope.vm.facetsToInitialize = [];
-                
+
                 scope.$root.checkReferenceURL = function (ref) {
                     var refUri = ref.isAttributeGroup ? ref.uri : ref.location.ermrestUri;
-                    if (refUri.length > MAX_LENGTH) {
+                    if (refUri.length > tableConstants.MAX_URL_LENGTH) {
                         $timeout(function () {
                             $window.scrollTo(0, 0);
                         }, 0);
@@ -877,7 +976,7 @@
                     }
 
                 };
-                
+
                 scope.focusOnSearchInput = function () {
                     angular.element("#search-input.main-search-input").focus();
                 };
@@ -993,22 +1092,20 @@
                 window.updated = function() {
                     updated = true;
                 };
-                
+
                 scope.$on('facet-modified', function ($event) {
                     $log.debug("-----------------------------");
                     $log.debug('facet-modified in recordset directive');
                     recordTableUtils.update(scope.vm, true, true, true);
                 });
-                
-                
+
                 scope.$on('record-deleted', function ($event) {
                     $log.debug("-----------------------------");
                     $log.debug('record-deleted in recordset directive');
                     scope.vm.lastActiveFacet = -1;
                     recordTableUtils.update(scope.vm, true, true, true);
                 });
-                
-                
+
                 // This is not used now, but we should change the record-deleted to this.
                 // row data has been modified (from ellipses) do read
                 scope.$on('record-modified', function($event) {
@@ -1017,25 +1114,25 @@
                     scope.vm.lastActiveFacet = -1;
                     recordTableUtils.update(scope.vm, true, true, true);
                 });
-                
+
                 scope.$on('page-loaded', function ($event) {
                     scope.$root.pageLoaded = true;
                     if (scope.vm.reference.facetColumns.length == 0) {
                         scope.$root.facetsLoaded = true;
                     }
                 });
-                
+
                 scope.$watch(function () {
                     return scope.$root.pageLoaded && scope.$root.facetsLoaded;
                 }, function (newValue, oldValue) {
                     if(angular.equals(newValue, oldValue) || !newValue){
                         return;
                     }
-                    
+
                     $timeout(function() {
-                        // NOTE 
-                        // This order is very important, the ref.facetColumns is going to change the 
-                        // location, so we should call read after that. 
+                        // NOTE
+                        // This order is very important, the ref.facetColumns is going to change the
+                        // location, so we should call read after that.
                         // TODO BUT WE SHOULD DO SOMETHING ABOUT IT IN ERMRESTJS
                         if (scope.vm.reference.facetColumns.length > 0) {
                             var firstOpen = -1;
@@ -1049,7 +1146,7 @@
                                     scope.vm.facetModels[index].isLoading = true;
                                 }
                             });
-                            
+
                             firstOpen = (firstOpen !== -1) ? firstOpen : 0;
                             scope.vm.focusOnFacet(firstOpen);
                         }

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -21,7 +21,7 @@
         <label />
     </div>
 </td>
-<td ng-show="config.showNull || tuple.uniqueId" ng-repeat="val in rowValues track by $index">
+<td ng-if="config.showNull || tuple.uniqueId" ng-repeat="val in rowValues track by $index">
     <div ng-switch="val.isHTML">
         <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" ng-style="overflow[$index+1] && maxHeightStyle">
             <span ng-switch-when="true" class="markdown-container" ng-bind-html="val.value | trustedHTML"></span>
@@ -38,4 +38,4 @@
         </div>
     </div>
 </td>
-<td ng-show="!config.showNull && !tuple.uniqueId" colspan="{{rowValues.length}}" ng-bind-html="defaultDisplayname.null"></td>
+<td ng-if="!config.showNull && !tuple.uniqueId" colspan="{{rowValues.length}}" ng-bind-html="defaultDisplayname.null"></td>

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -17,7 +17,7 @@
         </button>
     </div>
     <div ng-if="config.selectMode == multiSelect" class="chaise-checkbox">
-        <input type="checkbox" ng-checked="selected || selectDisabled" ng-click="onSelect()" ng-disabled="selectDisabled">
+        <input type="checkbox" ng-checked="selected" ng-click="onSelect()" ng-disabled="selectDisabled">
         <label />
     </div>
 </td>
@@ -28,8 +28,8 @@
             <span ng-switch-default ng-if="!config.showNull" ng-bind="val.value"></span>
             <span ng-switch-default ng-if="config.showNull">
                 <span ng-if="val.value" ng-bind="val.value"></span>
-                <span ng-if="val.value == ''"><i>Empty</i></span>
-                <span ng-if="val.value == null"><i>No Value</i></span>
+                <span ng-if="val.value == ''" ng-bind-html="defaultDisplayname.empty"></span>
+                <span ng-if="val.value == null" ng-bind-html="defaultDisplayname.null"></span>
             </span>
         </div>
         <div ng-if="overflow[$index+1]" style="display:inline;">
@@ -38,6 +38,4 @@
         </div>
     </div>
 </td>
-<td ng-show="!config.showNull && !tuple.uniqueId" colspan="{{rowValues.length}}">
-    <i>No Value</i>
-</td>
+<td ng-show="!config.showNull && !tuple.uniqueId" colspan="{{rowValues.length}}" ng-bind-html="defaultDisplayname.null"></td>

--- a/common/templates/ellipses.html
+++ b/common/templates/ellipses.html
@@ -21,7 +21,7 @@
         <label />
     </div>
 </td>
-<td ng-repeat="val in rowValues track by $index">
+<td ng-show="config.showNull || tuple.uniqueId" ng-repeat="val in rowValues track by $index">
     <div ng-switch="val.isHTML">
         <div ng-class="{'hideContent': hideContent == true, 'showContent': hideContent == false}" ng-style="overflow[$index+1] && maxHeightStyle">
             <span ng-switch-when="true" class="markdown-container" ng-bind-html="val.value | trustedHTML"></span>
@@ -37,4 +37,7 @@
             <span style="display:inline-block; text-decoration: underline;cursor: pointer;" class="text-primary readmore" ng-click="readmore($index+1)">{{linkText}}</span>
         </div>
     </div>
+</td>
+<td ng-show="!config.showNull && !tuple.uniqueId" colspan="{{rowValues.length}}">
+    <i>No Value</i>
 </td>

--- a/common/templates/faceting/choice-picker.html
+++ b/common/templates/faceting/choice-picker.html
@@ -19,5 +19,5 @@
         </span>
     </div>
     <record-list rows='checkboxRows' on-row-click='onRowClick' initialized='facetModel.initialized && facetModel.isOpen'></record-list>
-    <a id="show-more" ng-if="hasMore || showFindMore" ng-click="openSearchPopup()"><b>Show More ...</b></a>
+    <a id="show-more" ng-if="hasMore || showFindMore" ng-click="openSearchPopup()"><b>Show Details ...</b></a>
 </div>

--- a/common/templates/faceting/faceting.html
+++ b/common/templates/faceting/faceting.html
@@ -6,7 +6,7 @@
                     <uib-accordion-heading>
                         <h3 class="panel-title accordion-toggle ellipsis" id="fc-heading-{{$index}}" ng-click="toggleFacet($index)" tooltip-enable="tooltipEnabled" uib-tooltip-html="fc.displayname.value" tooltip-placement="bottom" chaise-enable-tooltip-width>
                             <i class="pull-left glyphicon toggle-icon" ng-class="{'glyphicon-chevron-down': vm.facetModels[$index].isOpen, 'glyphicon-chevron-right': !vm.facetModels[$index].isOpen}"></i>
-                                
+
                             <a>
                                 <span ng-if="::fc.displayname.isHTML" ng-bind-html="::fc.displayname.value"></span>
                                 <span ng-if="::!fc.displayname.isHTML" ng-bind="::fc.displayname.value"></span>

--- a/common/templates/list.html
+++ b/common/templates/list.html
@@ -1,14 +1,10 @@
 <ul class="chaise-list-container">
     <span ng-if="initialized && rows.length === 0">No Results Found</span>
-    <li ng-repeat="row in rows track by $index" class="chaise-checkbox ellipsis-text">
-        <input id="checkbox-{{$index}}" type="checkbox" ng-checked="row.selected" ng-click="onSelect(row, $event)" />
+    <li ng-repeat="row in rows track by $index" class="chaise-checkbox ellipsis-text" ng-class="{'disabled-row': row.disabled}">
+        <input id="checkbox-{{$index}}" type="checkbox" ng-checked="row.selected" ng-click="onSelect(row, $event)" ng-disabled="row.disabled" />
         <label ng-if="row.displayname.value && row.displayname.isHTML" ng-bind-html="row.displayname.value" tooltip-enable="tooltipEnabled" uib-tooltip-html="row.displayname.value" tooltip-placement="bottom" chaise-enable-width></label>
         <label ng-if="row.displayname.value && !row.displayname.isHTML" ng-bind="row.displayname.value" tooltip-enable="tooltipEnabled" uib-tooltip="{{row.displayname.value}}" tooltip-placement="bottom" chaise-enable-tooltip-width></label>
-        <label ng-if="row.displayname.value == ''" tooltip-enable="tooltipEnabled" uib-tooltip="Empty" tooltip-placement="bottom" chaise-enable-tooltip-width>
-            <i>Empty</i>
-        </label>
-        <label ng-if="row.displayname.value == null" tooltip-enable="tooltipEnabled" uib-tooltip="No Value" tooltip-placement="bottom" chaise-enable-tooltip-width>
-            <i>No Value</i>
-        </label>
+        <label ng-if="row.displayname.value == ''" tooltip-enable="tooltipEnabled" uib-tooltip-html="defaultDisplayname.empty" tooltip-placement="bottom" chaise-enable-tooltip-width ng-bind-html="defaultDisplayname.empty"></label>
+        <label ng-if="row.displayname.value == null" tooltip-enable="tooltipEnabled" uib-tooltip-html="defaultDisplayname.null" tooltip-placement="bottom" chaise-enable-tooltip-width ng-bind-html="defaultDisplayname.null"></label>
     </li>
 </ul>

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -16,10 +16,10 @@
                         <a class="remove-link" ng-click="removePill(row.uniqueId)"><i class="glyphicon glyphicon-remove"></i></a>
                         <span ng-if="row.displayname.value && row.displayname.isHTML" ng-bind-html="row.displayname.value"></span>
                         <span ng-if="row.displayname.value && !row.displayname.isHTML" ng-bind="row.displayname.value"></span>
-                        <span ng-if="row.displayname.value == ''">
+                        <span ng-if="row.displayname.value == '' && row.uniqueId != null">
                             <i>Empty</i>
                         </span>
-                        <span ng-if="row.displayname.value == null">
+                        <span ng-if="row.displayname.value == null || row.uniqueId == null">
                             <i>No Value</i>
                         </span>
                     </div>

--- a/common/templates/recordsetSelectFaceting.html
+++ b/common/templates/recordsetSelectFaceting.html
@@ -64,34 +64,15 @@
                     </ul>
                 </span>
             </div>
-
-            <div class="col-lg-4 col-md-3 col-sm-2 col-xs-2">
-                <!-- add record -->
-                <button id="add-record-btn" type="button" class="btn btn-primary btn-inverted pull-right" ng-if="vm.reference.canCreate && allowCreate" ng-click="addRecord()"  tooltip-placement="bottom" uib-tooltip="Create new record">
-                    <span class="glyphicon glyphicon-plus"></span>
-                </button>
-            </div>
-        </div>
-        <div ng-if="vm.initialized && vm.filterString" class="row total-filters selected-rows">
-            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12" style="padding-left: 0;">
-                <a class="remove-link" ng-click="unfiltered()" tooltip-placement="bottom" uib-tooltip="Show unfiltered list">
-                    <span class="filter-label label label-primary label-inverted">
-                        Clear All
-                    </span>
-                </a>
-                <div class="filter-label label label-default" tooltip-enable="tooltipEnabled" uib-tooltip="{{vm.filterString}}" tooltip-placement="bottom" chaise-enable-tooltip-width>
-                    <a class="remove-link" ng-click="unfiltered()"><i class="glyphicon glyphicon-remove"></i></a>
-                    <span ng-bind="vm.filterString"></span>
-                </div>
-            </div>
         </div>
 
         <!-- record table -->
-        <div ng-if="vm.hasLoaded">
-            <h3 ng-if="!vm.config.hideTotalCount" id="rs-total-count">Displaying {{vm.rowValues.length}}{{vm.totalRowsCnt ? " of " + (vm.totalRowsCnt > vm.rowValues.length ? vm.totalRowsCnt : vm.rowValues.length) : ''}} Records</h3>
+        <div ng-if="vm.hasLoaded" class="row">
+            <div ng-if="!vm.config.hideTotalCount" id="rs-total-count" class="col-lg-3 col-md-3 col-sm-3 col-xs-12">Displaying {{vm.rowValues.length}}{{vm.totalRowsCnt ? " of " + (vm.totalRowsCnt > vm.rowValues.length ? vm.totalRowsCnt : vm.rowValues.length) : ''}} Records</div>
+            <span class="chaise-checkbox col-lg-4 col-md-4 col-sm-4 col-xs-12"><input type="checkbox" id="rs-match-not-null" ng-click="toggleMatchNotNull()" ng-checked="vm.matchNotNull"><label>Records With Values</label></span>
         </div>
         <div ng-if="vm.hasLoaded">
-            <record-table id="rs-{{vm.makeSafeIdAttr(vm.tableDisplayName.value)}}" vm="vm" on-row-click-bind="onRowClick"></record-table>
+            <record-table-select-faceting id="rs-{{vm.makeSafeIdAttr(vm.tableDisplayName.value)}}" vm="vm" on-row-click-bind="onRowClick"></record-table-select-faceting>
         </div>
 
         <!-- bottom pagination -->

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -1,4 +1,5 @@
 <div class="recordset-container" ng-class="vm.config.showFaceting ? 'row with-faceting':'without-faceting'">
+    <div ng-bind="whatever"></div>
     <loading-spinner ng-show="!vm.initialized || $root.showSpinner"></loading-spinner>
     <div class="faceting-resizable" resizable r-directions=["right"] r-flex="true" ng-if="vm.config.showFaceting" ng-class="{'initializing': !vm.initialized}">
         <faceting vm="vm"></faceting>
@@ -99,12 +100,8 @@
                         <span ng-repeat="filter in vm.facetModels[$index].appliedFilters">
                             <span ng-if="::filter.displayname.value && filter.displayname.isHTML" ng-bind-html="::filter.displayname.value"></span>
                             <span ng-if="::filter.displayname.value && !filter.displayname.isHTML" ng-bind="::filter.displayname.value"></span>
-                            <span ng-if="::filter.displayname.value == ''">
-                                <i>Empty</i>
-                            </span>
-                            <span ng-if="::filter.displayname.value == null">
-                                <i>No Value</i>
-                            </span>
+                            <span ng-if="::filter.displayname.value == ''" ng-bind-html="defaultDisplayname.empty"></span>
+                            <span ng-if="::filter.displayname.value == null" ng-bind-html="defaultDisplayname.null"></span>
                             <span>{{$last ? '': ','}}</span>
                         </span>
                     </span>
@@ -113,12 +110,8 @@
                             <span>&bull;</span>
                             <span ng-if="::filter.displayname.value && filter.displayname.isHTML" ng-bind-html="::filter.displayname.value"></span>
                             <span ng-if="::filter.displayname.value && !filter.displayname.isHTML" ng-bind="::filter.displayname.value"></span>
-                            <span ng-if="::filter.displayname.value == ''">
-                                <i>Empty</i>
-                            </span>
-                            <span ng-if="::filter.displayname.value == null">
-                                <i>No Value</i>
-                            </span>
+                            <span ng-if="::filter.displayname.value == ''" ng-bind-html="defaultDisplayname.empty"></span>
+                            <span ng-if="::filter.displayname.value == null" ng-bind-html="defaultDisplayname.null"></span>
                         </span>
                     </script>
                 </div>

--- a/common/templates/searchPopup.modal.html
+++ b/common/templates/searchPopup.modal.html
@@ -10,5 +10,9 @@
     <span ng-if="ctrl.tableModel.config.selectMode=='multi-select'">
         <button id="multi-select-submit-btn" class="btn btn-primary btn-inverted pull-right" type="button" ng-click="ctrl.submit()" ng-disabled="ctrl.tableModel.selectedRows.length < 1">Submit</button>
     </span>
-    <recordset vm="ctrl.tableModel" on-row-click="ctrl.ok" allow-create="true" get-disabled-tuples="getDisabledTuples"></recordset>
+    <div ng-switch="ctrl.mode">
+        <recordset-select-faceting ng-switch-when="selectFaceting" vm="ctrl.tableModel" on-row-click="ctrl.ok" allow-create="false"></recordset-select-faceting>
+        <recordset ng-switch-default vm="ctrl.tableModel" on-row-click="ctrl.ok" allow-create="true" get-disabled-tuples="getDisabledTuples"></recordset>
+    </div>
+
 </div>

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -7,10 +7,10 @@
                     <span ng-switch-when="no-select">Actions</span>
                     <span ng-switch-when="single-select">Select</span>
                     <div ng-switch-when="multi-select">
-                        <button type="button" ng-click="::selectAll()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Select all rows in table">
+                        <button type="button" ng-click="::selectAll()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Select all rows in table" ng-disabled="vm.matchNotNull">
                             <span class="glyphicon glyphicon-check"></span> All
                         </button>
-                        <button type="button" ng-click="::selectNone()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Deselect all rows in table">
+                        <button type="button" ng-click="::selectNone()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Deselect all rows in table"  ng-disabled="vm.matchNotNull">
                             <span class="glyphicon glyphicon-unchecked"></span> None
                         </button>
                     </div>
@@ -29,9 +29,9 @@
 
         <!-- rows -->
         <tbody>
-            <tr class="table-row" ng-class="{'disabled-row': isDisabled(vm.page.tuples[$index].uniqueId)}"
-                ellipses ng-repeat="row in vm.rowValues track by $index" tuple="vm.page.tuples[$index]" from-tuple="vm.fromTuple" row-values="row" 
-                config="vm.config" context="vm.context" on-row-click-bind="onSelect" selected="isSelected(vm.page.tuples[$index].uniqueId)" select-disabled="isDisabled(vm.page.tuples[$index].uniqueId)">
+            <tr class="table-row" ng-class="{'disabled-row': isDisabled(vm.page.tuples[$index])}"
+                ellipses ng-repeat="row in vm.rowValues track by $index" tuple="vm.page.tuples[$index]" from-tuple="vm.fromTuple" row-values="row"
+                config="vm.config" context="vm.context" on-row-click-bind="onSelect" selected="isSelected(vm.page.tuples[$index])" select-disabled="isDisabled(vm.page.tuples[$index])">
             </tr>
             <tr ng-if="vm.rowValues.length < 1">
                 <td id="no-results-row" colspan="{{vm.columns.length + 1}}" style="text-align: center;">No Results Found</td>

--- a/common/utils.js
+++ b/common/utils.js
@@ -60,6 +60,13 @@
         singleSelectMode:"single-select",
         multiSelectMode:"multi-select"
     })
+
+    .constant("defaultDisplayname", {
+        null: "<i>No Value</i>",
+        empty: "<i>Empty</i>",
+        notNull: "<i>All Records With Value</i>"
+    })
+
     .factory('UriUtils', ['$injector', '$rootScope', '$window', 'appContextMapping', 'appTagMapping', 'ContextUtils', 'Errors', 'messageMap', 'parsedFilter',
         function($injector, $rootScope, $window, appContextMapping, appTagMapping, ContextUtils, Errors, messageMap, ParsedFilter) {
 

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -110,20 +110,20 @@ describe('View recordset,', function() {
 
             it("should show correct table rows", function() {
                 chaisePage.recordsetPage.getRows().then(function(rows) {
-                    expect(rows.length).toBe(4);
+                    expect(rows.length).toBe(4, "rows length missmatch.");
                     for (var i = 0; i < rows.length; i++) {
                         (function(index) {
                             rows[index].all(by.tagName("td")).then(function (cells) {
-                                expect(cells.length).toBe(accommodationParams.columns.length + 1);
-                                expect(cells[1].getText()).toBe(accommodationParams.data[index].title);
-                                expect(cells[2].element(by.tagName("a")).getAttribute("href")).toBe(accommodationParams.data[index].website);
-                                expect(cells[2].element(by.tagName("a")).getText()).toBe("Link to Website");
-                                expect(cells[3].getText()).toBe(accommodationParams.data[index].rating);
-                                expect(cells[4].getText()).toBe(accommodationParams.data[index].summary);
-                                expect(cells[5].getText()).toBe(accommodationParams.data[index].opened_on);
-                                expect(cells[6].getText()).toBe(accommodationParams.data[index].luxurious);
-                                expect(cells[7].getText()).toBe(accommodationParams.data[index].json_col);
-                                expect(cells[8].getText()).toBe(accommodationParams.data[index].json_col_with_markdown);
+                                expect(cells.length).toBe(accommodationParams.columns.length + 1, "cells length missmatch for row=" + index);
+                                expect(cells[1].getText()).toBe(accommodationParams.data[index].title, "title column missmatch for row=" + index);
+                                expect(cells[2].element(by.tagName("a")).getAttribute("href")).toBe(accommodationParams.data[index].website, "website column link missmatch for row=" + index);
+                                expect(cells[2].element(by.tagName("a")).getText()).toBe("Link to Website", "website column caption missmatch for row=" + index);
+                                expect(cells[3].getText()).toBe(accommodationParams.data[index].rating, "rating column missmatch for row=" + index);
+                                expect(cells[4].getText()).toBe(accommodationParams.data[index].summary, "summary column missmatch for row=" + index);
+                                expect(cells[5].getText()).toBe(accommodationParams.data[index].opened_on, "opened_on column missmatch for row=" + index);
+                                expect(cells[6].getText()).toBe(accommodationParams.data[index].luxurious, "luxurious column missmatch for row=" + index);
+                                expect(cells[7].getText()).toBe(accommodationParams.data[index].json_col, "json_col column missmatch for row=" + index);
+                                expect(cells[8].getText()).toBe(accommodationParams.data[index].json_col_with_markdown, "json_col_with_markdown column missmatch for row=" + index);
                             });
                         }(i))
                     }

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -36,86 +36,86 @@ var testParams = {
     tsMaxTimeInputClearClass: "max-time-clear",
     facets: [
         {
-            name: "id", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 2, 
-            filter: "id: 3", 
-            numRows: 1, 
+            name: "id",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 2,
+            filter: "id: 3",
+            numRows: 1,
             options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10' ]
         },
         {
-            name: "int_col", 
-            type: "numeric", 
+            name: "int_col",
+            type: "numeric",
             listElems: 1,
             invalid: 1.1,
             error: "Please enter an integer value.",
-            range: { 
-                min: 5, 
-                max: 10, 
-                filter: "int_col: 5 to 10", 
+            range: {
+                min: 5,
+                max: 10,
+                filter: "int_col: 5 to 10",
                 numRows: 4
             },
             justMin: {
-                min: 6, 
-                filter: "int_col: > 6", 
+                min: 6,
+                filter: "int_col: > 6",
                 numRows: 16
             },
             justMax: {
-                max: 12, 
-                filter: "int_col: < 12", 
+                max: 12,
+                filter: "int_col: < 12",
                 numRows: 14
             }
         },
         {
-            name: "float_col", 
-            type: "numeric", 
+            name: "float_col",
+            type: "numeric",
             listElems: 0,
             invalid: "1.1.",
             error: "Please enter a decimal value.",
             range: {
-                min: 6.5, 
-                max: 12.2, 
-                filter: "float_col: 6.5000 to 12.2000", 
+                min: 6.5,
+                max: 12.2,
+                filter: "float_col: 6.5000 to 12.2000",
                 numRows: 12
             },
             justMin: {
-                min: 8.9, 
-                filter: "float_col: > 8.9000", 
+                min: 8.9,
+                filter: "float_col: > 8.9000",
                 numRows: 14
             },
             justMax: {
-                max: 7.45, 
-                filter: "float_col: < 7.4500", 
+                max: 7.45,
+                filter: "float_col: < 7.4500",
                 numRows: 4
             }
         },
         {
-            name: "date_col", 
-            type: "date", 
+            name: "date_col",
+            type: "date",
             listElems: 0,
             invalid: "2006-14-22",
             error: "Please enter a date value in YYYY-MM-DD format.",
             range: {
-                min: "2002-06-14", 
-                max: "2007-12-12", 
-                filter: "date_col: 2002-06-14 to 2007-12-12", 
+                min: "2002-06-14",
+                max: "2007-12-12",
+                filter: "date_col: 2002-06-14 to 2007-12-12",
                 numRows: 5
             },
             justMin: {
-                min: "2009-12-14", 
-                filter: "date_col: > 2009-12-14", 
+                min: "2009-12-14",
+                filter: "date_col: > 2009-12-14",
                 numRows: 3
             },
             justMax: {
-                max: "2007-04-18", 
-                filter: "date_col: < 2007-04-18", 
+                max: "2007-04-18",
+                filter: "date_col: < 2007-04-18",
                 numRows: 14
             }
         },
         {
-            name: "timestamp_col", 
-            type: "timestamp", 
+            name: "timestamp_col",
+            type: "timestamp",
             listElems: 0,
             invalid: {
                 date: "2001-14-04",
@@ -124,105 +124,105 @@ var testParams = {
                 timeError: "Please enter a time value in 24-hr HH:MM:SS format."
             },
             range: {
-                minDate: "2004-05-20", 
-                minTime: "10:08:00", 
-                maxDate: "2007-12-06", 
-                maxTime: "17:26:12", 
-                filter: "timestamp_col: 2004-05-20 10:08:00 to 2007-12-06 17:26:12", 
+                minDate: "2004-05-20",
+                minTime: "10:08:00",
+                maxDate: "2007-12-06",
+                maxTime: "17:26:12",
+                filter: "timestamp_col: 2004-05-20 10:08:00 to 2007-12-06 17:26:12",
                 numRows: 3
             },
             justMin: {
-                date: "2004-05-20", 
-                time: "10:08:00", 
-                filter: "timestamp_col: > 2004-05-20 10:08:00", 
+                date: "2004-05-20",
+                time: "10:08:00",
+                filter: "timestamp_col: > 2004-05-20 10:08:00",
                 numRows: 8
             },
             justMax: {
-                date: "2007-12-06", 
-                time: "17:26:12", 
-                filter: "timestamp_col: < 2007-12-06 17:26:12", 
+                date: "2007-12-06",
+                time: "17:26:12",
+                filter: "timestamp_col: < 2007-12-06 17:26:12",
                 numRows: 15
             }
         },
         {
-            name: "text_col", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 1, 
-            filter: "text_col: one", 
-            numRows: 5, 
+            name: "text_col",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 1,
+            filter: "text_col: one",
+            numRows: 5,
             options: [ 'Empty', 'one', 'two', 'No Value', 'eight', 'eleven', 'five', 'four', 'nine', 'seven' ]
         },
         {
-            name: "longtext_col", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 2, 
-            filter: "longtext_col: two", 
-            numRows: 5, 
+            name: "longtext_col",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 2,
+            filter: "longtext_col: two",
+            numRows: 5,
             options: [ 'Empty', 'one', 'two', 'No Value', 'eight', 'eleven', 'five', 'four', 'nine', 'seven' ]
         },
         {
-            name: "markdown_col", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 4, 
-            filter: "markdown_col: eight", 
-            numRows: 1, 
+            name: "markdown_col",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 4,
+            filter: "markdown_col: eight",
+            numRows: 1,
             options: [ 'Empty', 'one', 'two', 'No Value', 'eight', 'eleven', 'five', 'four', 'nine', 'seven' ]
         },
         {
-            name: "boolean_col", 
-            type: "choice", 
-            totalNumOptions: 3, 
-            option: 1, 
-            filter: "boolean_col: true", 
-            numRows: 10, 
+            name: "boolean_col",
+            type: "choice",
+            totalNumOptions: 3,
+            option: 1,
+            filter: "boolean_col: true",
+            numRows: 10,
             options: [ 'false', 'true', 'No Value' ]
         },
         {
-            name: "jsonb_col", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 6, 
-            filter: 'jsonb_col: { "key": "four" }', 
-            numRows: 1, 
+            name: "jsonb_col",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 6,
+            filter: 'jsonb_col: { "key": "four" }',
+            numRows: 1,
             options: [ 'No Value', '{"key":"one"}', '{"key":"two"}', '{"key":"eight"}', '{"key":"eleven"}', '{"key":"five"}', '{"key":"four"}', '{"key":"nine"}', '{"key":"seven"}', '{"key":"six"}' ]
         },
         {
-            name: "F1", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 1, 
-            filter: "F1 : two", 
-            numRows: 10, 
+            name: "F1",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 1,
+            filter: "F1 : two",
+            numRows: 10,
             options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
         },
         {
-            name: "to_name", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 0, 
-            filter: "to_name: one", 
-            numRows: 10, 
+            name: "to_name",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 0,
+            filter: "to_name: one",
+            numRows: 10,
             options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
         },
         {
-            name: "f3 (term)", 
-            type: "choice", 
-            totalNumOptions: 2, 
-            option: 0, 
-            filter: "f3 (term): one", 
-            numRows: 6, 
-            options: [ 'one', 'two' ]
+            name: "f3 (term)",
+            type: "choice",
+            totalNumOptions: 3,
+            option: 0,
+            filter: "f3 (term): one",
+            numRows: 6,
+            options: [ 'one', 'two', "No Value" ]
         },
         {
-            name: "from_name", 
-            type: "choice", 
-            totalNumOptions: 10, 
-            option: 4, 
-            filter: "from_name: 5", 
-            numRows: 1, 
+            name: "from_name",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 4,
+            filter: "from_name: 5",
+            numRows: 1,
             options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10' ]
         }
     ],
@@ -249,39 +249,39 @@ var testParams = {
 }
 
 describe("Viewing Recordset with Faceting,", function() {
-    
+
     describe("For table " + testParams.table_name + ",", function() {
-        
+
         var table, record,
         uri = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schema_name + ":" + testParams.table_name;
-        
+
         beforeAll(function () {
             browser.ignoreSynchronization=true;
             browser.get(uri);
             chaisePage.waitForElementInverse(element(by.id("spinner")));
         });
-        
+
         describe("default presentation based on facets annotation ", function () {
             it("should have 12 facets", function () {
                 chaisePage.recordsetPage.getAllFacets().count().then(function (ct) {
                     expect(ct).toBe(testParams.totalNumFacets, "Number of all facets is incorrect");
-                    
+
                     return chaisePage.recordsetPage.getFacetTitles();
                 }).then(function (text) {
                     expect(text).toEqual(testParams.facetNames, "All facets' names is incorrect");
                 });
             });
-            
+
             it("should have 3 facets open", function () {
                 chaisePage.recordsetPage.getOpenFacets().count().then(function (ct) {
                     expect(ct).toBe(testParams.defaults.openFacetNames.length, "Number of open facets is incorrect");
-                    
+
                     return chaisePage.recordsetPage.getOpenFacetTitles();
                 }).then(function (text) {
                     expect(text).toEqual(testParams.defaults.openFacetNames, "Names of open facets are incorrect");
                 });
             });
-            
+
             // test defaults and values shown
             it("'id' facet should have 1 row checked", function () {
                 // use 0 index
@@ -289,22 +289,22 @@ describe("Viewing Recordset with Faceting,", function() {
                     expect(ct).toBe(1);
                 });
             });
-            
+
             it("should have 2 filters selected", function () {
-                chaisePage.recordsetPage.getFilters().count().then(function (ct) {  
+                chaisePage.recordsetPage.getFilters().count().then(function (ct) {
                     expect(ct).toBe(testParams.defaults.numFilters, "Number of visible filters is incorrect");
                 });
             });
-            
+
             it("should have 1 row visible", function () {
                 chaisePage.recordsetPage.getRows().count().then(function (ct) {
                     expect(ct).toBe(testParams.defaults.numRows, "Number of visible rows is incorrect");
                 });
             });
-            
+
             it("should have 1 row selected in show more popup for scalar picker.", function () {
                 var showMore = chaisePage.recordsetPage.getShowMore(0);
-                
+
                 // open show more, verify only 1 row checked, check another and submit
                 showMore.click().then(function () {
                     browser.wait(function () {
@@ -312,7 +312,7 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == 1;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getModalOptions();
                 }).then(function (options) {
                     // click the 3rd option
@@ -325,69 +325,69 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == 2;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getCheckedFacetOptions(0).count();
                 }).then(function (ct) {
                     expect(ct).toBe(2, "Number of facet options is incorrect after returning from modal");
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(2, "Number of visible rows after selecting a second option from the modal is incorrect");
-                    
+
                     // search string too
                     chaisePage.recordsetPage.getFacetSearchBox(0).sendKeys(11);
-                    
+
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getFacetOptions(0).count().then(function(ct) {
                             return ct == 3;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getFacetOptions(0).count();
                 }).then(function (ct) {
                     expect(ct).toBe(3, "Facet values after search are incorrect");
-                    
+
                     return chaisePage.recordsetPage.getFacetSearchBoxClear(0).click();
                 });
             });
-            
+
             it("boolean facet should not have a search box present", function () {
                 // idx 8 is for boolean facet
                 var booleanFacet = chaisePage.recordsetPage.getFacetById(8);
-                
+
                 booleanFacet.click().then(function () {
                     return chaisePage.recordsetPage.getFacetSearchBox(8).isDisplayed();
                 }).then(function (bool) {
                     expect(bool).toBeFalsy();
-                    
+
                     return booleanFacet.click();
                 });
             });
-            
+
             it("search using the global search box should search automatically, show the search phrase as a filter, and show the set of results", function () {
                 var mainSearch = chaisePage.recordsetPage.getSearchBox();
-                
+
                 chaisePage.recordsetPage.getClearAllFilters().click().then(function () {
                     return chaisePage.waitForElementInverse(element(by.id("spinner")));
                 }).then(function () {
                     mainSearch.sendKeys(testParams.searchBox.term);
-                    
+
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                             return ct == testParams.searchBox.numRows;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getFilters();
                 }).then(function (filters) {
                     return filters[0].getText();
                 }).then(function (text) {
                     expect(text).toBe(testParams.searchBox.filter, "Filter for global search input is incorrect");
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(testParams.searchBox.numRows, "Number of rows for search input is incorrect");
-                    
+
                     return chaisePage.recordsetPage.getSearchClearButton().click();
                 }).then(function () {
                     browser.wait(function () {
@@ -395,23 +395,23 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == testParams.defaults.pageSize;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(testParams.defaults.pageSize, "Number of rows after clearing search input via search clear button");
-                    
+
                     return mainSearch.getText();
                 }).then(function (text) {
                     expect(text).toBe("", "Main search did not clear properly after clicking the remove search button in the search input");
-                    
+
                     mainSearch.sendKeys(testParams.searchBox.term);
-                    
+
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                             return ct == testParams.searchBox.numRows;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getFilters();
                 }).then(function (filters) {
                     return filters[0].element(by.css(".remove-link")).click();
@@ -421,29 +421,29 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == testParams.defaults.pageSize;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(testParams.defaults.pageSize, "Number of rows after clearing search input via search clear button");
-                    
+
                     return mainSearch.getText();
                 }).then(function (text) {
                     expect(text).toBe("", "Main search did not clear properly after clicking the 'x' in the filter");
-                    
+
                     mainSearch.sendKeys(testParams.searchBox.term2);
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                             return ct == testParams.searchBox.term2Rows;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     mainSearch.sendKeys(testParams.searchBox.term3);
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                             return ct == testParams.searchBox.term3Rows;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getFilters();
                 }).then(function (filters) {
                     return filters[0].getText();
@@ -451,7 +451,7 @@ describe("Viewing Recordset with Faceting,", function() {
                     expect(text).toBe(testParams.searchBox.term3Filter, "adding another character to an existing search did not update the filter properly");
                 });
             });
-            
+
             it("should show 25 rows and 0 filters after clicking 'clear all'", function () {
                 var sortString = "@sort(id)";
                 chaisePage.recordsetPage.getClearAllFilters().click().then(function () {
@@ -461,20 +461,20 @@ describe("Viewing Recordset with Faceting,", function() {
                     return browser.getCurrentUrl();
                 }).then(function (url) {
                     expect(url).toBe(uri + sortString);
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(testParams.defaults.pageSize, "Number of visible rows is incorrect");
-                    
+
                     return chaisePage.recordsetPage.getFilters().count();
                 }).then(function (ct) {
                     expect(ct).toBe(0, "Number of visible filters is incorrect");
                 });
             });
-    
+
             it("should have 1 row selected in show more popup for entity.", function () {
                 var showMore = chaisePage.recordsetPage.getShowMore(11);
-    
+
                 chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(11, 0)).then(function () {
                     // open show more, verify only 1 row checked, check another and submit
                     return showMore.click()
@@ -484,7 +484,7 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == 1;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getModalOptions();
                 }).then(function (options) {
                     // click the 3rd option
@@ -497,19 +497,19 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == 2;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getCheckedFacetOptions(11).count();
                 }).then(function (ct) {
                     expect(ct).toBe(2, "Number of facet options is incorrect after returning from modal");
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function (ct) {
                     expect(ct).toBe(15, "Number of visible rows after selecting a second option from the modal is incorrect");
-    
+
                     return chaisePage.recordsetPage.getClearAllFilters().click();
                 });
             });
-            
+
             afterAll(function () {
                 // close the facets in opposite order so they dont move when trying to click others
                 //close first facet
@@ -532,15 +532,15 @@ describe("Viewing Recordset with Faceting,", function() {
                 });
             });
         });
-        
+
         describe("selecting individual filters for each facet type", function () {
-    
+
             var clearAll;
-    
+
             beforeAll(function () {
                 clearAll = chaisePage.recordsetPage.getClearAllFilters();
             });
-    
+
             for (var j=0; j<testParams.totalNumFacets; j++) {
                 // anon function to capture looping variable
                 (function(facetParams, idx) {
@@ -558,49 +558,49 @@ describe("Viewing Recordset with Faceting,", function() {
                                 }).then(function() {
                                     // wait for facet to open
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
-                                    
+
                                     // wait for facet checkboxes to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getFacetOptions(idx).count().then(function(ct) {
                                             return ct == facetParams.totalNumOptions;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     // wait for list to be fully visible
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getList(idx)), browser.params.defaultTimeout);
-                                    
+
                                     // special case for 'jsonb'
                                     return (facetParams.name == "jsonb_col" ? chaisePage.recordsetPage.getJsonbFacetOptionsText(idx) : chaisePage.recordsetPage.getFacetOptionsText(idx));
                                 }).then(function (text) {
                                     expect(text).toEqual(facetParams.options, "facet options are incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(idx, facetParams.option));
                                 }).then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getFilters().count();
                                 }).then(function (ct) {
                                     expect(ct).toBe(1, "number of filters is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.filter, "filter name is inccorect for '" + facetParams.name + "' facet");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
@@ -611,11 +611,11 @@ describe("Viewing Recordset with Faceting,", function() {
                                 });
                             });
                         });
-    
+
                     } else if (facetParams.type == "numeric" || facetParams.type == "date" ) {
                         describe("for range facet: " + facetParams.name + ",", function () {
                             var minInput, maxInput, minClear, maxClear;
-    
+
                             beforeAll(function () {
                                 // inputs
                                 minInput = chaisePage.recordsetPage.getRangeMinInput(idx, testParams.minInputClass);
@@ -624,7 +624,7 @@ describe("Viewing Recordset with Faceting,", function() {
                                 minClear = chaisePage.recordsetPage.getInputClear(idx, testParams.minInputClearClass);
                                 maxClear = chaisePage.recordsetPage.getInputClear(idx, testParams.maxInputClearClass);
                             });
-    
+
                             it("should open the facet, test validators, filter on a range, and update the search criteria.", function () {
                                 // open facet
                                 browser.wait(function () {
@@ -637,139 +637,139 @@ describe("Viewing Recordset with Faceting,", function() {
                                     // wait for facet to open
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getRangeSubmit(idx)), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getFacetOptions(idx).count();
                                 }).then(function (ct) {
                                     expect(ct).toBe(facetParams.listElems, "There are more list elements for '" + facetParams.name + "' facet than expected");
                                     // test validators
                                     minInput.sendKeys(facetParams.invalid);
-                                    
+
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getValidationError(idx)), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getValidationError(idx).getText();
                                 }).then(function (text) {
                                     expect(text).toBe(facetParams.error, "Validation error for '" + facetParams.name + "' did not show up or the message is incorrect");
-                                    
+
                                     return minClear.click();
                                 }).then(function () {
-                                    
+
                                     // test min and max being set
                                     // define test params values
                                     minInput.sendKeys(facetParams.range.min);
                                     maxInput.sendKeys(facetParams.range.max);
-                                    
+
                                     // let validation message disappear
                                     browser.sleep(10);
-                                    
+
                                     return chaisePage.recordsetPage.getRangeSubmit(idx).click();
                                 }).then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getFilters().count();
                                 }).then(function (ct) {
                                     expect(ct).toBe(1, "number of filters is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.range.filter, "filter name is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.range.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.range.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
-                                    
+
                                     return minClear.click();
                                 }).then(function () {
                                     return maxClear.click();
                                 });
                             });
-                            
+
                             it("should filter on just a min value and update the search criteria.", function () {
                                 var minInput = chaisePage.recordsetPage.getRangeMinInput(idx, testParams.minInputClass),
                                 minClear = chaisePage.recordsetPage.getInputClear(idx, testParams.minInputClearClass);
-                                
+
                                 // test just min being set
                                 minInput.sendKeys(facetParams.justMin.min);
-                                
+
                                 // let validation message disappear
                                 browser.sleep(20);
-                                
+
                                 chaisePage.recordsetPage.getRangeSubmit(idx).click().then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.justMin.filter, "filter name is incorrect for '" + facetParams.name + "' facet with just min value");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.justMin.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.justMin.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet with just min value");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
-                                    
+
                                     return minClear.click();
                                 });
                             });
-                            
+
                             it("should filter on just a max value and update the search criteria.", function () {
                                 var maxInput = chaisePage.recordsetPage.getRangeMaxInput(idx, testParams.maxInputClass),
                                 maxClear = chaisePage.recordsetPage.getInputClear(idx, testParams.maxInputClearClass);
-                                
+
                                 // test just max being set
                                 maxInput.sendKeys(facetParams.justMax.max);
-                                
+
                                 // let validation message disappear
                                 browser.sleep(20);
-                                
+
                                 chaisePage.recordsetPage.getRangeSubmit(idx).click().then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.justMax.filter, "filter name is incorrect for '" + facetParams.name + "' facet with just min value");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.justMax.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.justMax.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet with just min value");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
@@ -780,12 +780,12 @@ describe("Viewing Recordset with Faceting,", function() {
                                 });
                             });
                         });
-    
+
                     } else if (facetParams.type == "timestamp") {
                         describe("for range facet: " + facetParams.name + ",", function () {
                             var minDateInput, minTimeInput, maxDateInput, maxTimeInput,
                                 minDateClear, minTimeClear, maxDateClear, maxTimeClear;
-    
+
                             beforeAll(function () {
                                 // inputs
                                 minDateInput = chaisePage.recordsetPage.getRangeMinInput(idx, testParams.tsMinDateInputClass);
@@ -798,7 +798,7 @@ describe("Viewing Recordset with Faceting,", function() {
                                 maxDateClear = chaisePage.recordsetPage.getInputClear(idx, testParams.tsMaxDateInputClearClass);
                                 maxTimeClear = chaisePage.recordsetPage.getInputClear(idx, testParams.tsMaxTimeInputClearClass);
                             });
-    
+
                             it("should open the facet, test validators, filter on a range, and update the search criteria.", function () {
                                 browser.wait(function () {
                                     return chaisePage.recordsetPage.getClosedFacets().count().then(function(ct) {
@@ -811,11 +811,11 @@ describe("Viewing Recordset with Faceting,", function() {
                                     // wait for facet to open
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getRangeSubmit(idx)), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getFacetOptions(idx).count();
                                 }).then(function (ct) {
                                     expect(ct).toBe(facetParams.listElems, "There are more list elements for '" + facetParams.name + "' facet than expected");
-                                    
+
                                     // test validators
                                     minDateInput.sendKeys(facetParams.invalid.date);
                                     browser.wait(function () {
@@ -823,29 +823,29 @@ describe("Viewing Recordset with Faceting,", function() {
                                             return text == facetParams.invalid.date;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getValidationError(idx)), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getValidationError(idx).getText();
                                 }).then(function (text) {
                                     expect(text).toBe(facetParams.invalid.dateError, "The date validation message did not show up or is incorrect");
-                                    
+
                                     return minDateClear.click();
                                 }).then(function () {
                                     minTimeInput.sendKeys(facetParams.invalid.time);
-                                    
+
                                     browser.wait(function () {
                                         return minTimeInput.getAttribute("value").then(function (text) {
                                             return text == facetParams.invalid.time;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getValidationError(idx)), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getValidationError(idx).getText();
                                 }).then(function (text) {
                                     expect(text).toBe(facetParams.invalid.timeError, "The time validation message did not show up or is incorrect");
-                                    
+
                                     return minTimeClear.click();
                                 }).then(function() {
                                     // test min and max being set
@@ -854,42 +854,42 @@ describe("Viewing Recordset with Faceting,", function() {
                                     minTimeInput.sendKeys(facetParams.range.minTime);
                                     maxDateInput.sendKeys(facetParams.range.maxDate);
                                     maxTimeInput.sendKeys(facetParams.range.maxTime);
-                                    
+
                                     // let validation message disappear
                                     browser.sleep(20);
-                                    
+
                                     // get submit button
                                     return chaisePage.recordsetPage.getRangeSubmit(idx).click();
                                 }).then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getFilters().count();
                                 }).then(function (ct) {
                                     expect(ct).toBe(1, "number of filters is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.range.filter, "filter name is inccorect for '" + facetParams.name + "' facet");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.range.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.range.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
-                                    
+
                                     //clear the inputs
                                     return minDateClear.click();
                                 }).then(function () {
@@ -900,84 +900,84 @@ describe("Viewing Recordset with Faceting,", function() {
                                     return maxTimeClear.click();
                                 })
                             });
-                            
+
                             it("should filter on just a min value and update the search criteria.", function () {
                                 // test just min being set
                                 minDateInput.sendKeys(facetParams.justMin.date);
                                 minTimeInput.sendKeys(facetParams.justMin.time);
-                                
+
                                 //let validation dissappear
                                 browser.sleep(20);
-                                
+
                                 // get submit button
                                 chaisePage.recordsetPage.getRangeSubmit(idx).click().then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.justMin.filter, "filter name is inccorect for '" + facetParams.name + "' facet");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.justMin.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.justMin.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
-                                    
+
                                     //clear the min inputs
                                     return minDateClear.click();
                                 }).then(function () {
                                     return minTimeClear.click();
                                 })
                             });
-                            
+
                             it("should filter on just a max value and update the search criteria.", function () {
                                 // test just max being set
                                 maxDateInput.sendKeys(facetParams.justMax.date);
                                 maxTimeInput.sendKeys(facetParams.justMax.time);
-                                
+
                                 //let validation dissappear
                                 browser.sleep(20);
-                                
+
                                 // get submit button
                                 chaisePage.recordsetPage.getRangeSubmit(idx).click().then(function () {
                                     // wait for request to return
                                     browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                                    
+
                                     //should only be one
                                     return chaisePage.recordsetPage.getFilters();
                                 }).then(function (filters) {
                                     return filters[0].getText();
                                 }).then(function(text) {
                                     expect(text).toBe(facetParams.justMax.filter, "filter name is inccorect for '" + facetParams.name + "' facet");
-                                    
+
                                     // wait for table rows to load
                                     browser.wait(function () {
                                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                             return ct == facetParams.justMax.numRows;
                                         });
                                     }, browser.params.defaultTimeout);
-                                    
+
                                     return chaisePage.recordsetPage.getRows().count();
                                 }).then(function(ct) {
                                     expect(ct).toBe(facetParams.justMax.numRows, "number of rows is incorrect for '" + facetParams.name + "' facet");
-                                    
+
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
-                                    
+
                                     // close the facet
                                     return chaisePage.recordsetPage.getFacetById(idx).click();
                                 }).catch(function (exc) {
@@ -989,10 +989,10 @@ describe("Viewing Recordset with Faceting,", function() {
                 })(testParams.facets[j], j);
             }
         });
-        
+
         // tests selecting an option for a facet, verifying the filters shown and rows displayed, then moving to the next one while preserving the previous selection
         describe("selecting facet options and verifying row after each selection", function () {
-            
+
             beforeEach(function () {
                 browser.wait(function () {
                     return chaisePage.recordsetPage.getClosedFacets().count().then(function(ct) {
@@ -1000,47 +1000,47 @@ describe("Viewing Recordset with Faceting,", function() {
                     });
                 }, browser.params.defaultTimeout);
             });
-            
+
             for (var i=0; i<testParams.multipleFacets.length; i++) {
                 // anon function to capture looping variable
                 (function(facetParams, idx) {
                     it("for facet at index: " + facetParams.facetIdx + ", it should open the facet, select a value to filter on, and update the search criteria.", function () {
                         var clearAll = chaisePage.recordsetPage.getClearAllFilters();
-                        
+
                         chaisePage.recordsetPage.getFacetById(facetParams.facetIdx).click().then(function () {
                             // wait for facet to open
                             browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(facetParams.facetIdx)), browser.params.defaultTimeout);
-                            
+
                             // wait for facet checkboxes to load
                             browser.wait(function () {
                                 return chaisePage.recordsetPage.getFacetOptions(facetParams.facetIdx).count().then(function(ct) {
                                     return ct == facetParams.numOptions;
                                 });
                             }, browser.params.defaultTimeout);
-                            
+
                             // wait for list to be fully visible
                             browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getList(facetParams.facetIdx)), browser.params.defaultTimeout);
-                            
+
                             return chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(facetParams.facetIdx, facetParams.option));
                         }).then(function () {
                             // wait for request to return
                             browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
-                            
+
                             return chaisePage.recordsetPage.getFilters().count();
                         }).then(function (ct) {
                             expect(ct).toBe(idx+1, "number of filters is incorrect for facet at index: " + facetParams.facetIdx + " facet");
-                            
+
                             // wait for table rows to load
                             browser.wait(function () {
                                 return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                                     return ct == facetParams.numRows;
                                 });
                             }, browser.params.defaultTimeout);
-                            
+
                             return chaisePage.recordsetPage.getRows().count();
                         }).then(function(ct) {
                             expect(ct).toBe(facetParams.numRows, "number of rows is incorrect for facet at index: " + facetParams.facetIdx + " facet");
-                            
+
                             return chaisePage.recordsetPage.getFacetById(facetParams.facetIdx).click();
                         }).catch(function (exc) {
                             console.dir(exc);
@@ -1048,23 +1048,23 @@ describe("Viewing Recordset with Faceting,", function() {
                     });
                 })(testParams.multipleFacets[i], i);
             }
-        
+
             afterAll(function () {
                 chaisePage.recordsetPage.getClearAllFilters().click();
             });
         });
-    
+
         describe("selecting facet options in sequence and verifying the data after all selections.", function () {
             beforeAll(function () {
                 browser.wait(EC.not(EC.visibilityOf(chaisePage.recordsetPage.getClearAllFilters())), browser.params.defaultTimeout);
-    
+
                 browser.wait(function () {
                     return chaisePage.recordsetPage.getClosedFacets().count().then(function(ct) {
                         return ct == testParams.totalNumFacets;
                     });
                 }, browser.params.defaultTimeout);
             });
-    
+
             it("should open facets, click an option in each, and verify the data after", function () {
                 // open the four facets
                 chaisePage.recordsetPage.getFacetById(testParams.multipleFacets[3].facetIdx).click().then(function () {
@@ -1079,7 +1079,7 @@ describe("Viewing Recordset with Faceting,", function() {
                             return ct == testParams.totalNumFacets-4;
                         });
                     }, browser.params.defaultTimeout);
-    
+
                     return chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(testParams.multipleFacets[0].facetIdx, testParams.multipleFacets[0].option));
                 }).then(function () {
                     return chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(testParams.multipleFacets[1].facetIdx, testParams.multipleFacets[1].option));
@@ -1090,18 +1090,18 @@ describe("Viewing Recordset with Faceting,", function() {
                 }).then(function () {
                     // wait for request to return
                     browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getClearAllFilters()), browser.params.defaultTimeout);
-    
+
                     return chaisePage.recordsetPage.getFilters().count();
                 }).then(function (ct) {
                     expect(ct).toBe(4, "Number of filters is incorrect after making 4 selections");
-    
+
                     // wait for table rows to load
                     browser.wait(function () {
                         return chaisePage.recordsetPage.getRows().count().then(function(ct) {
                             return ct == testParams.multipleFacets[3].numRows;
                         });
                     }, browser.params.defaultTimeout);
-                    
+
                     return chaisePage.recordsetPage.getRows().count();
                 }).then(function(ct) {
                     expect(ct).toBe(testParams.multipleFacets[3].numRows, "number of rows is incorrect after making multiple consecutive selections");

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -245,8 +245,20 @@ var testParams = {
         jsonb_col: JSON.stringify({"key":"one"},undefined,2),
         faceting_main_fk1: "one",
         faceting_main_fk2: "one"
+    },
+    not_null: {
+        option: 0,
+        result_num_w_not_null: 20,
+        modal_available_options: 20,
+        disabled_rows_w_not_null: 9,
+        options_w_not_null: [
+            'All Records With Value', '1', '2', '3', '4', '5', '6', '7', '8', '9'
+        ],
+        options_wo_not_null: [
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'
+        ]
     }
-}
+};
 
 describe("Viewing Recordset with Faceting,", function() {
 
@@ -1108,6 +1120,146 @@ describe("Viewing Recordset with Faceting,", function() {
                 });
             });
         });
+
+        describe("Records With Value (not-null) filter, ", function () {
+            var notNullBtn, showMore;
+
+            beforeAll(function () {
+                var uri = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schema_name + ":" + testParams.table_name;
+
+                browser.ignoreSynchronization=true;
+                browser.get(uri);
+                chaisePage.waitForElementInverse(element(by.id("spinner")));
+
+                clearAll = chaisePage.recordsetPage.getClearAllFilters();
+                showMore = chaisePage.recordsetPage.getShowMore(testParams.not_null.option);
+            });
+
+            it ("`All Records With Value` option must be available in modal picker.", function (done) {
+                browser.wait(EC.elementToBeClickable(showMore));
+                showMore.click().then(function () {
+                    chaisePage.waitForElementInverse(element(by.id("spinner")));
+                    notNullBtn = chaisePage.recordsetPage.getModalMatchNotNullInput();
+                    expect(notNullBtn.isPresent()).toEqual(true);
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+
+            });
+
+            it ("Selecting `All Records With Value` should disable all the rows.", function (done) {
+                notNullBtn.click().then(function () {
+                    browser.wait(function () {
+                        return chaisePage.recordsetPage.getModalDisabledRows().count().then(function (ct) {
+                            return (ct > 0);
+                        });
+                    });
+                    expect(chaisePage.recordsetPage.getModalDisabledRows().count()).toBe(testParams.not_null.modal_available_options, "number of disabled rows missmatch.");
+                    expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(0, "number of checked rows missmatch.");
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("After submitting the filters, `All Records With Value` should be on top of the list with the rest of options being disabled", function (done) {
+                chaisePage.recordsetPage.getModalSubmit().click().then(function () {
+                    chaisePage.waitForElementInverse(chaisePage.recordsetPage.getFacetSpinner(testParams.not_null.option));
+                    browser.wait(function () {
+                        return chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count().then(function(ct) {
+                            return ct == 1;
+                        });
+                    }, browser.params.defaultTimeout);
+
+                    return chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count();
+                }).then(function (count) {
+                    expect(count).toBe(1, "number of selected filters missmatch.");
+
+                    return chaisePage.recordsetPage.getFacetOptionsText(testParams.not_null.option);
+                }).then(function (text) {
+                    expect(text).toEqual(testParams.not_null.options_w_not_null, "the text of selected faacet missmatch.");
+                    expect(chaisePage.recordsetPage.getDisabledFacetOptions(testParams.not_null.option).count()).toBe(testParams.not_null.disabled_rows_w_not_null, "numer of disabled filters missmatch.");
+                    expect(chaisePage.recordsetPage.getRows().count()).toBe(testParams.not_null.result_num_w_not_null, "number of results missmatch.");
+
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("Deselecting `All Records With Value` should enable all the values on the list.", function (done) {
+                chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(testParams.not_null.option, 0)).then(function () {
+                    return chaisePage.recordsetPage.getFacetOptionsText(testParams.not_null.option);
+                }).then(function (text) {
+                    // make sure the options havn't changed
+                    expect(text).toEqual(testParams.not_null.options_w_not_null, "the text of selected faacet missmatch.");
+
+                    expect(chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count()).toBe(0, "number of selected filters missmatch.");
+                    expect(chaisePage.recordsetPage.getDisabledFacetOptions(testParams.not_null.option).count()).toBe(0, "numer of disabled filters missmatch.");
+
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("should be able to select other filters on the facet.", function (done) {
+                chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(testParams.not_null.option, 1)).then(function () {
+                    return chaisePage.recordsetPage.getFacetOptionsText(testParams.not_null.option);
+                }).then(function (text) {
+                    // make sure the options havn't changed
+                    expect(text).toEqual(testParams.not_null.options_w_not_null, "the text of selected faacet missmatch.");
+
+                    expect(chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count()).toBe(1, "Number of selected filters missmatch.");
+                    expect(chaisePage.recordsetPage.getDisabledFacetOptions(testParams.not_null.option).count()).toBe(0, "numer of disabled filters missmatch.");
+
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("Selecting `All Records With Value` in the list, should remove all the checked filters on facet.", function (done) {
+                chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(testParams.not_null.option, 0)).then(function () {
+                    return chaisePage.recordsetPage.getFacetOptionsText(testParams.not_null.option);
+                }).then(function (text) {
+                    // make sure the options haven't changed
+                    expect(text).toEqual(testParams.not_null.options_w_not_null, "the text of selected faacet missmatch.");
+
+                    expect(chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count()).toBe(1, "number of selected filters missmatch.");
+                    expect(chaisePage.recordsetPage.getDisabledFacetOptions(testParams.not_null.option).count()).toBe(testParams.not_null.disabled_rows_w_not_null, "numer of disabled filters missmatch.");
+
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("going to modal picker with `All Records With Value`, the checkmark for `All Records With Value` must be checked.", function (done) {
+                browser.wait(EC.elementToBeClickable(showMore));
+                showMore.click().then(function () {
+                    chaisePage.waitForElementInverse(element(by.id("spinner")));
+                    notNullBtn = chaisePage.recordsetPage.getModalMatchNotNullInput();
+                    expect(notNullBtn.isPresent()).toBeTruthy("not-null is not present");
+                    expect(notNullBtn.isSelected()).toBeTruthy("not-null not checked.");
+                    expect(chaisePage.recordsetPage.getModalDisabledRows().count()).toBe(testParams.not_null.modal_available_options, "number of disabled rows missmatch.");
+                    expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(0, "number of checked rows missmatch.");
+
+                    // NOTE after this test case the modal is still open, the next test cases should just start a new url.
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+        });
     });
 
     describe("For table " + testParams.table_name + ",", function() {
@@ -1148,4 +1300,5 @@ describe("Viewing Recordset with Faceting,", function() {
             });
         });
     });
+
 });

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -1158,6 +1158,8 @@ describe("Viewing Recordset with Faceting,", function() {
                     });
                     expect(chaisePage.recordsetPage.getModalDisabledRows().count()).toBe(testParams.not_null.modal_available_options, "number of disabled rows missmatch.");
                     expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(0, "number of checked rows missmatch.");
+                    return chaisePage.recordsetPage.getModalSubmit().click();
+                }).then(function () {
                     done();
                 }).catch(function (err) {
                     console.log(err);
@@ -1166,16 +1168,14 @@ describe("Viewing Recordset with Faceting,", function() {
             });
 
             it ("After submitting the filters, `All Records With Value` should be on top of the list with the rest of options being disabled", function (done) {
-                chaisePage.recordsetPage.getModalSubmit().click().then(function () {
-                    chaisePage.waitForElementInverse(chaisePage.recordsetPage.getFacetSpinner(testParams.not_null.option));
-                    browser.wait(function () {
-                        return chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count().then(function(ct) {
-                            return ct == 1;
-                        });
-                    }, browser.params.defaultTimeout);
+                chaisePage.waitForElementInverse(chaisePage.recordsetPage.getFacetSpinner(testParams.not_null.option));
+                browser.wait(function () {
+                    return chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count().then(function(ct) {
+                        return ct == 1;
+                    });
+                }, browser.params.defaultTimeout);
 
-                    return chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count();
-                }).then(function (count) {
+                chaisePage.recordsetPage.getCheckedFacetOptions(testParams.not_null.option).count().then(function (count) {
                     expect(count).toBe(1, "number of selected filters missmatch.");
 
                     return chaisePage.recordsetPage.getFacetOptionsText(testParams.not_null.option);
@@ -1265,15 +1265,19 @@ describe("Viewing Recordset with Faceting,", function() {
     describe("For table " + testParams.table_name + ",", function() {
 
         var uri = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schema_name + ":" + testParams.table_name;
+        var clearAll;
 
         beforeEach(function () {
             browser.ignoreSynchronization=true;
             browser.get(uri);
             chaisePage.waitForElementInverse(element(by.id("spinner")));
+
+            clearAll = chaisePage.recordsetPage.getClearAllFilters();
         });
 
         it("clicking edit should show the same number of forms as rows.", function () {
-            chaisePage.recordsetPage.getClearAllFilters().click().then(function () {
+            browser.wait(EC.elementToBeClickable(clearAll));
+            clearAll.click().then(function () {
                 return chaisePage.waitForElementInverse(element(by.id("spinner")));
             }).then(function () {
                 return chaisePage.recordsetPage.getEditRecordLink().click()
@@ -1287,7 +1291,9 @@ describe("Viewing Recordset with Faceting,", function() {
                 return chaisePage.recordEditPage.getForms().count();
             }).then(function(count) {
                 expect(count).toBe(25);
-            });
+            }).catch(function (err) {
+                console.log(err);
+            })
         });
 
         it("navigating to record with a facet url", function () {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -654,7 +654,7 @@ var recordPage = function() {
         displayName = safeId?displayName:makeSafeIdAttr(displayName);
         return element(by.id("entity-" + displayName)).element(by.css(".ng-scope")).element(by.css(".ng-scope"));
     };
-    
+
 
     this.getRelatedTableHeadings = function() {
         return element.all(by.css(".related-table-heading"));
@@ -709,7 +709,7 @@ var recordPage = function() {
 
     this.getNoResultsRow = function(displayName) {
         displayName = makeSafeIdAttr(displayName);
-        return element(by.id("rt-" + displayName)).element(by.id("no-results-row")); 
+        return element(by.id("rt-" + displayName)).element(by.id("no-results-row"));
     };
 
     this.getCreateRecordButton = function() {
@@ -755,11 +755,11 @@ var recordPage = function() {
     this.getErrorModalOkButton = function(){
         return browser.executeScript("return $('button')[1]");
     };
-    
+
     this.getModalDisabledRows = function () {
         return browser.executeScript("return $('.modal-body tr.disabled-row')");
     };
-    
+
     this.getSuccessAlert = function () {
         return element(by.css(".alert-success"));
     };
@@ -810,7 +810,7 @@ var recordsetPage = function() {
     this.getRows = function() {
         return element.all(by.css('.table-row'));
     };
-    
+
     this.getModalRows = function () {
         return element.all(by.css('.modal-body .table-row'));
     };
@@ -977,7 +977,7 @@ var recordsetPage = function() {
     }
 
     this.getCheckedModalOptions = function () {
-        return element(by.css(".modal-body")).all(by.css(".chaise-checkbox input[checked=checked]"));
+        return element(by.css(".modal-body .recordset-table")).all(by.css(".chaise-checkbox input[checked=checked]"));
     }
 
     this.getModalOptions = function () {
@@ -1008,6 +1008,22 @@ var recordsetPage = function() {
     this.getRangeSubmit = function (idx) {
         return element(by.id("fc-" + idx)).element(by.css("button[type=submit]"));
     }
+
+    this.getModalMatchNotNullInput = function () {
+        return element(by.id("rs-match-not-null"));
+    };
+
+    this.getModalDisabledRows = function () {
+        return element.all(by.css('.modal-body tr.disabled-row'));
+    };
+
+    this.getFacetSpinner= function (idx) {
+        return element(by.id("fc-" + idx)).element(by.css(".spinner"));
+    };
+
+    this.getDisabledFacetOptions = function (idx) {
+        return element(by.id("fc-" + idx)).all(by.css(".chaise-checkbox input[disabled=disabled]"));
+    };
 };
 
 // Makes a string safe and valid for use in an HTML element's id attribute.


### PR DESCRIPTION
This PR includes:

1. Adding "Records With Value" (not-null) option in the recordset selector for faceting. The logic for not-null filter is as follows:
   -  In modal: If you choose "Records With value" all the selected rows must be deselected and all the rows should be disabled. Users should be able to click on `clear all`, `x` besides the "Records With Value", and also the checkmark for "Records With Value" to remove the filter. After removing it, all the rows should become selectable.
   - In Facet panel: If you end up in the recordset with not-null filter, it should always show at the top of the list, and other options must be disabled. Deselecting it, should make all the other options enabled. If you select the not-null again, it should clear and disable all the other filters.

2. Extracting logic of recordset and table into the recordTable factory which then can be used in multiple places.

- ~~**Since I changed the structure of the recordset table, some of the test cases are failing. I created this PR so we can just review the change, and discuss if this approach of extending directive is acceptable or not.**~~**Test cases seem stable now.**

- **This PR needs e2e testing**.

*We need to merge the ermrestjs PR first.*

Related Issue: #1354 
