### PR TITLE
Recordedit bookmark container

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -162,7 +162,7 @@ img.spinner-sm {
 }
 
 #bookmark-container {
-    padding: 15px 40px 15px 40px; /* padding-left and padding-right sides are to equal the left and right paddings of .container-fluid */
+    padding: 15px 40px 10px 40px; /* padding-left and padding-right sides are to equal the left and right paddings of .container-fluid */
     background-color: #f1f1f1;
     box-shadow: 0 4px 2px -2px rgba(0,0,0,0.4);
     z-index: 100;

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -334,7 +334,7 @@
             return $rootScope.displayReady;
         }, function (newValue, oldValue) {
             if (newValue) {
-                setMainContainerHeight();
+                $timeout(setMainContainerHeight, 0);
             }
         });
 
@@ -343,7 +343,9 @@
             return mainBodyEl && mainBodyEl[0].offsetHeight;
         }, function (newValue, oldValue) {
             if (newValue) {
-                UiUtils.setFooterStyle(0);
+                $timeout(function () {
+                    UiUtils.setFooterStyle(0);
+                }, 0);
             }
         });
 

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -214,9 +214,9 @@
                     };
                 }
                 vm.resultset = true;
-                mainBodyEl = $document[0].getElementsByClassName('main-body')[1];
                 // delay updating the height of DOM elements so the current digest cycle can complete and "show" the resultset view
                 $timeout(function() {
+                    mainBodyEl = $document[0].getElementsByClassName('main-body')[1];
                     setMainContainerHeight();
                     UiUtils.setFooterStyle(1);
                 }, 0);
@@ -633,7 +633,7 @@
 
         // watch for the main body size to change
         $scope.$watch(function() {
-            return mainBodyEl && mainBodyEl[0].offsetHeight;
+            return mainBodyEl && mainBodyEl.offsetHeight;
         }, function (newValue, oldValue) {
             if (newValue) {
                 $timeout(function () {
@@ -651,7 +651,7 @@
         });
 
         $timeout(function () {
-            mainBodyEl = $document[0].getElementsByClassName('main-body');
+            mainBodyEl = $document[0].getElementsByClassName('main-body')[0];
         }, 0);
 
         /*------------------------code below is for fixing the column names when scrolling -----------*/

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -11,7 +11,6 @@
 
         vm.recordEditModel = recordEditModel;
         vm.dataFormats = dataFormats;
-        vm.resultset = false;
         vm.editMode = (context.mode == context.modes.EDIT ? true : false);
         vm.showDeleteButton = chaiseConfig.deleteRecord === true ? true : false;
         vm.booleanValues = context.booleanValues;
@@ -605,7 +604,7 @@
                 // get navbar height
                 elements.navbarHeight = $document[0].getElementById('mainnav').offsetHeight;
                 // get bookmark height
-                elements.bookmarkHeight = $document[0].getElementById('bookmark-container').offsetHeight;
+                elements.bookmarkHeight = $document[0].getElementsByClassName('meta-icons')[containerIndex].offsetHeight;
                 // get recordedit main container
                 elements.container = $document[0].getElementsByClassName('main-container')[containerIndex];
             } catch(error) {

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -217,7 +217,10 @@
                 vm.resultset = true;
                 mainBodyEl = $document[0].getElementsByClassName('main-body')[1];
                 // delay updating the height of DOM elements so the current digest cycle can complete and "show" the resultset view
-                $timeout(setMainHeights, 0);
+                $timeout(function() {
+                    setMainContainerHeight();
+                    UiUtils.setFooterStyle(1);
+                }, 0);
         }
     }
 
@@ -601,9 +604,8 @@
                 elements.docHeight = $document[0].documentElement.offsetHeight
                 // get navbar height
                 elements.navbarHeight = $document[0].getElementById('mainnav').offsetHeight;
-                // there is no bookmark bar
-                // TODO: if bookmark bar added
-                elements.bookmarkHeight = 0;
+                // get bookmark height
+                elements.bookmarkHeight = $document[0].getElementById('bookmark-container').offsetHeight;
                 // get recordedit main container
                 elements.container = $document[0].getElementsByClassName('main-container')[containerIndex];
             } catch(error) {
@@ -626,7 +628,7 @@
             return $rootScope.displayReady;
         }, function (newValue, oldValue) {
             if (newValue) {
-                setMainContainerHeight();
+                $timeout(setMainContainerHeight, 0);
             }
         });
 
@@ -635,7 +637,9 @@
             return mainBodyEl && mainBodyEl[0].offsetHeight;
         }, function (newValue, oldValue) {
             if (newValue) {
-                UiUtils.setFooterStyle(vm.resultset ? 1 : 0);
+                $timeout(function () {
+                    UiUtils.setFooterStyle(vm.resultset ? 1 : 0);
+                }, 0);
             }
         });
 

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -25,6 +25,30 @@
         <loading-spinner ng-show="!displayReady && !error"></loading-spinner>
         <div ng-if="reference && (reference.canCreate || reference.canUpdate)">
             <div ng-controller="FormController as form" class="row">
+                <div class="row">
+                    <div id="bookmark-container" class="col-xs-12 meta-icons">
+                        <div ng-if="displayname" id="title" class="pull-left">
+                            <h1 id="page-title">
+                                <span>{{ form.editMode ? "Edit " : "Create " }}</span>
+                                <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value"></span>
+                                <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value"></span>
+                                <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
+                            </h1>
+                            <div>
+                                <h3 id="page-subtitle" style="display:inline;">
+                                    <span ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                    <span ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                </h3>&nbsp;&nbsp;
+                                <span style="font-size:10px; display:inline;"><span class="text-danger">*</span> indicates required field</span>
+                            </div>
+                        </div>
+                        <div class="pull-right">
+                            <a id="submit-record-button" ng-click="::form.submit();" ng-disabled="form.submissionButtonDisabled" uib-tooltip="Click here to submit data." tooltip-placement="bottom">
+                                <span class="glyphicon glyphicon-saved"></span> <strong>Submit</strong>
+                            </a>
+                        </div>
+                    </div>
+                </div>
                 <div ng-hide="form.resultset">
                     <loading-spinner ng-show="form.submissionButtonDisabled || showSpinner"></loading-spinner>
                     <div class="main-container">
@@ -36,22 +60,6 @@
 
                             <!-- Form section -->
                             <div id="form-section">
-                                <div class="row">
-                                    <div ng-if="displayname" class="col-xs-7">
-                                        <div id="entity-title">
-                                            <span>{{ form.editMode ? "Edit " : "Create " }}</span>
-                                            <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                            <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                            <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
-                                        </div>
-                                        <span class="text-danger">*</span> indicates required field
-                                    </div>
-                                    <div class="col-xs-5 padding-top-10">
-                                        <div class="pull-right">
-                                            <button id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit();">Submit Data</button>
-                                        </div>
-                                    </div>
-                                </div>
                                 <div class="row padding-right-15" ng-show="::!form.editMode">
                                     <div class="btn-group pull-right">
                                         <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -27,25 +27,32 @@
             <div ng-controller="FormController as form" class="row">
                 <div class="row">
                     <div id="bookmark-container" class="col-xs-12 meta-icons">
-                        <div ng-if="displayname" id="title" class="pull-left">
+                        <div id="title" class="pull-left">
                             <h1 id="page-title">
-                                <span>{{ form.editMode ? "Edit " : "Create " }}</span>
-                                <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value"></span>
-                                <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value"></span>
-                                <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
+                                <div ng-if="!form.resultset">
+                                    <span>{{ form.editMode ? "Edit " : "Create " }}</span>
+                                    <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value"></span>
+                                    <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value"></span>
+                                    <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
+                                </div>
+                                <div ng-if="form.resultset">
+                                    <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}</span>
+                                    <a ng-href="{{::form.recordsetLink}}">
+                                        <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
+                                        <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
+                                    </a>
+                                    <span>Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
+                                </div>
                             </h1>
                             <div>
-                                <h3 id="page-subtitle" style="display:inline;">
+                                <h3 id="page-subtitle">
                                     <span ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
                                     <span ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                </h3>&nbsp;&nbsp;
-                                <span style="font-size:10px; display:inline;"><span class="text-danger">*</span> indicates required field</span>
+                                </h3>
                             </div>
                         </div>
                         <div class="pull-right">
-                            <a id="submit-record-button" ng-click="::form.submit();" ng-disabled="form.submissionButtonDisabled" uib-tooltip="Click here to submit data." tooltip-placement="bottom">
-                                <span class="glyphicon glyphicon-saved"></span> <strong>Submit</strong>
-                            </a>
+                            <button ng-if="!form.resultset" id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit()">Submit</button>
                         </div>
                     </div>
                 </div>
@@ -60,6 +67,7 @@
 
                             <!-- Form section -->
                             <div id="form-section">
+                                <span class="pull-left"><span class="text-danger">*</span> indicates required field</span>
                                 <div class="row padding-right-15" ng-show="::!form.editMode">
                                     <div class="btn-group pull-right">
                                         <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
@@ -82,7 +90,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="row form-container" style="margin-top: 25px;">
+                                <div class="row form-container">
                                     <div ng-show="displayReady" class="col-xs-12" id="formEditScroll" ng-class="{'editMode': form.editMode, 'createMode': !form.editMode}" ng-style="form.formEditDivMarginLeft">
                                         <div ng-style="form.tableWidth"></div>
                                     </div>
@@ -256,22 +264,12 @@
                 <div ng-if="form.resultset">
                     <div class="main-container">
                         <div class="main-body container-fluid">
-                            <h2 id="result-title" class="replace-margin">
-                                <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}</span>
-                                <a ng-href="{{::form.recordsetLink}}">
-                                    <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
-                                    <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
-                                </a>
-                                <span>Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
-                            </h2>
                             <div id="resultset-tables" class="side-padding-15">
                                 <h3 class="replace-margin">{{ form.resultsetModel.rowValues.length }} Successful <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
-
                                 <record-table vm="form.resultsetModel"></record-table>
 
                                 <div ng-if="form.omittedResultsetModel">
                                     <h3 class="replace-margin">{{ form.omittedResultsetModel.rowValues.length }} Failed <span ng-if="::!form.editMode">Creations</span><span ng-if="::form.editMode">Updates</span></h3>
-
                                     <record-table vm="form.omittedResultsetModel" default-row-linking="true"></record-table>
                                 </div>
                             </div>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -25,39 +25,27 @@
         <loading-spinner ng-show="!displayReady && !error"></loading-spinner>
         <div ng-if="reference && (reference.canCreate || reference.canUpdate)">
             <div ng-controller="FormController as form" class="row">
-                <div class="row">
-                    <div id="bookmark-container" class="col-xs-12 meta-icons">
-                        <div id="title" class="pull-left">
-                            <h1 id="page-title">
-                                <div ng-if="!form.resultset">
-                                    <span>{{ form.editMode ? "Edit " : "Create " }}</span>
-                                    <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value"></span>
-                                    <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value"></span>
-                                    <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
-                                </div>
-                                <div ng-if="form.resultset">
-                                    <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }}</span>
-                                    <a ng-href="{{::form.recordsetLink}}">
-                                        <span ng-if="::form.resultsetModel.tableDisplayname.isHTML" ng-bind-html="::form.resultsetModel.tableDisplayName.value"></span>
-                                        <span ng-if="::!form.resultsetModel.tableDisplayname.isHTML" ng-bind="::form.resultsetModel.tableDisplayName.value"></span>
-                                    </a>
-                                    <span>Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
-                                </div>
-                            </h1>
-                            <div>
-                                <h3 id="page-subtitle">
-                                    <span ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                    <span ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                </h3>
-                            </div>
-                        </div>
-                        <div class="pull-right">
-                            <button ng-if="!form.resultset" id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit()">Submit</button>
-                        </div>
-                    </div>
-                </div>
                 <div ng-hide="form.resultset">
                     <loading-spinner ng-show="form.submissionButtonDisabled || showSpinner"></loading-spinner>
+                    <div class="row">
+                        <div id="bookmark-container" class="col-xs-12 meta-icons">
+                            <div id="title" class="pull-left">
+                                <h1 id="page-title">
+                                        <span>{{ form.editMode ? "Edit " : "Create " }}</span>
+                                        <span class="re-displayname" ng-if="displayname.isHTML" ng-bind-html="displayname.value"></span>
+                                        <span class="re-displayname" ng-if="!displayname.isHTML" ng-bind="displayname.value"></span>
+                                        <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
+                                </h1>
+                                <h3 id="page-subtitle">
+                                    <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                    <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                </h3>
+                            </div>
+                            <div class="pull-right">
+                                <button id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit()">Submit</button>
+                            </div>
+                        </div>
+                    </div>
                     <div class="main-container">
                         <div class="main-body" style="padding-right:15px; padding-left:15px;">
                             <!-- Alerts section -->
@@ -261,7 +249,22 @@
                         <footer></footer>
                     </div>
                 </div>
-                <div ng-if="form.resultset">
+                <div class="resultset-container" ng-if="form.resultset">
+                    <div class="row">
+                        <div id="bookmark-container" class="col-xs-12 meta-icons">
+                            <div id="title" class="pull-left">
+                                <h1 id="page-title">
+                                    <span>{{ form.resultsetModel.rowValues.length }}/{{ form.resultsetModel.pageLimit }} Records <span ng-if="::!form.editMode">Created</span><span ng-if="::form.editMode">Updated</span> Successfully</span>
+                                </h1>
+                                <h3 id="page-subtitle">
+                                    <a ng-href="{{::form.recordsetLink}}">
+                                        <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                        <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                    </a>
+                                </h3>
+                            </div>
+                        </div>
+                    </div>
                     <div class="main-container">
                         <div class="main-body container-fluid">
                             <div id="resultset-tables" class="side-padding-15">

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -42,7 +42,7 @@
                                 </h3>
                             </div>
                             <div class="pull-right">
-                                <button id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit()">Submit</button>
+                                <button id="submit-record-button" class="btn btn-primary btn-inverted" type="submit" ng-disabled="form.submissionButtonDisabled" ng-click="::form.submit()" ng-attr-tooltip-placement="bottom-right" ng-attr-uib-tooltip="Submit data">Submit</button>
                             </div>
                         </div>
                     </div>
@@ -55,13 +55,13 @@
 
                             <!-- Form section -->
                             <div id="form-section">
-                                <span class="pull-left"><span class="text-danger">*</span> indicates required field</span>
+                                <span class="pull-left"><span class="text-danger"><b>*</b></span> indicates required field</span>
                                 <div class="row padding-right-15" ng-show="::!form.editMode">
                                     <div class="btn-group pull-right">
-                                        <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom" uib-tooltip="Click to add 1 record.">
+                                        <button id="copy-record-btn" class="btn btn-primary btn-inverted center-block" ng-click="::form.copyFormRow();" ng-if="::!form.editMode" type="button" ng-disabled="!form.canAddMore" tooltip-placement="top" uib-tooltip="Add 1 record.">
                                             <span class="glyphicon glyphicon-plus"></span>
                                         </button>
-                                        <button id="copy-x-rows-btn" class="btn btn-primary btn-inverted center-block" ng-click="::(form.showMultiInsert = !form.showMultiInsert)" type="button" ng-disabled="!form.canAddMore" tooltip-placement="bottom-right" uib-tooltip="Click to add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
+                                        <button id="copy-x-rows-btn" class="btn btn-primary btn-inverted center-block" ng-click="::(form.showMultiInsert = !form.showMultiInsert)" type="button" ng-disabled="!form.canAddMore" tooltip-placement="top-right" uib-tooltip="Add a maximum of {{::form.MAX_ROWS_TO_ADD-1}} records.">
                                             <span class="glyphicon glyphicon-chevron-down"></span>
                                         </button>
                                     </div>
@@ -71,7 +71,7 @@
                                         <div class="input-group">
                                             <input id="copy-rows-input" type="number" class="form-control " ng-model="form.numberRowsToAdd">
                                             <span class="input-group-btn">
-                                                <button id="copy-rows-submit" class="btn btn-sm btn-primary btn-inverted center-block" ng-click="::form.copyFormRow()" type="button" tooltip-placement="bottom" uib-tooltip="Submit">
+                                                <button id="copy-rows-submit" class="btn btn-sm btn-primary btn-inverted center-block" ng-click="::form.copyFormRow()" type="button" tooltip-placement="bottom" uib-tooltip="Apply">
                                                     <span class="glyphicon glyphicon-ok"></span>
                                                 </button>
                                             </span>
@@ -97,7 +97,7 @@
                                             </tr>
                                             <tr class="entity" ng-form="form.formContainer.row[rowIndex]" ng-repeat="column in reference.columns">
                                                 <td ng-style="form.captionColumnWidth" class="entity-key col-xs-1">
-                                                    <span ng-if="::form.isRequired(column);" class="text-danger">*</span>
+                                                    <span ng-if="::form.isRequired(column);" class="text-danger"><b>*</b></span>
                                                     <span class="column-displayname" ng-attr-tooltip-placement="{{::(column.comment) ? 'right' : undefined}}" ng-attr-uib-tooltip="{{::(column.comment) ? column.comment : undefined}}">
                                                         <span ng-if="::column.displayname.isHTML" ng-bind-html="::column.displayname.value"></span>
                                                         <span ng-if="::!column.displayname.isHTML" ng-bind="::column.displayname.value"></span>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -37,8 +37,8 @@
                                         <span>{{ (form.recordEditModel.rows.length > 1) ? " Records" : " Record" }}</span>
                                 </h1>
                                 <h3 id="page-subtitle">
-                                    <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                    <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                    <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="right" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                    <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="right" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
                                 </h3>
                             </div>
                             <div class="pull-right">
@@ -258,8 +258,8 @@
                                 </h1>
                                 <h3 id="page-subtitle">
                                     <a ng-href="{{::form.recordsetLink}}">
-                                        <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
-                                        <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                        <span class="re-subtitle" ng-if="tableDisplayName.isHTML" ng-bind-html="tableDisplayName.value" ng-attr-tooltip-placement="right" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
+                                        <span class="re-subtitle" ng-if="!tableDisplayName.isHTML" ng-bind="tableDisplayName.value" ng-attr-tooltip-placement="right" ng-attr-uib-tooltip="{{::tableComment ? tableComment : undefined}}"></span>
                                     </a>
                                 </h3>
                             </div>

--- a/recordedit/model.js
+++ b/recordedit/model.js
@@ -9,6 +9,7 @@
         rows: [{}], // rows of data in the form, not the table from ERMrest
         oldRows: [{}], // Keep a copy of the initial rows data so that we can see if user has made any changes later
         submissionRows: [{}], // rows of data converted to raw data for submission
-        foreignKeyData: [{}] // the linkedData that we get from tuple object (data from outbound foreign keys)
+        foreignKeyData: [{}], // the linkedData that we get from tuple object (data from outbound foreign keys)
+        resultset: false
     });
 })();

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -254,6 +254,7 @@
                                 $rootScope.displayname = page.tuples[0].displayname;
                                 $rootScope.tableComment = "";
                             }
+                            $rootScope.tableDisplayName = $rootScope.reference.displayname;
 
                             for (var j = 0; j < page.tuples.length; j++) {
                                 // initialize row objects {column-name: value,...}
@@ -363,7 +364,7 @@
                     }
                 } else if (context.mode == context.modes.CREATE) {
                     if ($rootScope.reference.canCreate) {
-                        $rootScope.displayname = $rootScope.reference.displayname;
+                        $rootScope.displayname = $rootScope.tableDisplayName = $rootScope.reference.displayname;
                         $rootScope.tableComment = $rootScope.reference.table.comment;
 
                         // populate defaults

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -248,11 +248,10 @@
                             // $rootScope.tuples is used for keeping track of changes in the tuple data before it is submitted for update
                             $rootScope.tuples = [];
                             if ((context.mode != context.modes.EDIT || page.tuples.length > 1)) {
-                                $rootScope.displayname = $rootScope.reference.displayname;
                                 $rootScope.tableComment = $rootScope.reference.table.comment;
                             } else {
                                 $rootScope.displayname = page.tuples[0].displayname;
-                                $rootScope.tableComment = "";
+                                $rootScope.tableComment = $rootScope.reference.table.comment;
                             }
                             $rootScope.tableDisplayName = $rootScope.reference.displayname;
 
@@ -364,7 +363,7 @@
                     }
                 } else if (context.mode == context.modes.CREATE) {
                     if ($rootScope.reference.canCreate) {
-                        $rootScope.displayname = $rootScope.tableDisplayName = $rootScope.reference.displayname;
+                        $rootScope.tableDisplayName = $rootScope.reference.displayname;
                         $rootScope.tableComment = $rootScope.reference.table.comment;
 
                         // populate defaults

--- a/recordedit/recordEdit.css
+++ b/recordedit/recordEdit.css
@@ -1,7 +1,7 @@
 .main-container {
     overflow-y: auto;
     overflow-x: hidden;
-    margin-top: 5px;
+    padding-top: 10px;
 }
 
 .padding-top-10 {
@@ -49,7 +49,7 @@ textarea {
 }
 
 .form-container {
-    margin-top: 40px;
+    margin-top: 0px;
 }
 
 .input-timestamptz {

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -127,7 +127,7 @@
             return recordsetModel.hasLoaded && recordsetModel.initialized;
         }, function (newValue, oldValue) {
             if (newValue) {
-                setRecordsetHeight();
+                $timeout(setRecordsetHeight, 0);
             }
         });
 
@@ -138,7 +138,9 @@
             }
         }, function (newValue, oldValue) {
             if (newValue) {
-                UiUtils.setFooterStyle(0);
+                $timeout(function () {
+                    UiUtils.setFooterStyle(0);
+                }, 0);
             }
         });
 

--- a/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
@@ -13,8 +13,9 @@ var testParams = {
     tables: [{
         schema_name: "product-edit",
         table_name: "accommodation",
-        table_displayname: "Sherathon Hotel", //since this is in single-edit, displayname is rowname.
-        table_comment: null, //since this is in single-edit, tooltip is missing.
+        record_displayname: "Sherathon Hotel", //since this is in single-edit, displayname is rowname.
+        table_displayname: "Accommodations",
+        table_comment: "List of different types of accommodations",
         key: { name: "id", value: "2000", operator: "="},
         primary_keys: ["id"],
         columns: [
@@ -55,8 +56,9 @@ var testParams = {
     }, {
        schema_name: "product-edit",
        table_name: "file",
-       table_displayname: "90008", //since this is in single-edit, displayname is rowname.
-       table_comment: null, //since this is in single-edit, tooltip is missing.
+       record_displayname: "90008", //since this is in single-edit, displayname is rowname.
+       table_displayname: "File",
+       table_comment: "asset/object",
        primary_keys: ["id"],
        key: { name: "id", value: "90008", operator: "="},
        columns: [

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -131,7 +131,7 @@ describe('View existing record,', function() {
                 }).then(function(txt) {
                     expect(txt).toBe("Create Record", "Recordedit title is incorrect.");
 
-                    return titleElement.element(by.css('span[ng-bind-html]')).getAttribute("innerHTML");
+                    return chaisePage.recordEditPage.getEntitySubtitleElement().element(by.css('span[ng-bind-html]')).getAttribute("innerHTML");
                 }).then(function(html) {
                     expect(html).toBe(testParams.table_inner_html_display);
 

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -129,7 +129,7 @@ describe('View existing record,', function() {
 
                     return titleElement.getText();
                 }).then(function(txt) {
-                    expect(txt).toBe("Create " + testParams.table_displayname +" Record");
+                    expect(txt).toBe("Create Record", "Recordedit title is incorrect.");
 
                     return titleElement.element(by.css('span[ng-bind-html]')).getAttribute("innerHTML");
                 }).then(function(html) {

--- a/test/e2e/specs/all-features/recordedit/permissions-visibility.spec.js
+++ b/test/e2e/specs/all-features/recordedit/permissions-visibility.spec.js
@@ -52,8 +52,8 @@ describe('When viewing RecordEdit app', function() {
     describe('as a user who can update (and create)', function() {
         beforeAll(function() {
             browser.get(baseUrl + ':main_update_table/' + testParams.key.columnName + testParams.key.operator + testParams.key.value);
-            chaisePage.waitForElement(element(by.id('entity-title'))).then(function() {
-                expect(element(by.id('entity-title')).isDisplayed()).toBe(true);
+            chaisePage.waitForElement(element(by.id('page-title'))).then(function() {
+                expect(element(by.id('page-title')).isDisplayed()).toBe(true);
             });
         });
 
@@ -134,7 +134,7 @@ describe('When viewing RecordEdit app', function() {
 
             browser.get(url);
             chaisePage.waitForElement(modalBody).then(function() {
-                expect(element(by.id('entity-title')).isPresent()).toBe(false);
+                expect(element(by.id('page-title')).isPresent()).toBe(false);
                 expect(modalBody.isDisplayed()).toBe(true);
                 expect(element(by.css('.modal-title')).isPresent()).toBe(true);
                 expect(element(by.css('.modal-title')).getText()).toBe('You need to be logged in to continue.');

--- a/test/e2e/specs/default-config/recordedit/multi-edit.spec.js
+++ b/test/e2e/specs/default-config/recordedit/multi-edit.spec.js
@@ -151,15 +151,19 @@ describe('Edit multiple existing record,', function() {
                     browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + schemaName + ":" + tableParams.table_name + "/" + keyPairs.join(";"));
                 });
 
-                it("should have the table displayname as part of the entity title.", function() {
+                it("should have the title displayed properly.", function() {
                     // if submit button is visible, this means the recordedit page has loaded
                     chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
-                        expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Edit " + tableParams.table_name + " Records");
+                        expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Edit Records", "Multi-edit title is incorrect.");
                     });
                 });
 
-                it("table tooltip must be correct.", function () {
-                    expect(chaisePage.recordEditPage.getEntityTitleTooltip()).toBe(tableParams.tableComment);
+                it("should have the table displayname as part of the entity subtitle witht eh proper tooltip.", function() {
+                    // if submit button is visible, this means the recordedit page has loaded
+                    chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+                        expect(chaisePage.recordEditPage.getEntitySubtitleElement().getText()).toBe(tableParams.table_name.toUpperCase(), "Entity subtitle is incorrect.");
+                        expect(chaisePage.recordEditPage.getEntitySubtitleTooltip()).toBe(tableParams.tableComment, "Subtitle comment is incorrect.");
+                    });
                 });
 
                 it("columns should have correct value, and selectable.", function() {
@@ -217,14 +221,14 @@ describe('Edit multiple existing record,', function() {
 
                     describe("result page", function () {
                         it("should have the correct title.", function() {
-                            expect(chaisePage.recordEditPage.getResultTitle().getText()).toBe(tableParams.results.length + "/" + tableParams.results.length + " "+ tableParams.table_name +" Records Updated Successfully");
+                            expect(chaisePage.recordEditPage.getResultsetTitleElement().getText()).toBe(tableParams.results.length + "/" + tableParams.results.length + " Records Updated Successfully", "Resultset title is incorrect.");
                         });
 
                         it('should point to the correct link with caption.', function () {
                             var expectedLink = process.env.CHAISE_BASE_URL + "/recordset/#" +  browser.params.catalogId + "/" + schemaName + ":" + tableParams.table_name + "/" + keyPairs.join(";") + "@sort(" + tableParams.sortColumns + ")";
 
-                            chaisePage.recordEditPage.getResultTitleLink().then(function (titleLink) {
-                                expect(titleLink[0].getText()).toBe(tableParams.table_name, "Title of result page doesn't have the expected caption.");
+                            chaisePage.recordEditPage.getResultsetSubtitleLink().then(function (titleLink) {
+                                expect(titleLink[0].getText()).toBe(tableParams.table_name.toUpperCase(), "Title of result page doesn't have the expected caption.");
                                 expect(titleLink[0].getAttribute("href")).toBe(expectedLink , "Title of result page doesn't have the expected link.");
                             });
                         });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -268,20 +268,24 @@ var recordEditPage = function() {
     };
 
     this.getEntityTitleElement = function() {
-        return element(by.id('entity-title'));
+        return element(by.id('page-title'));
     };
 
-    this.getEntityTitleTooltip = function () {
-        // the .re-displayname element might not exist, that's why it's different from other tooltips
-        return element.all(by.css("#entity-title .re-displayname")).first().getAttribute('uib-tooltip');
+    this.getResultsetTitleElement = function() {
+        return element(by.css('.resultset-container #page-title'));
     };
 
-    this.getResultTitle = function () {
-        return element(by.id('result-title'));
+    this.getEntitySubtitleElement = function() {
+        return element(by.id('page-subtitle'));
     };
 
-    this.getResultTitleLink = function () {
-        return element.all(by.css('#result-title > a'));
+    this.getEntitySubtitleTooltip = function () {
+        // the .re-subtitle element might not exist, that's why it's different from other tooltips
+        return element.all(by.css("#page-subtitle .re-subtitle")).first().getAttribute('uib-tooltip');
+    };
+
+    this.getResultsetSubtitleLink = function () {
+        return element.all(by.css('#page-subtitle > a'));
     };
 
     this.getAllColumnCaptions = function() {
@@ -395,7 +399,7 @@ var recordEditPage = function() {
     };
 
     this.getFormTitle = function() {
-        return element(by.id("entity-title"));
+        return element(by.id("page-title"));
     };
 
     this.getForeignKeyInputDisplay = function(columnDisplayName, index) {

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -765,7 +765,7 @@ exports.testAddRelatedTable = function (params, inputCallback) {
 				expect(url.indexOf('?prefill=')).toBeGreaterThan(-1, "didn't have prefill");
 
 				var title = chaisePage.recordEditPage.getFormTitle().getText();
-				expect(title).toBe("Create " + params.tableDisplayname + " Record", "recordedit title missmatch.")
+				expect(title).toBe("Create Record", "recordedit title missmatch.")
 
 				done();
 			}).catch(function (err) {

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -117,7 +117,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
             browser.wait(EC.visibilityOf(chaisePage.recordEditPage.getEntityTitleElement()), browser.params.defaultTimeout);
             var title = chaisePage.recordEditPage.getEntityTitleElement();
-            expect(title.getText()).toEqual("Edit " + tableParams.table_displayname + " Record");
+            expect(title.getText()).toEqual("Edit " + tableParams.record_displayname + " Record", "Edit mode title is incorrect.");
         });
 
         it("should not allow to add new rows/columns", function() {
@@ -132,7 +132,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
             var EC = protractor.ExpectedConditions;
 
             browser.wait(EC.visibilityOf(chaisePage.recordEditPage.getEntityTitleElement()), browser.params.defaultTimeout);
-            expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Create " + tableParams.table_displayname + " Record");
+            expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Create Record", "Create mode title is incorrect.");
         });
 
         it("should allow to add new rows/columns", function() {
@@ -144,7 +144,8 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
     }
 
     it ("should have the table subtitle.", function () {
-        expect(chaisePage.recordEditPage.getEntityTitleTooltip()).toBe(tableParams.table_comment);
+        expect(chaisePage.recordEditPage.getEntitySubtitleElement().getText()).toBe(tableParams.table_displayname.toUpperCase(), "Entity subtitle is incorrect.");
+        expect(chaisePage.recordEditPage.getEntitySubtitleTooltip()).toBe(tableParams.table_comment, "Entity subtitle tooltip is incorrect.");
     });
 
     it("should render columns which are inside the visible columns annotation if defined; Default all are visible", function() {
@@ -1345,8 +1346,8 @@ exports.testSubmission = function (tableParams, isEditMode) {
 
         describe('result page, ', function () {
             it("should have the correct title.", function() {
-                var title = tableParams.results.length + "/" + tableParams.results.length + " "+ tableParams.table_displayname +" Records "+(isEditMode? "Updated": "Created")+" Successfully";
-                expect(chaisePage.recordEditPage.getResultTitle().getText()).toBe(title);
+                var title = tableParams.results.length + "/" + tableParams.results.length + " Records " + (isEditMode ? "Updated" : "Created") + " Successfully";
+                expect(chaisePage.recordEditPage.getResultsetTitleElement().getText()).toBe(title, "Resultset page title is incorrect.");
             });
 
             it('should point to the correct link with caption.', function () {
@@ -1361,8 +1362,8 @@ exports.testSubmission = function (tableParams, isEditMode) {
 
                 var expectedLink = process.env.CHAISE_BASE_URL + "/recordset/#" +  browser.params.catalogId + "/" + tableParams.schema_name + ":" + tableParams.table_name + linkModifier;
 
-                chaisePage.recordEditPage.getResultTitleLink().then(function (titleLink) {
-                    expect(titleLink[0].getText()).toBe(tableParams.table_displayname, "Title of result page doesn't have the expected caption.");
+                chaisePage.recordEditPage.getResultsetSubtitleLink().then(function (titleLink) {
+                    expect(titleLink[0].getText()).toBe(tableParams.table_displayname.toUpperCase(), "Title of result page doesn't have the expected caption.");
                     expect(titleLink[0].getAttribute("href")).toBe(expectedLink , "Title of result page doesn't have the expected link.");
                 });
             });


### PR DESCRIPTION
This PR adds the bookmark container to the `recordedit` app outlined in issue #1491. This is now consistent across each application.

Notes:
 - `$timeout` wraps both setting the main container height and the footer styling
   - this had to be done for weird cases where the bookmark container would load smaller than it should in `RE` then expand after the height calculation was set.
 - `RE` has 2 bookmark containers.
   - there would have been too many converse `ng-if=bool` and `ng-if=!bool` with 1 container
 - displayname consistency in `RE`
   - the `page-title` element now shows the entities `displayname`  if in single edit or a more default title in other modes
   - the `page-subtitile` element shows the table name associated with the reference