### PR TITLE
Facet panel collapse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,9 +507,10 @@ RECSET_JS_SOURCE=$(COMMON)/authen.js \
 RECSET_SHARED_CSS_DEPS=$(CSS)/vendor/bootstrap.min.css \
 	$(CSS)/material-design/css/material-design-iconic-font.min.css
 
-RECSET_CSS_SOURCE=$(COMMON)/styles/app.css \
-    $(COMMON)/styles/appheader.css \
-		$(COMMON)/vendor/MarkdownEditor/styles/github-markdown.css
+RECSET_CSS_SOURCE=$(RECSET_ASSETS)/app.css \
+	$(COMMON)/styles/app.css \
+	$(COMMON)/styles/appheader.css \
+	$(COMMON)/vendor/MarkdownEditor/styles/github-markdown.css
 
 # Config file
 JS_CONFIG=chaise-config.js

--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,7 @@ RECORD_ASSETS=record
 
 RECORD_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(JS)/vendor/angular.js \
+	$(JS)/vendor/angular-plotly.js \
 	$(JS)/vendor/angular-messages.min.js \
 	$(JS)/vendor/angular-sanitize.js \
 	$(COMMON)/vendor/angular-cookies.min.js \
@@ -341,6 +342,7 @@ RECORD_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(COMMON)/authen.js \
 	$(COMMON)/delete-link.js \
 	$(COMMON)/errors.js \
+	$(COMMON)/faceting.js \
 	$(COMMON)/filters.js \
 	$(COMMON)/modal.js \
 	$(COMMON)/navbar.js \

--- a/Makefile
+++ b/Makefile
@@ -509,8 +509,7 @@ RECSET_JS_SOURCE=$(COMMON)/authen.js \
 RECSET_SHARED_CSS_DEPS=$(CSS)/vendor/bootstrap.min.css \
 	$(CSS)/material-design/css/material-design-iconic-font.min.css
 
-RECSET_CSS_SOURCE=$(RECSET_ASSETS)/app.css \
-	$(COMMON)/styles/app.css \
+RECSET_CSS_SOURCE=$(COMMON)/styles/app.css \
 	$(COMMON)/styles/appheader.css \
 	$(COMMON)/vendor/MarkdownEditor/styles/github-markdown.css
 

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1174,5 +1174,9 @@
                     });
                 }
             };
-        }]);
+        }])
+
+        .directive('facetingCollapse', function () {
+            
+        });
 })();

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1176,7 +1176,36 @@
             };
         }])
 
-        .directive('facetingCollapse', function () {
-            
+        .directive('facetingCollapseBtn', function () {
+            return {
+                restrict: 'E',
+                templateUrl: '../common/templates/faceting/collapse-btn.html',
+                scope: {
+                    togglePanel: "=",       // function for toggling the panel open/closed
+                    tooltipMessage: "@",    // tooltip message
+                    panelOpen: "=",         // boolean value to control the panel being open/closed
+                    position: "@"           // can be 'left' or 'right'
+                },
+                link: function (scope, element, attr, ctrls) {
+                    var LEFT = "left",
+                        RIGHT = "right";
+
+                    if (scope.position == LEFT) {
+                        scope.tooltipPosition = RIGHT;
+                    }
+
+                    if (scope.position == RIGHT) {
+                        scope.tooltipPosition = LEFT;
+                    }
+
+                    scope.setClass = function () {
+                        if (scope.position == LEFT) {
+                            return {'glyphicon glyphicon-triangle-left': scope.panelOpen, 'glyphicon glyphicon-triangle-right': !scope.panelOpen}
+                        } else if (scope.position == RIGHT) {
+                            return {'glyphicon glyphicon-triangle-right': scope.panelOpen, 'glyphicon glyphicon-triangle-left': !scope.panelOpen}
+                        }
+                    }
+                }
+            }
         });
 })();

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -1115,6 +1115,12 @@ footer .container1 {
      margin-top: 5px;
  }
 
+/******* faceting resizeable *******/
+
+ .faceting-resizable.close-panel .rg-left, .faceting-resizable.close-panel .rg-right {
+   display: none;
+ }
+
  .recordset-container.with-faceting > .faceting-resizable {
      flex:0 0 20vw;
      position: relative;
@@ -1133,6 +1139,23 @@ footer .container1 {
  .recordset-container.with-faceting > .faceting-resizable.initializing > .rg-right > span{
     display: none;
  }
+
+ .sidePanFiddler, #back-to-top {
+     cursor: pointer;
+     overflow: hidden;
+     z-index: 50;
+     font-size: 25px;
+     padding: 1px 0 1px 5px;
+     border-radius: 2px 0 0px 2px;
+     height: 35px;
+     width: 35px;
+ }
+
+ .sidePanFiddler {
+     top: 5px;
+ }
+
+ /****** RSwF main container *******/
 
  .recordset-container.with-faceting > .main-container {
      flex:1;

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -1155,6 +1155,10 @@ footer .container1 {
      top: 5px;
  }
 
+ .recordset-container .sidePanFiddler {
+     margin-bottom: 10px;
+ }
+
  /****** RSwF main container *******/
 
  .recordset-container.with-faceting > .main-container {

--- a/common/table.js
+++ b/common/table.js
@@ -1010,6 +1010,7 @@
                 scope.vm.dirtyResult = false;
                 scope.vm.occupiedSlots = 0;
                 scope.vm.facetsToInitialize = [];
+                scope.vm.facetPanelOpen = true;
 
                 scope.setPageLimit = function(limit) {
                     scope.vm.pageLimit = limit;
@@ -1136,6 +1137,10 @@
                 scope.removeAllPills = function() {
                     scope.vm.selectedRows.clear();
                     scope.vm.currentPageSelected = false;
+                };
+
+                scope.togglePanel = function () {
+                    scope.vm.facetPanelOpen = !scope.vm.facetPanelOpen;
                 };
 
                 // on window focus, if has pending add record requests

--- a/common/templates/faceting/collapse-btn.html
+++ b/common/templates/faceting/collapse-btn.html
@@ -1,0 +1,3 @@
+<div class="sidePanFiddler btn btn-primary btn-inverted" ng-class="{'open-panel': panelOpen, 'close-panel': !panelOpen}" ng-click="togglePanel()">
+    <i ng-class="setClass()" uib-tooltip="{{tooltipMessage}}" tooltip-placement="{{tooltipPosition}}"></i>
+</div>

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -1,7 +1,7 @@
-<div class="recordset-container" ng-class="vm.config.showFaceting ? 'row with-faceting':'without-faceting'">
+<div class="recordset-container" ng-class="vm.config.showFaceting ? 'row with-faceting':'without-faceting'" >
     <div ng-bind="whatever"></div>
     <loading-spinner ng-show="(!vm.initialized || $root.showSpinner) && !$root.error"></loading-spinner>
-    <div class="faceting-resizable" resizable r-directions=["right"] r-flex="true" ng-if="vm.config.showFaceting" ng-class="{'initializing': !vm.initialized}">
+    <div class="faceting-resizable" resizable r-directions=["right"] r-flex="true" ng-if="vm.config.showFaceting" ng-hide="!vm.facetPanelOpen" ng-class="{'open-panel': vm.facetPanelOpen, 'close-panel': !vm.facetPanelOpen, 'initializing': !vm.initialized}">
         <faceting vm="vm"></faceting>
     </div>
     <div class="main-container">
@@ -10,6 +10,11 @@
 
             <div style="margin-left: 15px;margin-right: 20px;">
                 <alerts alerts="$root.alerts"></alerts>
+            </div>
+
+            <div class="sidePanFiddler btn btn-primary btn-inverted" ng-class="{'open-panel': vm.facetPanelOpen, 'close-panel': !vm.facetPanelOpen}" ng-if="vm.config.showFaceting" ng-click="togglePanel()">
+                <i ng-class="{'glyphicon glyphicon-triangle-left': vm.facetPanelOpen, 'glyphicon glyphicon-triangle-right': !vm.facetPanelOpen}"
+                   uib-tooltip="{{'Click to ' + ((vm.facetPanelOpen) ? 'hide' : 'show') + ' list of available facets.'}}" tooltip-placement="right"></i>
             </div>
 
             <div ng-if="vm.selectedRows.length > 0 && vm.config.selectMode == 'multi-select' && !vm.config.hideSelectedRows" class="row total-filters">

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -12,10 +12,7 @@
                 <alerts alerts="$root.alerts"></alerts>
             </div>
 
-            <div class="sidePanFiddler btn btn-primary btn-inverted" ng-class="{'open-panel': vm.facetPanelOpen, 'close-panel': !vm.facetPanelOpen}" ng-if="vm.config.showFaceting" ng-click="togglePanel()">
-                <i ng-class="{'glyphicon glyphicon-triangle-left': vm.facetPanelOpen, 'glyphicon glyphicon-triangle-right': !vm.facetPanelOpen}"
-                   uib-tooltip="{{'Click to ' + ((vm.facetPanelOpen) ? 'hide' : 'show') + ' list of available facets.'}}" tooltip-placement="right"></i>
-            </div>
+            <faceting-collapse-btn panel-open="vm.facetPanelOpen" toggle-panel="togglePanel" position="left" tooltip-message="{{'Click to ' + ((vm.facetPanelOpen) ? 'hide' : 'show') + ' list of available facets.'}}" ng-hide="!vm.config.showFaceting"></faceting-collapse-btn>
 
             <div ng-if="vm.selectedRows.length > 0 && vm.config.selectMode == 'multi-select' && !vm.config.hideSelectedRows" class="row total-filters">
                 <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -52,11 +52,16 @@
         <div class="main-container" ng-class="{'initializing': !displayReady}">
             <alerts alerts="ctrl.alerts"></alerts>
 
+            <div class="sidePanFiddler btn btn-primary btn-inverted" ng-hide="ctrl.noVisibleRelatedTables()" ng-class="{'open-panel': recordSidePanOpen, 'close-panel': !recordSidePanOpen}" ng-click="ctrl.togglePan()">
+                <i ng-class="{'glyphicon glyphicon-triangle-right': recordSidePanOpen, 'glyphicon glyphicon-triangle-left': !recordSidePanOpen}"
+                   uib-tooltip="{{'Click to ' + ((recordSidePanOpen) ? 'hide' : 'show') + ' list of related records.'}}" tooltip-placement="left"></i>
+            </div>
+
             <!-- defined on $rootScope in run function -->
-                <record-display columns="::columns" values="::recordValues"  record-table-model="::colTableModels" related-reference-display-table="::rtrefDisTypetable"
-                toggle-related-table-display-type='ctrl.toggleRelatedTableDisplayType(dataModel)' can-edit-related="::ctrl.canEditRelated(ref)" can-create-related="::ctrl.canCreateRelated(ref)"
-                add-related-record="ctrl.addRelatedRecord(ref)" to-record-set="ctrl.toRecordSet(ref)" show-empty-related-tables="showEmptyRelatedTables">
-                </record-display>
+            <record-display columns="::columns" values="::recordValues"  record-table-model="::colTableModels" related-reference-display-table="::rtrefDisTypetable"
+            toggle-related-table-display-type='ctrl.toggleRelatedTableDisplayType(dataModel)' can-edit-related="::ctrl.canEditRelated(ref)" can-create-related="::ctrl.canCreateRelated(ref)"
+            add-related-record="ctrl.addRelatedRecord(ref)" to-record-set="ctrl.toRecordSet(ref)" show-empty-related-tables="showEmptyRelatedTables">
+            </record-display>
 
             <!-- used to delay empty accordions from displaying before simple record display -->
             <div ng-if="displayReady">
@@ -88,14 +93,9 @@
             <span id="rt-loading" ng-show="loading">Loading...</span>
         </div>
 
-        <div class="faceting-resizable record-toc" resizable r-directions=["left"] r-flex="true" id="record-side-pan" ng-show="!ctrl.noVisibleRleatedTables()" ng-class="{'open-panel': recordSidePanOpen, 'close-panel': !recordSidePanOpen}">
+        <div class="faceting-resizable record-toc" resizable r-directions=["left"] r-flex="true" id="record-side-pan" ng-hide="ctrl.hidePanel()" ng-class="{'open-panel': recordSidePanOpen, 'close-panel': !recordSidePanOpen}">
             <div class="btn btn-primary btn-inverted" id="back-to-top" ng-click="scrollToTop()" ng-show="showTopBtn">
                 <i uib-tooltip="Scroll To Top" tooltip-placement="left" class="glyphicon glyphicon-triangle-top"></i>
-            </div>
-
-            <div class="sidePanFiddler btn btn-primary btn-inverted" ng-class="{'open-panel': recordSidePanOpen, 'close-panel': !recordSidePanOpen}" ng-click="ctrl.togglePan()">
-                <i ng-class="{'glyphicon glyphicon-triangle-right': recordSidePanOpen, 'glyphicon glyphicon-triangle-left': !recordSidePanOpen}"
-                   uib-tooltip="{{'Click to ' + ((recordSidePanOpen) ? 'hide' : 'show') + ' list of related records.'}}" tooltip-placement="left"></i>
             </div>
 
             <div class="faceting-container" style="height: 100%;" >

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -52,10 +52,7 @@
         <div class="main-container" ng-class="{'initializing': !displayReady}">
             <alerts alerts="ctrl.alerts"></alerts>
 
-            <div class="sidePanFiddler btn btn-primary btn-inverted" ng-hide="ctrl.noVisibleRelatedTables()" ng-class="{'open-panel': recordSidePanOpen, 'close-panel': !recordSidePanOpen}" ng-click="ctrl.togglePan()">
-                <i ng-class="{'glyphicon glyphicon-triangle-right': recordSidePanOpen, 'glyphicon glyphicon-triangle-left': !recordSidePanOpen}"
-                   uib-tooltip="{{'Click to ' + ((recordSidePanOpen) ? 'hide' : 'show') + ' list of related records.'}}" tooltip-placement="left"></i>
-            </div>
+            <faceting-collapse-btn panel-open="recordSidePanOpen" toggle-panel="ctrl.togglePan" position="right" tooltip-message="{{'Click to ' + ((recordSidePanOpen) ? 'hide' : 'show') + ' list of related records.'}}" ng-hide="ctrl.noVisibleRelatedTables()"></faceting-collapse-btn>
 
             <!-- defined on $rootScope in run function -->
             <record-display columns="::columns" values="::recordValues"  record-table-model="::colTableModels" related-reference-display-table="::rtrefDisTypetable"

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -9,6 +9,7 @@
         'chaise.alerts',
         'chaise.delete',
         'chaise.errors',
+        'chaise.faceting',
         'chaise.modal',
         'chaise.navbar',
         'chaise.record.display',

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -131,7 +131,7 @@
             }
         };
 
-        vm.noVisibleRleatedTables = function () {
+        vm.noVisibleRelatedTables = function () {
             if ($rootScope.tableModels) {
                 return !$rootScope.tableModels.some(function (tm, index) {
                     return vm.showRelatedTable(index);
@@ -139,6 +139,10 @@
             }
             return true;
         };
+
+        vm.hidePanel = function () {
+            return vm.noVisibleRelatedTables() || !$scope.recordSidePanOpen;
+        }
 
         vm.toggleRelatedTableDisplayType = function(dataModel) {
             if (dataModel.displayType == 'markdown') {

--- a/record/record.css
+++ b/record/record.css
@@ -138,39 +138,17 @@
   padding-left: 10px;
 }
 
-.sidePanFiddler, #back-to-top {
-    cursor: pointer;
-    overflow: hidden;
-    z-index: 50;
-    font-size: 25px;
-    padding: 1px 0 1px 5px;
-    border-radius: 2px 0 0px 2px;
-    height: 35px;
-    width: 35px;
-}
-
 .sidePanFiddler{
     position: absolute;
-    left: -51px;
-    top: 5px;
+    right: 10px;
 }
 
 #record-side-pan {
-  width: 0;
-  max-width: 0;
-}
-
-#record-side-pan.close-panel .rg-left, #record-side-pan.close-panel .rg-right {
-  display: none;
-}
-
-#record-side-pan.open-panel {
   margin-left: 15px;
   min-width: 170px;
   max-width: 50vw;
   flex:0 0 15vw;
 }
-
 
 #record-side-pan.close-panel .sidePanFiddler {
     padding: 1px 4px 0 0px;

--- a/recordset/app.css
+++ b/recordset/app.css
@@ -1,3 +1,1 @@
-.sidePanFiddler{
-    margin-bottom: 10px;
-}
+

--- a/recordset/app.css
+++ b/recordset/app.css
@@ -1,0 +1,3 @@
+.sidePanFiddler{
+    margin-bottom: 10px;
+}

--- a/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
@@ -73,6 +73,26 @@ describe("Other facet features, ", function() {
             done();
         });
 
+        it('Side panel should hide/show by clicking pull button', function(done){
+            var recPan =  chaisePage.recordPage.getSidePanel(),
+                fiddlerBtn = chaisePage.recordPage.getSidePanelFiddler();
+
+            expect(fiddlerBtn.getAttribute("class")).toContain('glyphicon glyphicon-triangle-left', 'Side Pan Pull button is not pointing in the left direction');
+            expect(recPan.getAttribute("class")).toContain('open-panel', 'Side Panel is not visible when fiddler is poining in left direction');
+
+            fiddlerBtn.click().then(function(){
+                expect(fiddlerBtn.getAttribute("class")).toContain("glyphicon glyphicon-triangle-right", "Side Pan Pull button is not pointing in the right direction.");
+                expect(recPan.getAttribute("class")).toContain('close-panel', 'Side Panel is not hidden when fiddler is poining in right direction');
+
+                return fiddlerBtn.click();
+            }).then(function () {
+                done();
+            }).catch( function(err) {
+                console.log(err);
+                done.fail();
+            });
+        });
+
         it ("should open the facet, select a value to filter on.", function (done) {
             clearAll.click().then(function () {
                 return chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -789,7 +789,7 @@ var recordPage = function() {
     }
 
     this.getSidePanel = function() {
-      return element(by.id('record-side-pan'));
+      return element(by.css('.faceting-resizable'));
     }
 
     this.getSidePanelItemById = function (idx) {


### PR DESCRIPTION
This PR resolves issue #1288.

The facet panel can be opened and closed when in the `recordset` with faceting. This uses the same functionality as the Table of Contents in `record` app. I refactored the functionality in record app so that it would be consistent in both places.