### PR TITLE
Fix Facet Based on Secondary Key Bug

### DIFF
--- a/common/faceting.js
+++ b/common/faceting.js
@@ -669,6 +669,20 @@
             };
 
             /**
+             * Given tuple and the columnName that should be used, return
+             * the filter's uniqueId (in case of entityPicker, it might be different from the tuple's uniqueId)
+             * @param  {Object} tuple      the tuple object
+             * @param  {string} columnName name of column (in scalar it is 'value')
+             * @return {string}            filter's uniqueId
+             */
+            function getFilterUniqueId(tuple, columnName) {
+              if (tuple.data && columnName in tuple.data) {
+                  return tuple.data[columnName];
+              }
+              return tuple.uniqueId;
+            }
+
+            /**
              * Initialzie facet column.
              * This will take care of getting the displaynames of rows.
              * (If it's a entity picker, the displayname will be different than the value.).
@@ -693,7 +707,8 @@
                     filters.forEach(function (f) {
                         scope.facetModel.appliedFilters.push({
                             uniqueId: f.uniqueId,
-                            displayname: f.displayname
+                            displayname: f.displayname,
+                            tuple: f.tuple // this might be null
                         });
                     });
 
@@ -721,6 +736,7 @@
                         isNotNull: f.isNotNull,
                         uniqueId: f.uniqueId,
                         displayname: f.displayname,
+                        tuple: f.tuple, // might be null
                         selected: true
                     };
                 };
@@ -730,8 +746,11 @@
                 // facetColumn has changed so create the new reference
                 if (scope.facetColumn.isEntityMode) {
                     scope.reference = scope.facetColumn.sourceReference.contextualize.compactSelect;
+                    scope.columnName = scope.facetColumn.column.name;
                 } else {
                     scope.reference = scope.facetColumn.column.groupAggregate.entityCounts;
+                    // the first column will be the value column
+                    scope.columnName = scope.reference.columns[0].name;
                 }
 
                 // make sure to add the search term
@@ -767,15 +786,8 @@
                                 return;
                             }
 
-                            var value;
-                            if (scope.facetColumn.isEntityMode) {
-                                // the filter might not be on the shortest key,
-                                // therefore the uniqueId is not correct.
-                                value = tuple.data ? tuple.data[scope.facetColumn.column.name] : null;
-                            } else {
-                                // The name of column is value
-                                value = tuple.data ? tuple.data['value'] : null;
-                            }
+                            // filter and tuple uniqueId might be different
+                            var value = getFilterUniqueId(tuple, scope.columnName);
 
                             var i = scope.facetModel.appliedFilters.findIndex(function (row) {
                                 return row.uniqueId == value && !row.isNotNull;
@@ -788,10 +800,11 @@
 
                             // if we have a not_null filter, other filters must be disabled.
                             scope.checkboxRows.push({
-                                selected: false,
-                                disabled: scope.facetColumn.hasNotNullFilter,
-                                displayname: (value == null) ? {value: null, isHTML: false} : tuple.displayname,
                                 uniqueId: value,
+                                displayname: (value == null) ? {value: null, isHTML: false} : tuple.displayname,
+                                tuple:  tuple,
+                                disabled: scope.facetColumn.hasNotNullFilter,
+                                selected: false,
                             });
                         });
 
@@ -875,8 +888,27 @@
                             params.matchNotNull = true;
                         }
 
-                        params.selectedRows = scope.checkboxRows.filter(function (row) {
-                            return row.selected;
+                        params.selectedRows = [];
+
+                        // generate list of rows needed for modal
+                        scope.checkboxRows.forEach(function (row) {
+                            if (!row.selected) return;
+                            var newRow = {};
+
+                            // - row.uniqueId will return the filter's uniqueId and not
+                            //    the tuple's. We need tuple's uniqueId in here
+                            //    (it will be used in the logic of isSelected in modal).
+                            // - data is needed for the post process that we do on the data.
+                            if (row.tuple && scope.facetColumn.isEntityMode) {
+                                newRow.uniqueId = row.tuple.uniqueId;
+                                newRow.data =row.tuple.data;
+                            } else {
+                                newRow.uniqueId = row.uniqueId;
+                            }
+
+                            newRow.displayname = row.displayname;
+                            newRow.isNotNull = row.notNull;
+                            params.selectedRows.push(newRow);
                         });
 
                         if (!scope.facetColumn.isEntityMode) {
@@ -908,28 +940,22 @@
                             } else if (Array.isArray(res)){
                                 var tuples = res;
 
-                                // If the data was preselected, we won't have the data object attached
-                                // to the tuples. In case of entity picker we must always get the value from data.
-                                // NOTE This might be buggy.
-                                var getTupleValue = function (t) {
-                                    var col_name = scope.facetColumn.isEntityMode ? scope.facetColumn.column.name : "value";
-                                    if (t.data && col_name in t.data) {
-                                        return t.data[col_name];
-                                    } else {
-                                        return t.uniqueId;
-                                    }
-                                };
-
+                                // create the reference using filters
                                 ref = scope.facetColumn.replaceAllChoiceFilters(tuples.map(function (t) {
-                                    return getTupleValue(t);
+                                    return getFilterUniqueId(t, scope.columnName);
                                 }));
+
+                                // create the list of applied filters, this Will
+                                // be used for genreating the checkboxRows of current facet
                                 scope.facetModel.appliedFilters = tuples.map(function (t) {
-                                    var val = getTupleValue(t);
+                                    var val = getFilterUniqueId(t, scope.columnName);
+
                                     // NOTE displayname will always be string, but we want to treat null and empty string differently,
                                     // therefore we have a extra case for null, to just return null.
                                     return {
                                         uniqueId: val,
-                                        displayname: (val == null) ? {value: null, isHTML: false} : t.displayname
+                                        displayname: (val == null) ? {value: null, isHTML: false} : t.displayname,
+                                        tuple: t,
                                     };
                                 });
                             } else {
@@ -1004,7 +1030,8 @@
                             scope.facetModel.appliedFilters.push({
                                 selected: true,
                                 uniqueId: row.uniqueId,
-                                displayname: row.displayname
+                                displayname: row.displayname,
+                                tuple: row.tuple
                             });
                         } else {
                             scope.facetModel.appliedFilters = scope.facetModel.appliedFilters.filter(function (f) {
@@ -1089,6 +1116,5 @@
                     });
                 }
             };
-
         }]);
 })();

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -147,7 +147,8 @@
                             {"source": [{"outbound": ["faceting", "main_fk1"]}, "id"], "markdown_name": "**F1**"},
                             {"source": [{"outbound": ["faceting", "main_fk2"]}, "id"], "open": true},
                             {"source": [{"inbound": ["faceting", "main_f3_assoc_fk1"]}, {"outbound": ["faceting", "main_f3_assoc_fk2"]}, "term"]},
-                            {"source": [{"inbound": ["faceting", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "choices"}
+                            {"source": [{"inbound": ["faceting", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "choices"},
+                            {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term"}
                         ]
                     }
                 }
@@ -173,11 +174,12 @@
                 },
                 {
                     "name": "term",
+                    "nullok": false,
                     "type": {
                         "typename": "text"
                     }
                 }
-            ]    
+            ]
         },
         "f2": {
             "kind": "table",
@@ -191,7 +193,7 @@
             "foreign_keys": [],
             "column_definitions": [
                 {
-                    "name": "id", 
+                    "name": "id",
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -258,7 +260,7 @@
             ],
             "column_definitions": [
                 {
-                    "name": "id_main", 
+                    "name": "id_main",
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -284,7 +286,7 @@
             "foreign_keys": [],
             "column_definitions": [
                 {
-                    "name": "id", 
+                    "name": "id",
                     "nullok": false,
                     "type": {
                         "typename": "serial4"
@@ -333,7 +335,7 @@
             ],
             "column_definitions": [
                 {
-                    "name": "id", 
+                    "name": "id",
                     "nullok": false,
                     "type": {
                         "typename": "serial4"

--- a/test/e2e/specs/all-features/record/related-table-link.spec.js
+++ b/test/e2e/specs/all-features/record/related-table-link.spec.js
@@ -407,17 +407,12 @@ describe('View existing record,', function() {
                     expect(addRelatedRecordLink.getText()).toBe("Add", "The Add button is not displayed as Add");
 
                     addRelatedRecordLink.click().then(function(){
-                    }).then(function(){
-                        browser.wait(function () {
-                               return chaisePage.recordsetPage.getRows().count().then(function (ct) {
-                                   return (ct > 0);
-                               });
-                           });
-                        rows = chaisePage.recordsetPage.getRows();
-                    }).then(function(ct){
+                        chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
                         return browser.executeScript("return $('.modal-body tr input[type=checkbox]').get(2);");
                     }).then(function (selectButtons){
-                        selectButtons.click();
+                        return selectButtons.click();
+                    }).then(function () {
                         return browser.executeScript("return $('#multi-select-submit-btn').click();");
                     }).then(function () {
                         return browser.wait(EC.presenceOf(element(by.id('page-title'))), browser.params.defaultTimeout);

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -4,8 +4,8 @@ var EC = protractor.ExpectedConditions;
 var testParams = {
     schema_name: "faceting",
     table_name: "main",
-    totalNumFacets: 14,
-    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col", "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1", "to_name", "f3 (term)", "from_name" ],
+    totalNumFacets: 15,
+    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col", "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1", "to_name", "f3 (term)", "from_name", "F1 with Term" ],
     defaults: {
         openFacetNames: [ "id", "int_col", "to_name" ],
         numFilters: 2,
@@ -224,6 +224,15 @@ var testParams = {
             filter: "from_name: 5",
             numRows: 1,
             options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10' ]
+        },
+        {
+            name: "F1 with Term",
+            type: "choice",
+            totalNumOptions: 10,
+            option: 1,
+            filter: "F1 with Term : two",
+            numRows: 10,
+            options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
         }
     ],
     multipleFacets: [
@@ -245,6 +254,15 @@ var testParams = {
         jsonb_col: JSON.stringify({"key":"one"},undefined,2),
         faceting_main_fk1: "one",
         faceting_main_fk2: "one"
+    },
+    filter_secondary_key: {
+        facetIdx: 14,
+        option: 0,
+        modalOption: 1,
+        totalNumOptions: 10,
+        numRows: 10,
+        numRowsAfterModal: 20
+
     },
     not_null: {
         option: 0,
@@ -1119,6 +1137,103 @@ describe("Viewing Recordset with Faceting,", function() {
                     expect(ct).toBe(testParams.multipleFacets[3].numRows, "number of rows is incorrect after making multiple consecutive selections");
                 });
             });
+        });
+
+        describe("selecting entity facet that is not on the shortest key.", function () {
+            var facet, idx, clearAll;
+            beforeAll(function (done) {
+                var uri = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schema_name + ":" + testParams.table_name;
+
+                browser.ignoreSynchronization=true;
+                browser.get(uri);
+                chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
+                clearAll = chaisePage.recordsetPage.getClearAllFilters();
+
+                idx = testParams.filter_secondary_key.facetIdx;
+                facet = chaisePage.recordsetPage.getFacetById(idx);
+
+                done();
+            });
+
+            it ("should open the facet, select a value to filter on.", function (done) {
+                clearAll.click().then(function () {
+                    return chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+                }).then(function () {
+                  return facet.click();
+                }).then(function () {
+                    // wait for facet to open
+                    browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
+
+                    // wait for facet checkboxes to load
+                    browser.wait(function () {
+                        return chaisePage.recordsetPage.getFacetOptions(idx).count().then(function(ct) {
+                            return ct == testParams.filter_secondary_key.totalNumOptions;
+                        });
+                    }, browser.params.defaultTimeout);
+
+                    // wait for list to be fully visible
+                    browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getList(idx)), browser.params.defaultTimeout);
+
+                    return chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(idx, testParams.filter_secondary_key.option));
+                }).then(function () {
+                    // wait for request to return
+                    browser.wait(EC.visibilityOf(clearAll), browser.params.defaultTimeout);
+
+                    chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
+                    return chaisePage.recordsetPage.getRows().count();
+                }).then(function (ct) {
+                    expect(ct).toBe(testParams.filter_secondary_key.numRows, "number of rows is incorrect");
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+
+            });
+
+            it ("the selected value should be selected on the modal.", function (done) {
+                var showMore = chaisePage.recordsetPage.getShowMore(idx);
+                browser.wait(EC.elementToBeClickable(showMore));
+                showMore.click().then(function () {
+                    chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
+                    expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(1, "number of checked rows missmatch.");
+                    return chaisePage.recordsetPage.getModalOptions();
+                }).then(function (options) {
+                    expect(options[testParams.filter_secondary_key.option+1].isSelected()).toBeTruthy("the correct option was not selected.");
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
+            it ("selecting new values on the modal and submitting them, should change the filters on submit.", function (done) {
+                chaisePage.recordsetPage.getModalOptions().then(function (options) {
+                    return chaisePage.clickButton(options[testParams.filter_secondary_key.modalOption+1]);
+                }).then(function () {
+                    return chaisePage.recordsetPage.getModalSubmit().click();
+                }).then(function () {
+                    chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
+                    return chaisePage.recordsetPage.getCheckedFacetOptions(idx).count();
+                }).then (function (cnt) {
+                    expect(cnt).toBe(2, "Number of facet options is incorrect after returning from modal");
+
+                    return chaisePage.recordsetPage.getRows().count();
+                }).then(function (ct) {
+                    expect(ct).toBe(testParams.filter_secondary_key.numRowsAfterModal, "Number of visible rows after selecting a second option from the modal is incorrect");
+                    return chaisePage.recordsetPage.getClearAllFilters().click();
+                }).then(function () {
+                    done();
+                }).catch(function (err) {
+                    console.log(err);
+                    done.fail();
+                });
+            });
+
         });
 
         describe("Records With Value (not-null) filter, ", function () {


### PR DESCRIPTION
The assumption in the previous implementation was that the `tuple.uniqueId` and `filter.uniqueId` are the same, but that might not be the case. If the facet definition is not based on the shortestkey these two will be different values. I changed the choicePicker implementation to  store the whole tuple object, so we can extract the `tuple.uniqueId` which is needed for modal picker (it's used in the logic for `isSelected`).
I also added a test case to the faceting spec for this one, and fixed the condition of one of the test cases that was failing locally for me.