### PR TITLE
anonymous login popup only after a user has logged in

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -42,17 +42,19 @@
             return splits.join('/');
         };
 
-        /*
+        /**
          * Functions that interact with the StorageService tokens
-         *
          * There are 2 keys stored under the LOCAL_STORAGE_KEY object, PROMPT_EXPIRATION_KEY and PREVIOUS_SESSION_KEY
          */
+
+        // verifies value exists for `keyName`
         var _tokenExists = function(keyName) {
             var sessionStorage = StorageService.getStorage(LOCAL_STORAGE_KEY);
 
             return (sessionStorage && sessionStorage[keyName]);
         };
 
+        // creates an expiration token with `keyName`
         var _createToken = function (keyName) {
             var data = {};
             var hourFromNow = new Date();
@@ -63,24 +65,28 @@
             StorageService.updateStorage(LOCAL_STORAGE_KEY, data);
         };
 
+        // removes the key/value pair at `keyName`
         var _removeToken = function (keyName) {
             if (_tokenExists(keyName)) {
                 StorageService.deleteStorageValue(LOCAL_STORAGE_KEY, keyName);
             }
         };
 
+        // checks if the expiration token with `keyName` has expired
         var _expiredToken = function (keyName) {
             var sessionStorage = StorageService.getStorage(LOCAL_STORAGE_KEY);
 
             return (sessionStorage && new Date().getTime() > sessionStorage[keyName]);
         };
 
+        // extends the expiration token with `keyName` if it hasn't expired
         var _extendToken = function (keyName) {
             if (_tokenExists(keyName) && !_expiredToken(keyName)) {
                 _createToken(keyName);
             }
         };
 
+        // creates a boolean token with `keyName`
         var _createBool = function (keyName) {
             var data = {};
 

--- a/common/authen.js
+++ b/common/authen.js
@@ -335,6 +335,7 @@
                 url += '?logout_url=' + UriUtils.fixedEncodeURIComponent(logoutURL);
 
                 $http.delete(url).then(function(response) {
+                    StorageService.deleteStorageNamespace(LOCAL_STORAGE_KEY);
                     $window.location = response.data.logout_url;
                 }, function(error) {
                     // if the logout fails for some reason, send the user to the logout url as defined above

--- a/common/storage.js
+++ b/common/storage.js
@@ -7,12 +7,25 @@
         var localStorage = $window.localStorage;
 
         /**
-         * Deletes the data in local storage defined under `storageLocation`
+         * Deletes all the data in local storage defined under `storageLocation`
          *
          * @param {String} storageLocation - name of object data is stored under
          */
-        var deleteStorage = function (storageLocation) {
+        var deleteStorageNamespace = function (storageLocation) {
             localStorage.removeItem(storageLocation);
+        };
+
+        /**
+         * Deletes the data in local storage defined under `storageLocation` with `keyName`
+         *
+         * @param {String} storageLocation - name of object data is stored under
+         * @param {String} keyName - key name of the data to be deleted
+         */
+        var deleteStorageValue = function (storageLocation, keyName) {
+            var value = getStorage(storageLocation);
+
+            delete value[keyName];
+            setStorage(storageLocation, value);
         };
 
         /**
@@ -52,7 +65,8 @@
         };
 
         return {
-            deleteStorage: deleteStorage,
+            deleteStorageNamespace: deleteStorageNamespace,
+            deleteStorageValue: deleteStorageValue,
             getStorage: getStorage,
             setStorage: setStorage,
             updateStorage: updateStorage

--- a/common/utils.js
+++ b/common/utils.js
@@ -709,7 +709,7 @@
     .factory('FunctionUtils', ['Session', 'UriUtils', function(Session, UriUtils) {
         function registerErmrestCallbacks() {
             ERMrest.appLinkFn(UriUtils.appTagToURL);
-            ERMrest.onHTTPSuccess(Session.extendPromptExpiration);
+            ERMrest.onHTTPSuccess(Session.extendPromptExpirationToken);
         }
 
         return {


### PR DESCRIPTION
This PR addresses issue #1457. 

There are 2 values stored in the localStorage. 
```
localStorage.session = {
  previousSession: Boolean (always true if key is defined),
  promptExpiration: String (1 hour from when it is set/updated)
}
```

The prompt will only show if a user has logged into the system with that browser before. Once the user logs in, `previousSession` is set to true. Next time the user comes back to the system and they don't have a session, they will be prompted to login or to continue anonymously. If they choose to continue anonymously, an expiration token is set. 

If the user logs in again, this expiration token is deleted.
If the user explicitly logs out of the system, this whole object is removed 
(i.e.`delete localStorage.session`)