### PR TITLE
removed encoding of catalog id

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -258,7 +258,7 @@
             }
 
             var baseUri = chaiseConfig.ermrestLocation ? chaiseConfig.ermrestLocation : location.origin + '/ermrest';
-            var path = '/catalog/' + fixedEncodeURIComponent(catalogId) + '/entity' + hash;
+            var path = '/catalog/' + catalogId + '/entity' + hash;
             return baseUri + path;
         }
 
@@ -292,7 +292,7 @@
                 appPath = ContextUtils.getValueFromContext(appContextMapping, context);
             }
 
-            var url = chaiseBaseURL + appPath + "/#" + fixedEncodeURIComponent(location.catalog) + "/" + location.path;
+            var url = chaiseBaseURL + appPath + "/#" + location.catalog + "/" + location.path;
             if (location.queryParamsString && (context.indexOf("compact") === 0)) {
                 url = url + "?" + location.queryParamsString;
             }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -87,10 +87,10 @@
             // Created a single entity or Updated one
             if (rowset.length == 1) {
                 AlertsService.addAlert('Your data has been submitted. Redirecting you now to the record...', 'success');
-                redirectUrl += "record/#" + UriUtils.fixedEncodeURIComponent(page.reference.location.catalog) + '/' + page.reference.location.compactPath;
+                redirectUrl += "record/#" + page.reference.location.catalog + '/' + page.reference.location.compactPath;
             } else {
                 AlertsService.addAlert('Your data has been submitted. Redirecting you now to the recordset...', 'success');
-                redirectUrl += "recordset/#" + UriUtils.fixedEncodeURIComponent(page.reference.location.catalog) + '/' + page.reference.location.compactPath;
+                redirectUrl += "recordset/#" + page.reference.location.catalog + '/' + page.reference.location.compactPath;
             }
 
             // Redirect to record or recordset app..

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -31,7 +31,7 @@
             }
 
             //var url = context.mainURI;
-            var url = context.chaiseBaseURL + "#" + UriUtils.fixedEncodeURIComponent(recordsetModel.reference.location.catalog) + "/" +
+            var url = context.chaiseBaseURL + "#" + recordsetModel.reference.location.catalog + "/" +
                 recordsetModel.reference.location.compactPath;
 
             // add sort modifier


### PR DESCRIPTION
This removes encoding of the catalog id in the `chaise` application. Related to [this issue](https://github.com/informatics-isi-edu/ermrestjs/issues/494) in `ermrestJS`.