### PR TITLE
versioned url is used for the uri that is stored with asset data

### DIFF
--- a/common/upload.js
+++ b/common/upload.js
@@ -512,11 +512,12 @@
             // This function is called as a success promise callback by completeUpload function above for each file
             // Once upload jobs are marked as completed it sets the url in the columns for rows
             // And closes the modal
-            uploadFile.prototype.onCompleteUploadJob = function() {
+            uploadFile.prototype.onCompleteUploadJob = function(url) {
 
                 if (vm.erred || vm.aborted) return;
 
                 this.completeUploadJob = true;
+                this.versionedUrl = url;
 
 
                 // This code updates the main progress bar for job completion progress for all files
@@ -554,7 +555,7 @@
                             // then set the url in the corresonding column for the row as its value
                             var column = reference.columns.find(function(c) { return c.name == k;  });
                             if (column && row[k] != null && (column.isAsset) && typeof row[k] == 'object' && row[k].file) {
-                                row[k] = vm.rows[index][rowIndex++].url;
+                                row[k] = vm.rows[index][rowIndex++].versionedUrl;
                             }
                         }
 

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -62,8 +62,8 @@ var testParams = {
            "fileid", "uri", "filename", "bytes"
        ],
        results: [
-           ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1,024,000"],
-           ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+           ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1,024,000"],
+           ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
        ],
        files : [{
            name: "testfile1MB.txt",


### PR DESCRIPTION
This PR addresses issue [#616](https://github.com/informatics-isi-edu/ermrestjs/issues/616) in `ermrestJS`.

We were not using the returned url in `chaise` from the `ermrestJS` function that triggered on completion of the upload job.

Note:
The modified tests will only run in the local environment (file upload features are not tested in travis).