### PR TITLE
scroll on recordedit resultset view

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -215,6 +215,7 @@
                     };
                 }
                 vm.resultset = true;
+                UiUtils.setDisplayHeight(fetchElements(1));
         }
     }
 
@@ -573,7 +574,8 @@
 
         // fetches the height of navbar, bookmark container, and view
         // also fetches the faceting container for defining the dynamic height
-        function fetchElements() {
+        // There are 2 main containers on `recordedit` app
+        function fetchElements(mainContainerIndex) {
             var elements = {};
             try {
                 // get document height
@@ -584,7 +586,7 @@
                 // TODO: if bookmark bar added
                 elements.bookmarkHeight = 0;
                 // get recordset main container
-                elements.container = $document[0].getElementsByClassName('main-container')[0];
+                elements.container = $document[0].getElementsByClassName('main-container')[mainContainerIndex];
             } catch(error) {
                 $log.warn(error);
             }
@@ -595,7 +597,11 @@
             return $rootScope.displayReady;
         }, function (newValue, oldValue) {
             if (newValue) {
-                var elements = fetchElements();
+                var idx = 0;
+                if (vm.resultset) {
+                    idx = 1;
+                }
+                var elements = fetchElements(idx);
                 // if the navbarHeight is not set yet, don't set the height
                 // no bookmark container here
                 if(elements.navbarHeight) {
@@ -618,7 +624,11 @@
 
         angular.element($window).bind('resize', function(){
             if ($rootScope.displayReady) {
-                var elements = fetchElements();
+                var idx = 0;
+                if (vm.resultset) {
+                    idx = 1;
+                }
+                var elements = fetchElements(idx);
                 // if the navbarHeight is not set yet, don't set the height
                 // no bookmark container here
                 if(elements.navbarHeight) {

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -54,12 +54,10 @@
                                 </div>
                                 <div class="row padding-right-15" ng-show="::!form.editMode">
                                     <div class="btn-group pull-right">
-                                        <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button"
-                                            ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
+                                        <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
                                             <span class="glyphicon glyphicon-plus"></span>
                                         </button>
-                                        <button id="copy-x-rows-btn" class="btn btn-primary btn-inverted center-block" ng-click="::(form.showMultiInsert = !form.showMultiInsert)" type="button"
-                                            ng-disabled="!form.canAddMore" tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
+                                        <button id="copy-x-rows-btn" class="btn btn-primary btn-inverted center-block" ng-click="::(form.showMultiInsert = !form.showMultiInsert)" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
                                             <span class="glyphicon glyphicon-chevron-down"></span>
                                         </button>
                                     </div>
@@ -69,8 +67,7 @@
                                         <div class="input-group">
                                             <input id="copy-rows-input" type="number" class="form-control " ng-model="form.numberRowsToAdd">
                                             <span class="input-group-btn">
-                                                <button id="copy-rows-submit" class="btn btn-sm btn-primary btn-inverted center-block" ng-click="::form.copyFormRow()" type="button"
-                                                    tooltip-placement="bottom" uib-tooltip="Submit">
+                                                <button id="copy-rows-submit" class="btn btn-sm btn-primary btn-inverted center-block" ng-click="::form.copyFormRow()" type="button" tooltip-placement="bottom" uib-tooltip="Submit">
                                                     <span class="glyphicon glyphicon-ok"></span>
                                                 </button>
                                             </span>
@@ -81,7 +78,7 @@
                                     <div ng-show="displayReady" class="col-xs-12" id="formEditScroll" ng-class="{'editMode': form.editMode, 'createMode': !form.editMode}" ng-style="form.formEditDivMarginLeft">
                                         <div ng-style="form.tableWidth"></div>
                                     </div>
-                                    <div ng-show="displayReady" class="col-xs-12" id="formEdit" ng-class="{'editMode': form.editMode, 'createMode': !form.editMode}" ng-style="form.formEditDivMarginLeft">
+                                    <div ng-show="displayReady" class="col-xs-12" id="formEdit" ng-class="{'editMode': form.editMode, 'createMode': !form.editMode}" ng-style="form.formEditDivMarginLeft"><!-- no match -->
                                         <table ng-form="form.formContainer" class="table">
                                             <tr>
                                                 <td ng-style="form.firstHeaderStyle">Record Number</td>
@@ -107,12 +104,10 @@
                                                     <!-- date input-->
                                                     <div ng-switch-when="date">
                                                         <div ng-show="form.isDisabled(column);" >
-                                                            <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}"
-                                                                placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">
+                                                            <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}"></input>
                                                         </div>
                                                         <div ng-show="!form.isDisabled(column);" class="input-group">
-                                                            <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name]" placeholder="{{form.dataFormats.date}}" name="{{::column.name}}"
-                                                                ui-mask="9999-19-39" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date>
+                                                            <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name]" placeholder="{{form.dataFormats.date}}" name="{{::column.name}}" ui-mask="9999-19-39" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date></input>
                                                             <span class="input-group-btn">
                                                                 <button type="button" class="btn btn-primary btn-inverted" ng-click="::form.applyCurrentDatetime(rowIndex, column.name, column.type.name);" ng-disabled="::form.isDisabled(column);">Today</button>
                                                                 <button type="button" class="btn btn-danger btn-inverted" ng-click="::form.clearModel(rowIndex, column.name, column.type.name);" ng-disabled="::form.isDisabled(column);">Clear</button>
@@ -122,21 +117,18 @@
 
                                                     <!-- timestamp[tz] input -->
                                                     <div ng-switch-when="timestamp">
-                                                        <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{column.name}}"
-                                                            ng-show="form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}">
+                                                        <input id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" type="text" ng-disabled="::form.isDisabled(column);" class="form-control" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{column.name}}" ng-show="form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}"></input>
                                                         <div class="row" ng-show="::!form.isDisabled(column);">
                                                             <div class="col-xs-12">
                                                                 <div class="input-group">
                                                                     <span class="input-group-addon">Date</span>
-                                                                    <input class="form-control input-timestamptz" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].date" placeholder="{{form.dataFormats.date}}" name="{{::column.name}}"
-                                                                        ui-mask="9999-99-99" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]">
+                                                                    <input class="form-control input-timestamptz" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].date" placeholder="{{form.dataFormats.date}}" name="{{::column.name}}" ui-mask="9999-99-99" ui-options="form.maskOptions.date" model-view-value="true" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" date timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]"></input>
                                                                 </div>
                                                             </div>
                                                             <div class="col-xs-12">
                                                                 <div class="input-group">
                                                                     <span class="input-group-addon">Time</span>
-                                                                    <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].time" placeholder="{{form.dataFormats.time24}}" name="{{::column.name}}"
-                                                                         model-view-value="true" ng-disabled="::form.isDisabled(column);" time timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]">
+                                                                    <input class="form-control" type="text" ng-model="form.recordEditModel.rows[rowIndex][column.name].time" placeholder="{{form.dataFormats.time24}}" name="{{::column.name}}" model-view-value="true" ng-disabled="::form.isDisabled(column);" time timestamp validate-values="form.recordEditModel.rows[rowIndex][column.name]"></input>
                                                                     <span class="input-group-btn">
                                                                         <button class="btn btn-primary btn-inverted" name="{{::column.name}}" type="button" ng-click="::form.toggleMeridiem(rowIndex, column.name);" ng-bind="form.recordEditModel.rows[rowIndex][column.name].meridiem || 'AM'" ng-disabled="::form.isDisabled(column);">AM</button>
                                                                     </span>
@@ -154,8 +146,7 @@
                                                     <!-- modal popup input -->
                                                     <div ng-switch-when="popup-select" class="form-group has-feedback input-group modal-popup">
                                                         <label class="sr-only"></label>
-                                                        <div id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-display" contenteditable="false" ng-disabled="::form.isDisabled(column);" class="form-control popup-select-value" ng-style="form.isDisabled(column) ? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="::form.searchPopup(rowIndex, column)"
-                                                            ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
+                                                        <div id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-display" contenteditable="false" ng-disabled="::form.isDisabled(column);" class="form-control popup-select-value" ng-style="form.isDisabled(column) ? {'cursor': 'default'} : {'cursor': 'pointer'}" ng-click="::form.searchPopup(rowIndex, column)" ng-bind-html="(form.recordEditModel.rows[rowIndex][column.name] ? form.recordEditModel.rows[rowIndex][column.name] : form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]))"></div>
                                                         <div class="form-control-feedback coltooltip" ng-hide="(form.isDisabled(column)) || (!form.recordEditModel.rows[rowIndex][column.name])" ng-style="{'cursor': 'pointer', 'right': '40px', 'pointer-events': 'all'}">
                                                             <span class="glyphicon glyphicon-remove coltooltiptext foreignkey-remove" ng-click="::form.clearForeignKey(rowIndex, column)" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
                                                         </div>
@@ -172,8 +163,7 @@
                                                     </div>
 
                                                     <!-- int2 input -->
-                                                    <input ng-switch-when="integer2" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]"
-                                                        name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int2min}}" max="{{::form.int2max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
+                                                    <input ng-switch-when="integer2" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int2min}}" max="{{::form.int2max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
                                                         <div ng-messages="form.formContainer.row[rowIndex][column.name].$error" ng-show="form.formContainer.row[rowIndex][column.name].$dirty  || form.formContainer.$submitted" class="text-danger" role="alert" ng-if="::column.type.name == 'int2'">
                                                             <div ng-message="min">This field requires a value greater than {{form.int2min}}.</div>
                                                             <div ng-message="max">This field requires a value smaller than {{form.int2max}}.</div>
@@ -181,8 +171,7 @@
                                                     </input>
 
                                                     <!-- int4 input -->
-                                                    <input ng-switch-when="integer4" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]"
-                                                        name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int4min}}" max="{{::form.int4max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
+                                                    <input ng-switch-when="integer4" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int4min}}" max="{{::form.int4max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
                                                         <div ng-messages="form.formContainer.row[rowIndex][column.name].$error" ng-show="form.formContainer.row[rowIndex][column.name].$dirty  || form.formContainer.$submitted" class="text-danger" role="alert" ng-if="::column.type.name == 'int4'">
                                                             <div ng-message="min">This field requires a value greater than {{form.int4min}}.</div>
                                                             <div ng-message="max">This field requires a value smaller than {{form.int4max}}.</div>
@@ -190,8 +179,7 @@
                                                     </input>
 
                                                     <!-- int8 input -->
-                                                    <input ng-switch-when="integer8" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]"
-                                                        name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int8min}}" max="{{::form.int8max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
+                                                    <input ng-switch-when="integer8" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" min="{{::form.int8min}}" max="{{::form.int8max}}" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" integer>
                                                         <div ng-messages="form.formContainer.row[rowIndex][column.name].$error" ng-show="form.formContainer.row[rowIndex][column.name].$dirty || form.formContainer.$submitted" class="text-danger" role="alert" ng-if="::column.type.name == 'int8'">
                                                             <div ng-message="min">This field requires a value greater than {{form.int8min}}.</div>
                                                             <div ng-message="max">This field requires a value smaller than {{form.int8max}}.</div>
@@ -199,8 +187,7 @@
                                                     </input>
 
                                                     <!-- float/decimal/numeric -->
-                                                    <input ng-switch-when="number" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]"
-                                                        name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" float>
+                                                    <input ng-switch-when="number" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="number" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" float></input>
 
 
                                                     <!-- boolean input -->
@@ -215,28 +202,23 @@
 
                                                     <!-- longtext/textarea input -->
                                                     <div ng-switch-when="longtext">
-                                                        <textarea id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" rows="5"
-                                                            name="{{::column.name}}" class="form-control content-box" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" empty-to-null markdown-editor="{'iconlibrary': 'glyph', addExtraButtons:true ,fullscreen:{ enable: false, icons: {}}, resize: 'vertical'}"></textarea>
-                                                            <a href id="previewLinkId-form-{{rowIndex}}-{{::column.name}}" class="live-preview"  markdown-preview textinput="form.recordEditModel.rows[rowIndex][column.name]"></a>
+                                                        <textarea id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" rows="5" name="{{::column.name}}" class="form-control content-box" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" empty-to-null markdown-editor="{'iconlibrary': 'glyph', addExtraButtons:true ,fullscreen:{ enable: false, icons: {}}, resize: 'vertical'}"></textarea>
+                                                        <a href id="previewLinkId-form-{{rowIndex}}-{{::column.name}}" class="live-preview"  markdown-preview textinput="form.recordEditModel.rows[rowIndex][column.name]"></a>
                                                     </div>
 
 
                                                     <!-- File input -->
                                                     <div ng-switch-when="file">
-                                                        <upload id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" reference="::reference"  column="::column"
-                                                                is-disabled="::form.isDisabled(column)" placeholder="form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name])"
-                                                                values="form.recordEditModel.rows[rowIndex]" value="form.recordEditModel.rows[rowIndex][column.name]"></upload>
+                                                        <upload id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" reference="::reference"  column="::column" is-disabled="::form.isDisabled(column)" placeholder="form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name])" values="form.recordEditModel.rows[rowIndex]" value="form.recordEditModel.rows[rowIndex][column.name]"></upload>
                                                     </div>
 
                                                     <!--JSON input -->
                                                     <div ng-switch-when="json">
-                                                        <textarea json id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" rows="5"
-                                                            name="{{::column.name}}" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);"  placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}"  empty-to-null></textarea>
+                                                        <textarea json id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" rows="5" name="{{::column.name}}" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);"  placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}"  empty-to-null></textarea>
                                                     </div>
 
                                                     <!-- shorttext/default text input -->
-                                                    <input ng-switch-default id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]"
-                                                        name="{{::column.name}}" type="text" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" empty-to-null>
+                                                    <input ng-switch-default id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="text" class="form-control" ng-required="::form.isRequired(column);" ng-disabled="::form.isDisabled(column);" placeholder="{{::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name]);}}" empty-to-null></input>
 
                                                     <!-- Validation error messages to show when the form field is touched -->
                                                     <div ng-messages="form.formContainer.row[rowIndex][column.name].$error" ng-show="form.formContainer.row[rowIndex][column.name].$dirty || form.formContainer.$submitted" class="text-danger" role="alert">
@@ -256,38 +238,35 @@
                                                 </td>
                                             </tr>
                                         </table>
-
                                     </div>
                                 </div>
                             </div>
                         </div>
-
                     </div>
-
                 </div>
-
                 <div ng-show="form.resultset" class="container-fluid">
-                    <h2 id="result-title">
-                        <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}</span>
-                        <a ng-href="{{::form.recordsetLink}}">
-                            <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
-                            <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
-                        </a>
-                        <span>Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
-                    </h2>
-                    <div class="side-padding-15">
-                        <h3>{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+                    <div class="main-container">
+                        <h2 id="result-title">
+                            <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}</span>
+                            <a ng-href="{{::form.recordsetLink}}">
+                                <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
+                                <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
+                            </a>
+                            <span>Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
+                        </h2>
+                        <div class="side-padding-15">
+                            <h3>{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
 
-                        <record-table vm="form.resultsetModel"></record-table>
+                            <record-table vm="form.resultsetModel"></record-table>
 
-                        <div ng-if="form.omittedResultsetModel">
-                            <h3>{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
+                            <div ng-if="form.omittedResultsetModel">
+                                <h3>{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
 
-                            <record-table vm="form.omittedResultsetModel" default-row-linking="true"></record-table>
+                                <record-table vm="form.omittedResultsetModel" default-row-linking="true"></record-table>
+                            </div>
                         </div>
                     </div>
                 </div>
-
             </div>
         </div>
 


### PR DESCRIPTION
This PR addresses issue #1435.

The issue was that the `main-container` was only part of the `recordedit` form input and not present when we saw the resultset.

Note: I changed the lines that some of the tags were placed on. We had tags that when too long, we put a return character so the code looked cleaner for editing. This made it really tough for the editor to help me with auto-indentation and verifying that the template was stable. If this is a continued issue, each developer can change their personal editor to have content wrap to the next line or not.