### PR TITLE
Issue 1511

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -93,7 +93,10 @@
             var defer = $q.defer();
             (function (uri) {
                 vm.reference.read(vm.pageLimit, vm.logObject).then(function (page) {
-                    if (vm.reference.uri !== uri) return defer.resolve(false);
+                    if (vm.reference.uri !== uri) {
+                        defer.resolve(false);
+                        return defer.promise;
+                    }
 
                     vm.page = page;
 
@@ -104,7 +107,7 @@
                     vm.initialized = true;
                     vm.rowValues = DataUtils.getRowValuesFromPage(vm.page);
 
-                    return defer.resolve(true);
+                    defer.resolve(true);
                 }).catch(function(err) {
                     if (vm.reference.uri !== uri) {
                         defer.resolve(false);
@@ -115,7 +118,7 @@
                     if (DataUtils.isObjectAndKeyDefined(err.errorData, 'redirectPath')) {
                       err.errorData.redirectUrl = UriUtils.createRedirectLinkFromPath(err.errorData.redirectPath);
                     }
-                    return defer.reject(err);
+                    defer.reject(err);
                 });
             }) (vm.reference.uri);
             return defer.promise;
@@ -142,14 +145,16 @@
                     {action: logActions.recordsetCount}
                 ).then(function getAggregateCount(response) {
                     if (vm.reference.uri !== uri) {
-                        return defer.resolve(false);
+                        defer.resolve(false);
+                        return defer.promise;
                     }
 
                     vm.totalRowsCnt = response[0];
-                    return defer.resolve(true);
+                    defer.resolve(true);
                 }).catch(function (err) {
                     if (vm.reference.uri !== uri) {
-                        return defer.resolve(false);
+                        defer.resolve(false);
+                        return defer.promise;
                     }
 
                     // fail silently

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -7,7 +7,7 @@
                     <span ng-switch-when="no-select">{{(vm.reference.canUpdate || vm.reference.canDelete) ? "Actions" : "View"}}</span>
                     <span ng-switch-when="single-select">Select</span>
                     <div ng-switch-when="multi-select">
-                        <button type="button" ng-click="::selectAll()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Select all rows in table" ng-disabled="vm.matchNotNull">
+                        <button id="table-select-all-rows" type="button" ng-click="::selectAll()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Select all rows in table" ng-disabled="vm.matchNotNull">
                             <span class="glyphicon glyphicon-check"></span> All
                         </button>
                         <button type="button" ng-click="::selectNone()" class="btn btn-sm btn-primary btn-inverted btn-condensed" tooltip-placement="bottom" uib-tooltip="Deselect all rows in table"  ng-disabled="vm.matchNotNull">

--- a/test/e2e/data_setup/data/faceting/main.json
+++ b/test/e2e/data_setup/data/faceting/main.json
@@ -1,152 +1,182 @@
 [
     {
-        "id": "1", "fk_to_f1": "1", "fk_to_f2": "1", 
+        "id": "1", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**" ,
-        "boolean_col": true, "jsonb_col": {"key": "one"}
+        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
     },
     {
         "id": "2", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"}
+        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002"
     },
     {
         "id": "3", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"}
+        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"
     },
     {
         "id": "4", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"}
+        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004"
     },
     {
         "id": "5", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"}
+        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005"
     },
     {
         "id": "6", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"}
+        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006"
     },
     {
         "id": "7", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"}
+        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007"
     },
     {
         "id": "8", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"}
+        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008"
     },
     {
         "id": "9", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"}
+        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009"
     },
     {
         "id": "10", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"}
+        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010"
     },
     {
         "id": "11", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 3, "float_col": 3.3, "date_col": "2003-03-03", "timestamp_col": "2003-03-03T03:03:03-07:00", "text_col": "three", "shorttext_col": "three", "longtext_col": "three", "markdown_col": "**three**",
-        "boolean_col": false, "jsonb_col": {"key": "three"}
+        "boolean_col": false, "jsonb_col": {"key": "three"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011"
     },
     {
         "id": "12", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 4, "float_col": 4.4, "date_col": "2004-04-04", "timestamp_col": "2004-04-04T04:04:04-07:00", "text_col": "four", "shorttext_col": "four", "longtext_col": "four", "markdown_col": "**four**",
-        "boolean_col": false, "jsonb_col": {"key": "four"}
+        "boolean_col": false, "jsonb_col": {"key": "four"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012"
     },
     {
         "id": "13", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 5, "float_col": 5.5, "date_col": "2005-05-05", "timestamp_col": "2005-05-05T05:05:05-07:00", "text_col": "five", "shorttext_col": "five", "longtext_col": "five", "markdown_col": "**five**",
-        "boolean_col": false, "jsonb_col": {"key": "five"}
+        "boolean_col": false, "jsonb_col": {"key": "five"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013"
     },
     {
         "id": "14", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 6, "float_col": 6.6, "date_col": "2006-06-06", "timestamp_col": "2006-06-06T06:06:06-07:00", "text_col": "six", "shorttext_col": "six", "longtext_col": "six", "markdown_col": "**six**",
-        "boolean_col": false, "jsonb_col": {"key": "six"}
+        "boolean_col": false, "jsonb_col": {"key": "six"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014"
     },
     {
         "id": "15", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 7, "float_col": 7.7, "date_col": "2007-07-07", "timestamp_col": "2007-07-07T07:07:07-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "seven", "markdown_col": "**seven**",
-        "boolean_col": false, "jsonb_col": {"key": "seven"}
+        "boolean_col": false, "jsonb_col": {"key": "seven"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "16", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 8, "float_col": 8.8, "date_col": "2008-08-08", "timestamp_col": "2008-08-08T08:08:08-07:00", "text_col": "eight", "shorttext_col": "eight", "longtext_col": "eight", "markdown_col": "**eight**",
-        "boolean_col": false, "jsonb_col": {"key": "eight"}
+        "boolean_col": false, "jsonb_col": {"key": "eight"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016"
     },
     {
         "id": "17", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 9, "float_col": 9.9, "date_col": "2009-09-09", "timestamp_col": "2009-09-09T09:09:09-07:00", "text_col": "nine", "shorttext_col": "nine", "longtext_col": "nine", "markdown_col": "**nine**",
-        "boolean_col": false, "jsonb_col": {"key": "nine"}
+        "boolean_col": false, "jsonb_col": {"key": "nine"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000017"
     },
     {
         "id": "18", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 10, "float_col": 10.10, "date_col": "2010-10-10", "timestamp_col": "2010-10-10T10:10:10-07:00", "text_col": "ten", "shorttext_col": "ten", "longtext_col": "ten", "markdown_col": "**ten**",
-        "boolean_col": false, "jsonb_col": {"key": "ten"}
+        "boolean_col": false, "jsonb_col": {"key": "ten"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000018"
     },
     {
         "id": "19", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 11, "float_col": 11.11, "date_col": "2011-11-11", "timestamp_col": "2011-11-11T11:11:11-07:00", "text_col": "eleven", "shorttext_col": "eleven", "longtext_col": "eleven", "markdown_col": "**eleven**",
-        "boolean_col": false, "jsonb_col": {"key": "eleven"}
+        "boolean_col": false, "jsonb_col": {"key": "eleven"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000019"
     },
     {
         "id": "20", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 12, "float_col": 12.12, "date_col": "2012-12-12", "timestamp_col": "2012-12-12T12:12:12-07:00", "text_col": "twelve", "shorttext_col": "twelve", "longtext_col": "twelve", "markdown_col": "**twelve**",
-        "boolean_col": false, "jsonb_col": {"key": "twelve"}
+        "boolean_col": false, "jsonb_col": {"key": "twelve"},
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020"
     },
     {
         "id": "21", "fk_to_f1": "3", "fk_to_f2": "4",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000021"
     },
     {
         "id": "22", "fk_to_f1": "4", "fk_to_f2": "5",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022"
     },
     {
         "id": "23", "fk_to_f1": "5", "fk_to_f2": "6",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023"
     },
     {
         "id": "24", "fk_to_f1": "6", "fk_to_f2": "7",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024"
     },
     {
         "id": "25", "fk_to_f1": "7", "fk_to_f2": "8",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000025"
     },
     {
         "id": "26", "fk_to_f1": "8", "fk_to_f2": "9",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026"
     },
     {
         "id": "27", "fk_to_f1": "9", "fk_to_f2": "10",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000027"
     },
     {
         "id": "28", "fk_to_f1": "10", "fk_to_f2": "11",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000028"
     },
     {
         "id": "29", "fk_to_f1": "11", "fk_to_f2": "12",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000029"
     },
     {
         "id": "30", "fk_to_f1": "12", "fk_to_f2": "13",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null
+        "boolean_col": null, "jsonb_col": null,
+        "col_w_long_values": "100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000030"
     }
 ]

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -126,6 +126,12 @@
                     "type": {
                         "typename": "serial4"
                     }
+                },
+                {
+                    "name": "col_w_long_values",
+                    "type": {
+                        "typename": "text"
+                    }
                 }
             ],
             "annotations": {
@@ -148,7 +154,8 @@
                             {"source": [{"outbound": ["faceting", "main_fk2"]}, "id"], "open": true},
                             {"source": [{"inbound": ["faceting", "main_f3_assoc_fk1"]}, {"outbound": ["faceting", "main_f3_assoc_fk2"]}, "term"]},
                             {"source": [{"inbound": ["faceting", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "choices"},
-                            {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term"}
+                            {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term"},
+                            {"source": "col_w_long_values"}
                         ]
                     }
                 }

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -4,8 +4,8 @@ var EC = protractor.ExpectedConditions;
 var testParams = {
     schema_name: "faceting",
     table_name: "main",
-    totalNumFacets: 15,
-    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col", "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1", "to_name", "f3 (term)", "from_name", "F1 with Term" ],
+    totalNumFacets: 16,
+    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col", "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1", "to_name", "f3 (term)", "from_name", "F1 with Term", "col_w_long_values" ],
     defaults: {
         openFacetNames: [ "id", "int_col", "to_name" ],
         numFilters: 2,
@@ -257,7 +257,7 @@ describe("Viewing Recordset with Faceting,", function() {
         });
 
         describe("default presentation based on facets annotation ", function () {
-            it("should have 14 facets", function () {
+            it("should have " + testParams.totalNumFacets + " facets", function () {
                 chaisePage.recordsetPage.getAllFacets().count().then(function (ct) {
                     expect(ct).toBe(testParams.totalNumFacets, "Number of all facets is incorrect");
 
@@ -543,7 +543,7 @@ describe("Viewing Recordset with Faceting,", function() {
                 clearAll = chaisePage.recordsetPage.getClearAllFilters();
             });
 
-            for (var j=0; j<testParams.totalNumFacets; j++) {
+            for (var j=0; j<testParams.facets.length; j++) {
                 // anon function to capture looping variable
                 (function(facetParams, idx) {
                     if (facetParams.type == "choice") {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1151,6 +1151,18 @@ var recordsetPage = function() {
     this.getPlotlyReset = function (idx) {
         return element(by.id("fc-" + idx)).element(by.css(".reset-plotly-button"));
     };
+
+    this.getWarningAlert = function () {
+        return element(by.css(".alert-warning"));
+    };
+
+    this.getWarningAlertDissmBtn = function () {
+        return element(by.css(".alert-warning")).element(by.css("button"));
+    }
+
+    this.getSelectAllBtn = function () {
+        return element(by.id("table-select-all-rows"));
+    }
 };
 
 var errorModal = function () {


### PR DESCRIPTION
For some issues that we faced in the past, I had to introduce an attribute in chaise that keeps track of applied filters. Since it was manually added in chaise, we had to make sure that it is always
aligned with the reference facets that ermrestjs is returning. In case of submitting the facets, I was changing that variable first and then was checking the reference for URL limit. So in that case
the reference and appliedFilters would be inconsistent and recordset would break.

I also noticed that we don't have any testcases for this. So I added two for the following scenarios:

1. Long search string (2000 characters)
2. Selecting a lot of facet options in the modal

The only problem with the first one is that I'm using `sendKeys` for now, which is trying to mimic human typing, so it is taking more than 30 seconds for it to finish writing the 2000 characters. I will try to find an alternative for this, otherwise I will remove the test case.