### PR TITLE
Rename action column header when only view is available

### DIFF
--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -4,7 +4,7 @@
         <thead class="table-heading">
             <tr>
                 <th ng-switch="vm.config.selectMode" ng-if="(vm.config.viewable || vm.config.editable || vm.config.deletable || vm.config.selectMode != noSelect)" ng-class="{'multi-select-width': vm.config.selectMode == 'multi-select'}">
-                    <span ng-switch-when="no-select">Actions</span>
+                    <span ng-switch-when="no-select">{{(vm.reference.canUpdate || vm.reference.canDelete) ? "Actions" : "View"}}</span>
                     <span ng-switch-when="single-select">Select</span>
                     <div ng-switch-when="multi-select">
                         <button type="button" ng-click="::selectAll()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Select all rows in table" ng-disabled="vm.matchNotNull">

--- a/test/e2e/specs/all-features/recordset/permissions-visibility.spec.js
+++ b/test/e2e/specs/all-features/recordset/permissions-visibility.spec.js
@@ -35,8 +35,11 @@ describe('When viewing Recordset app', function() {
         });
 
         describe('the action column', function() {
-            it('should display the view button', function() {
+            it("should display 'View' as the column header", function() {
+                expect(element.all(by.tagName('th')).get(0).getText()).toBe("View");
+            });
 
+            it('should display the view button', function() {
                 var button = recordsetPage.getViewActionButtons().first();
                 // There's only 1 button because the table only has 1 row
                 chaisePage.waitForElement(button).then(function(){
@@ -78,10 +81,14 @@ describe('When viewing Recordset app', function() {
 
         it('should not display the Edit link', function() {
             var link = recordsetPage.getEditRecordLink();
-            expect(link.isPresent()).toBe(false);          
+            expect(link.isPresent()).toBe(false);
         });
 
         describe('the action column', function() {
+            it("should display 'View' as the column header", function() {
+                expect(element.all(by.tagName('th')).get(0).getText()).toBe("View");
+            });
+
             it('should display the view button', function() {
                 var button = recordsetPage.getViewActionButtons().first();
                 // There's only 1 button because the table only has 1 row
@@ -125,6 +132,10 @@ describe('When viewing Recordset app', function() {
         });
 
         describe('the action column', function() {
+            it("should display 'Actions' as the column header", function() {
+                expect(element.all(by.tagName('th')).get(0).getText()).toBe("Actions");
+            });
+
             it('should display the view button', function() {
                 var button = recordsetPage.getViewActionButtons().first();
                 // There's only 1 button because the table only has 1 row
@@ -167,6 +178,10 @@ describe('When viewing Recordset app', function() {
         });
 
         describe('the action column', function() {
+            it("should display 'Actions' as the column header", function() {
+                expect(element.all(by.tagName('th')).get(0).getText()).toBe("Actions");
+            });
+
             it('should display the view button', function() {
                 chaisePage.waitForElementInverse(element(by.id("spinner")));
                 var button = recordsetPage.getViewActionButtons().first();


### PR DESCRIPTION
Added a conditional based on whether the user has permission to edit or delete anything on that reference. 

The only case this doesn't support is when a user has those permissions given to them by the reference but each row has row level security that prevents them from doing anything but view those rows. If this is true about every row displayed in the table, this will still display "Actions".