### PR TITLE
TOC header and Main link on the top

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -99,10 +99,13 @@
             </div>
 
             <div class="faceting-container" style="height: 100%;" >
-                <h2 class="sidePanelHeading">Related Records</h2>
+                <h2 class="sidePanelHeading">Contents</h2>
                 <div class="columns-container">
                     <ul>
+                      <li id="main-to-top" style="padding:5px" ng-click="scrollToTop()">
+                        <a uib-tooltip="Main" tooltip-placement="bottom" chaise-enable-tooltip-width>Main</a> </li>
                         <div ng-repeat="relatedRef in relatedReferences track by $index"  id="recordSidePan-{{$index}}" ng-if="ctrl.showRelatedTable($index)" class="{{lastActiveFacet == $index ? 'focused': ''}}" ng-click="ctrl.gotoRelatedTable(relatedRef.displayname.value, $index)">
+
                             <li  id="recordSidePan-heading-{{$index}}" style="padding:5px">
                                 <a uib-tooltip="{{relatedRef.displayname.value}}" tooltip-placement="bottom" chaise-enable-tooltip-width>
                                     <span ng-if="::relatedRef.displayname.isHTML" ng-bind-html="::relatedRef.displayname.value"></span>

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -62,10 +62,10 @@ var testParams = {
       schemaName: "product-record",
       tableName: "accommodation_collection",
       id: "2003",
-      tocCount: 7,
+      tocCount: 8,
       tableToShow: 'Categories_5',
-      sidePanelTableOrder:[ 'Categories_collection\n (5)',  'media\n \n (1)', 'Categories_collection_2\n (5)',  'Categories_3\n (5)',  'Categories_4\n (5)',  'Categories_5\n (5)',  'Categories_6\n (5)'],
-      panelHeading: "Related Records"
+      sidePanelTableOrder:[ 'Main', 'Categories_collection\n (5)',  'media\n \n (1)', 'Categories_collection_2\n (5)',  'Categories_3\n (5)',  'Categories_4\n (5)',  'Categories_5\n (5)',  'Categories_6\n (5)'],
+      panelHeading: "Contents"
     }
 };
 
@@ -200,6 +200,19 @@ describe('View existing record,', function() {
                 console.log(err);
                 done.fail();
             });
+        });
+        //Main Button
+        it('after clicking Main button, page should move up', function(done){
+            var mainButton = element(by.id('main-to-top')),
+                topOfPage = element(by.id('row-id'));
+
+            mainButton.click().then(function(){
+              expect(topOfPage.getLocation()).toEqual(jasmine.objectContaining({x: 30}, "Main button did not scroll up the page"));
+              done();
+           }).catch( function(err) {
+              console.log(err);
+              done.fail();
+          });
         });
 
         it('Record count along with heading should match for the panel and related table content should be in correct order', function(done){

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -201,19 +201,6 @@ describe('View existing record,', function() {
                 done.fail();
             });
         });
-        //Main Button
-        it('after clicking Main button, page should move up', function(done){
-            var mainButton = element(by.id('main-to-top')),
-                topOfPage = element(by.id('row-id'));
-
-            mainButton.click().then(function(){
-              expect(topOfPage.getLocation()).toEqual(jasmine.objectContaining({x: 30}, "Main button did not scroll up the page"));
-              done();
-           }).catch( function(err) {
-              console.log(err);
-              done.fail();
-          });
-        });
 
         it('Record count along with heading should match for the panel and related table content should be in correct order', function(done){
             chaisePage.recordPage.getSidePanelTableTitles().then(function(tableNames){


### PR DESCRIPTION
This PR addresses #1449 
Added **Main** link on the top of the list and renamed the header to **Contents**.
Test case is in [`presentation.spec.js`](https://github.com/informatics-isi-edu/chaise/compare/tocHeader?expand=1#diff-0c4175e21d5fe1dffc2ed1275f8a5798)