### PR TITLE
Anonymous login alert

### DIFF
--- a/common/alerts.js
+++ b/common/alerts.js
@@ -7,25 +7,27 @@
         var alerts = [];
         var ALERT_TYPES = ['success', 'error', 'warning'];
 
-        function Alert(message, type) {
+        function Alert(message, type, cb) {
             DataUtils.verify(message, 'Message required to create an alert.');
             if (type === undefined || ALERT_TYPES.indexOf(type) === -1) {
                 type = 'error';
             }
             this.message = message;
             this.type = type;
+            this.callback = cb;
         }
 
-        function addAlert(message, type) {
+        function addAlert(message, type, closeCallback) {
             DataUtils.verify(message, 'Message required to create an alert.');
-            var alert = new Alert(message, type);
+            var alert = new Alert(message, type, closeCallback);
             alerts.push(alert);
             return alert;
         }
 
         function deleteAlert(alert) {
             var index = alerts.indexOf(alert);
-            DataUtils.verify((index > -1), 'Alert not found.')
+            DataUtils.verify((index > -1), 'Alert not found.');
+            if (alert.callback) alert.callback();
             return alerts.splice(index, 1);
         }
 
@@ -36,7 +38,7 @@
         };
     }])
 
-    .directive('alerts', ['AlertsService', function(AlertsService) {
+    .directive('alerts', ['AlertsService', 'Session', function(AlertsService, Session) {
 
         return {
             restrict: 'E',
@@ -47,6 +49,10 @@
             link: function (scope, elem, attr) {
                 scope.closeAlert = function(alert) {
                     AlertsService.deleteAlert(alert);
+                };
+
+                scope.login = function() {
+                    Session.loginInAPopUp();
                 };
             }
         };

--- a/common/alerts.js
+++ b/common/alerts.js
@@ -51,6 +51,9 @@
                     AlertsService.deleteAlert(alert);
                 };
 
+                /****** Functions used within alert messages *******/
+                // defined here to allow for any callback to be used with the alert messages
+                // passing along the named functions and attaching them to the alert scope may be over-engineering, so this will suffice for now
                 scope.login = function() {
                     Session.loginInAPopUp();
                 };

--- a/common/authen.js
+++ b/common/authen.js
@@ -9,8 +9,8 @@
         var serviceURL = $window.location.origin;
 
         var LOCAL_STORAGE_KEY = 'session';              // name of object session information is stored under
-        var PROMPT_EXPIRATION_KEY = 'promptExpiration'  // name of key for prompt expiration value
-        var PREVIOUS_SESSION_KEY = 'previousSession'    // name of key for previous session boolean
+        var PROMPT_EXPIRATION_KEY = 'promptExpiration'; // name of key for prompt expiration value
+        var PREVIOUS_SESSION_KEY = 'previousSession';   // name of key for previous session boolean
 
         // Private variable to store current session object
         var _session = null;
@@ -277,45 +277,10 @@
                 return _session;
             },
 
-            promptUserPreviousSession: function() {
-                var defer = $q.defer();
-                // if there's a previous login token AND
-                // the prompt expiration token does not exist OR it has expired
-                if(!_session) {
-                    if (_tokenExists(PREVIOUS_SESSION_KEY) && (!_tokenExists(PROMPT_EXPIRATION_KEY) || _expiredToken(PROMPT_EXPIRATION_KEY))) {
-                        var params = {
-                            title: messageMap.sessionExpired.title,
-                            message: messageMap.sessionExpired.message,
-                            subMessage: messageMap.previousSession.message
-                        }
-
-                        var modalProperties = {
-                            windowClass: "modal-login-instruction",
-                            templateUrl: "../common/templates/loginDialog.modal.html",
-                            controller: 'LoginDialogController',
-                            controllerAs: 'ctrl',
-                            resolve: {
-                                params: params
-                            },
-                            openedClass: 'previous-login'
-                        }
-
-                        modalUtils.showModal(modalProperties, function () {
-                            // success callback
-                        }, function () {
-                            // error callback
-                            // set prompt expiration
-                            _createToken(PROMPT_EXPIRATION_KEY);
-                            defer.resolve();
-                        });
-                    } else {
-                        defer.resolve();
-                    }
-                } else {
-                    defer.resolve();
-                }
-
-                return defer.promise;
+            // if there's a previous login token AND
+            // the prompt expiration token does not exist OR it has expired
+            showPreviousSessionAlert: function() {
+                return (_tokenExists(PREVIOUS_SESSION_KEY) && (!_tokenExists(PROMPT_EXPIRATION_KEY) || _expiredToken(PROMPT_EXPIRATION_KEY)));
             },
 
             subscribeOnChange: function(fn) {
@@ -330,6 +295,10 @@
 
             unsubscribeOnChange: function(id) {
                 delete _changeCbs[id];
+            },
+
+            createPromptExpirationToken: function() {
+                _createToken(PROMPT_EXPIRATION_KEY);
             },
 
             extendPromptExpirationToken: function() {

--- a/common/templates/alerts.html
+++ b/common/templates/alerts.html
@@ -1,4 +1,4 @@
-<div ng-repeat="alert in alerts" class="row">
+<div ng-repeat="alert in alerts">
     <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
         <button type="button" class="close" ng-click="closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>{{alert.type | toTitleCase}}</strong> <span ng-bind-html="alert.message"></span>

--- a/common/templates/alerts.html
+++ b/common/templates/alerts.html
@@ -1,6 +1,6 @@
 <div ng-repeat="alert in alerts" class="row">
     <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
         <button type="button" class="close" ng-click="closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <strong>{{alert.type | toTitleCase}}</strong> {{alert.message}}
+        <strong>{{alert.type | toTitleCase}}</strong> <span ng-bind-html="alert.message"></span>
     </div>
 </div>

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -2,6 +2,11 @@
     <loading-spinner ng-show="((!vm.hasLoaded && !vm.backgroundSearch) || showSpinner) && !error"></loading-spinner>
     <div class="main-container">
         <div ng-show="vm.initialized" class="row" style="margin-bottom: 10px;">
+
+            <div style="margin-left:15px; margin-right:20px;">
+                <alerts alerts="$root.alerts"></alerts>
+            </div>
+
             <div ng-if="vm.config.selectMode == 'multi-select' && !vm.config.hideSelectedRows" class="row total-filters selected-rows">
                 <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                     <a class="remove-link" ng-click="removeAllPills()" ng-disabled="vm.selectedRows.length < 1">

--- a/common/templates/recordsetWithFaceting.html
+++ b/common/templates/recordsetWithFaceting.html
@@ -7,9 +7,7 @@
         <loading-spinner id="main-spinner" ng-show="!vm.hasLoaded && vm.initialized"></loading-spinner>
         <div style="margin-bottom: 10px;" ng-show="vm.initialized">
 
-            <div style="margin-left: 15px;margin-right: 20px;">
-                <alerts alerts="$root.alerts"></alerts>
-            </div>
+            <alerts alerts="$root.alerts"></alerts>
 
             <faceting-collapse-btn panel-open="$root.facetPanelOpen" toggle-panel="togglePanel" position="left" tooltip-message="{{'Click to ' + (($root.facetPanelOpen) ? 'hide' : 'show') + ' list of available facets.'}}" ng-hide="!$root.showFaceting || !vm.showFaceting"></faceting-collapse-btn>
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -48,7 +48,7 @@
             message: "To open the login window press"
         },
         "previousSession": {
-            message: "To access the site anonymously with limited access, click"
+            message: "A previous session was detected, you may want to <a ng-click='login'>Login</a>."
         },
         "noSession": {
             title: "You need to be logged in to continue.",

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -46,8 +46,8 @@
         $logProvider.debugEnabled(chaiseConfig.debug === true);
     }])
 
-    .run(['constants', 'DataUtils', 'ERMrest', 'ErrorService', 'FunctionUtils', 'headInjector', 'logActions', 'MathUtils', 'modalBox', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', 'Errors',
-        function runApp(constants, DataUtils, ERMrest, ErrorService, FunctionUtils, headInjector, logActions, MathUtils, modalBox, Session, UiUtils, UriUtils, $log, $rootScope, $window, Errors) {
+    .run(['AlertsService', 'constants', 'DataUtils', 'ERMrest', 'ErrorService', 'FunctionUtils', 'headInjector', 'logActions', 'MathUtils', 'messageMap', 'modalBox', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', 'Errors',
+        function runApp(AlertsService, constants, DataUtils, ERMrest, ErrorService, FunctionUtils, headInjector, logActions, MathUtils, messageMap, modalBox, Session, UiUtils, UriUtils, $log, $rootScope, $window, Errors) {
 
         var session,
             context = {},
@@ -144,15 +144,14 @@
             // Unsubscribe onchange event to avoid this function getting called again
             Session.unsubscribeOnChange(subId);
 
-            Session.promptUserPreviousSession().then(function () {
-                return ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name });
-            }).then(function getReference(reference) {
+            ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
                 context.filter = reference.location.filter;
                 context.facets = reference.location.facets;
 
                 DataUtils.verify((context.filter || context.facets), 'No filter or facet was defined. Cannot find a record without a filter or facet.');
 
                 session = Session.getSessionValue();
+                if (!session && Session.showPreviousSessionAlert()) AlertsService.addAlert(messageMap.previousSession.message, 'warning', Session.createPromptExpirationToken);
 
                 // $rootScope.reference != reference after contextualization
                 $rootScope.reference = reference.contextualize.detailed;

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -30,14 +30,10 @@
                     <div class="col-xs-12">
                         <div class="row main-container">
                             <!-- Alerts section -->
-                            <div ng-repeat="alert in form.alerts" class="row">
-                                <div class="col-xs-12">
-                                    <div class="alert alert-dismissible" ng-class="{'alert-danger': alert.type == 'error', 'alert-success': alert.type == 'success', 'alert-warning': alert.type == 'warning'}" role="alert">
-                                        <button type="button" class="close" ng-click="::form.closeAlert(alert);" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                                        <strong>{{alert.type | toTitleCase}}</strong> <span ng-bind-html="alert.message"></span>
-                                    </div>
-                                </div>
+                            <div style="margin-left:15px; margin-right:20px;">
+                                <alerts alerts="form.alerts"></alerts>
                             </div>
+
                             <!-- Form section -->
                             <div class="col-xs-12">
                                 <div class="row">

--- a/recordset/recordset.js
+++ b/recordset/recordset.js
@@ -83,7 +83,7 @@
     })
 
     // Register the recordset controller
-    .controller('recordsetController', ['context', 'DataUtils', 'ErrorService', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$document', '$log', '$rootScope', '$scope', '$window', function(context, DataUtils, ErrorService, recordsetModel, Session, UiUtils, UriUtils, $document, $log, $rootScope, $scope, $window) {
+    .controller('recordsetController', ['context', 'DataUtils', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$document', '$log', '$rootScope', '$scope', '$window', function(context, DataUtils, recordsetModel, Session, UiUtils, UriUtils, $document, $log, $rootScope, $scope, $window) {
 
         $scope.vm = recordsetModel;
         recordsetModel.RECORDEDIT_MAX_ROWS = 200;
@@ -231,8 +231,8 @@
     }])
 
     // Register work to be performed after loading all modules
-    .run(['AlertsService', 'context', 'DataUtils', 'ERMrest', 'ErrorService', 'FunctionUtils', 'headInjector', 'MathUtils', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', 'modalBox', 'logActions',
-        function(AlertsService, context, DataUtils, ERMrest, ErrorService, FunctionUtils, headInjector, MathUtils, recordsetModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, modalBox, logActions) {
+    .run(['AlertsService', 'context', 'DataUtils', 'ERMrest', 'FunctionUtils', 'headInjector', 'MathUtils', 'messageMap', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$log', '$rootScope', '$window', 'modalBox', 'logActions',
+        function(AlertsService, context, DataUtils, ERMrest, FunctionUtils, headInjector, MathUtils, messageMap, recordsetModel, Session, UiUtils, UriUtils, $log, $rootScope, $window, modalBox, logActions) {
         try {
             var session;
 
@@ -274,10 +274,9 @@
                 // Unsubscribe onchange event to avoid this function getting called again
                 Session.unsubscribeOnChange(subId);
 
-                Session.promptUserPreviousSession().then(function () {
-                    return ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name });
-                }).then(function getReference(reference) {
+                ERMrest.resolve(ermrestUri, { cid: context.appName, pid: context.pageId, wid: $window.name }).then(function getReference(reference) {
                     session = Session.getSessionValue();
+                    if (!session && Session.showPreviousSessionAlert()) AlertsService.addAlert(messageMap.previousSession.message, 'warning', Session.createPromptExpirationToken);
 
                     var location = reference.location;
 


### PR DESCRIPTION
The anonymous login prompt is no longer a modal popup but a soft alert warning that follows a similar set of use cases. This is for issue #1469.

The alert only shows up if a user has logged in before and had their session expire. 
  - If the user logs out, it deletes the stored value that we check for when deciding whether to show the alert or not. 
  - If the user does nothing with the alert, it will continue to show on each subsequent `record` and `recordset` page if the user doesn't login. 
  - If the user clicks the `x` to dismiss the alert, it creates the expiration token and sets it to an hour from now
  - If the user continues to make successful http requests, this expiration is extended to be an hour from now