### PR TITLE
error test case changed due to ermrest changes

### DIFF
--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -3,7 +3,7 @@ var recordHelpers = require('../../../utils/record-helpers.js');
 var testParams = {
     table_name: "accommodation",
     schemaName:  "product-record",
-    deletionErrText : "This entry cannot be deleted as it is still referenced from the booking table. All dependent entries must be removed before this item can be deleted.\n\nClick OK to go to the Record Page Show Error Details",
+    deletionErrText : "This entry cannot be deleted as it is still referenced from the booking table. All dependent entries must be removed before this item can be deleted. If you have trouble removing dependencies please contact the site administrator.\n\nClick OK to go to the Record Page Show Error Details",
     uniqueConstraint : "Error The entry cannot be created/updated. Please use a different ID for this record."
 };
 


### PR DESCRIPTION
This PR adds just one phrase in the existing test case which was changed at `ermrest`. 
Text added in `test/e2e/specs/all-features-confirmation/errors/errors.spec.js`