### PR TITLE
recordedit error check login state first

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -223,6 +223,10 @@
             });
         };
 
+        /**
+         * uses the reloadCb function to reload the page no matter what after a user logs in
+         * creates a race condition with the calback registered for the LoginInAModal function
+         */
         var popupLogin = function () {
             var reloadCb = function(){
                 window.location.reload();
@@ -273,6 +277,22 @@
                 });
             },
 
+            /**
+             * Will return a promise that is resolved with the session.
+             * Meant for validating the server session and verify if it's still active or not
+             */
+            validateSession: function () {
+                return $http.get(serviceURL + "/authn/session").then(function(response) {
+                    _session = response.data;
+                    return _session;
+                }).catch(function(err) {
+                    $log.warn(err);
+
+                    _session = null;
+                    return _session;
+                });
+            },
+
             getSessionValue: function() {
                 return _session;
             },
@@ -307,6 +327,13 @@
 
             loginInAPopUp: popupLogin,
 
+            /**
+             * This function opens a modal dialog which has a link for login
+             * the callback for this function has a race condition because the login link in the modal uses `loginInAPopUp`
+             * that function uses the embedded `reloadCb` as the callback for the actual login window closing.
+             * these 2 callbacks trigger in the order of `popupCb` first then `modalCb` where modalCb is ignored more often than not
+             * @param {Function} notifyErmrestCB - runs after the login process has been complete
+             */
             loginInAModal: function(notifyErmrestCB) {
                 logInHelper(loginWindowCb, "", notifyErmrestCB, 'modal');
             },

--- a/common/errors.js
+++ b/common/errors.js
@@ -248,9 +248,18 @@
             if (exceptionFlag || window.location.pathname.indexOf('/search/') != -1 || window.location.pathname.indexOf('/viewer/') != -1) return;
 
             // If not authorized, ask user to sign in first
-            if ( (ERMrest && exception instanceof ERMrest.UnauthorizedError)) {
+            if (ERMrest && exception instanceof ERMrest.UnauthorizedError) {
                 // Unauthorized (needs to login)
                 Session.loginInAModal(reloadCb);
+                return;
+            }
+
+            // If conflict Error and user was previously logged in
+            // if session is invalid, ask user to login rather than throw an error
+            if (ERMrest && exception instanceof ERMrest.ConflictError && Session.getSessionValue()) {
+                Session.getSession().then(function (session) {
+                    if (!session) Session.loginInAModal();
+                });
                 return;
             }
 

--- a/common/errors.js
+++ b/common/errors.js
@@ -254,8 +254,8 @@
                 return;
             }
 
-            // If conflict Error and user was previously logged in
-            // if session is invalid, ask user to login rather than throw an error
+            // If Conflict Error and user was previously logged in
+            // AND if session is invalid, ask user to login rather than throw an error
             if (ERMrest && exception instanceof ERMrest.ConflictError && Session.getSessionValue()) {
                 Session.getSession().then(function (session) {
                     if (!session) Session.loginInAModal();

--- a/common/errors.js
+++ b/common/errors.js
@@ -257,7 +257,8 @@
             // If Conflict Error and user was previously logged in
             // AND if session is invalid, ask user to login rather than throw an error
             if (ERMrest && exception instanceof ERMrest.ConflictError && Session.getSessionValue()) {
-                Session.getSession().then(function (session) {
+                // validate session will never throw an error, so it's safe to not write a reject callback or catch clause
+                Session.validateSession().then(function (session) {
                     if (!session) Session.loginInAModal();
                 });
                 return;

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -2,8 +2,8 @@
     'use strict';
     angular.module('chaise.recordcreate', ['chaise.errors','chaise.utils'])
 
-    .factory("recordCreate", ['$cookies', '$log', '$q', '$rootScope', '$window', 'AlertsService', 'DataUtils', 'logActions', 'messageMap', 'modalBox', 'modalUtils', 'Session', 'UriUtils',
-        function($cookies, $log, $q, $rootScope, $window, AlertsService, DataUtils, logActions, messageMap, modalBox, modalUtils, Session, UriUtils) {
+    .factory("recordCreate", ['$cookies', '$log', '$rootScope', '$window', 'modalUtils', 'AlertsService', 'DataUtils', 'UriUtils', 'modalBox', '$q', 'logActions',
+        function($cookies, $log, $rootScope, $window, modalUtils, AlertsService, DataUtils, UriUtils, modalBox, $q, logActions) {
 
         var viewModel = {};
         var GV_recordEditModel = {},
@@ -230,17 +230,11 @@
                     }
                 }).catch(function(exception) {
                     viewModel.submissionButtonDisabled = false;
-                    // non-expensive query, no need to check for exception type before checking for session expired
-                    // this is for creating/update callback, so a session should exist
-                    Session.getSession().then(function (session) {
-                        if (exception instanceof ERMrest.ConflictError && !session) {
-                            Session.loginInAModal();
-                        } else if (exception instanceof ERMrest.NoDataChangedError) {
-                            AlertsService.addAlert(exception.message, 'warning');
-                        } else {
-                            AlertsService.addAlert(exception.message, 'error');
-                        }
-                    });
+                    if (exception instanceof ERMrest.NoDataChangedError) {
+                        AlertsService.addAlert(exception.message, 'warning');
+                    } else {
+                        AlertsService.addAlert(exception.message, 'error');
+                    }
                 });
 
             });

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -2,8 +2,8 @@
     'use strict';
     angular.module('chaise.recordcreate', ['chaise.errors','chaise.utils'])
 
-    .factory("recordCreate", ['$cookies', '$log', '$rootScope', '$window', 'modalUtils', 'AlertsService', 'DataUtils', 'UriUtils', 'modalBox', '$q', 'logActions',
-        function($cookies, $log, $rootScope, $window, modalUtils, AlertsService, DataUtils, UriUtils, modalBox, $q, logActions) {
+    .factory("recordCreate", ['$cookies', '$log', '$q', '$rootScope', '$window', 'AlertsService', 'DataUtils', 'logActions', 'modalBox', 'modalUtils', 'Session', 'UriUtils',
+        function($cookies, $log, $q, $rootScope, $window, AlertsService, DataUtils, logActions, modalBox, modalUtils, Session, UriUtils) {
 
         var viewModel = {};
         var GV_recordEditModel = {},
@@ -230,11 +230,12 @@
                     }
                 }).catch(function(exception) {
                     viewModel.submissionButtonDisabled = false;
-                    if (exception instanceof ERMrest.NoDataChangedError) {
-                        AlertsService.addAlert(exception.message, 'warning');
-                    } else {
-                        AlertsService.addAlert(exception.message, 'error');
-                    }
+                    // assume user had been previously logged in (can't create/update without it)
+                    // if no valid current session, user should re-login
+                    Session.getSession().then(function (session) {
+                        if (!session && exception instanceof ERMrest.ConflictError) throw new ERMrest.UnauthorizedError();
+                        AlertsService.addAlert(exception.message, (exception instanceof ERMrest.NoDataChangedError ? 'warning' : 'error') );
+                    });
                 });
 
             });

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -232,7 +232,8 @@
                     viewModel.submissionButtonDisabled = false;
                     // assume user had been previously logged in (can't create/update without it)
                     // if no valid current session, user should re-login
-                    Session.getSession().then(function (session) {
+                    // validate session will never throw an error, so it's safe to not write a reject callback or catch clause
+                    Session.validateSession().then(function (session) {
                         if (!session && exception instanceof ERMrest.ConflictError) throw new ERMrest.UnauthorizedError();
                         AlertsService.addAlert(exception.message, (exception instanceof ERMrest.NoDataChangedError ? 'warning' : 'error') );
                     });

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -2,8 +2,8 @@
     'use strict';
     angular.module('chaise.recordcreate', ['chaise.errors','chaise.utils'])
 
-    .factory("recordCreate", ['$cookies', '$log', '$rootScope', '$window', 'modalUtils', 'AlertsService', 'DataUtils', 'UriUtils', 'modalBox', '$q', 'logActions',
-        function($cookies, $log, $rootScope, $window, modalUtils, AlertsService, DataUtils, UriUtils, modalBox, $q, logActions) {
+    .factory("recordCreate", ['$cookies', '$log', '$q', '$rootScope', '$window', 'AlertsService', 'DataUtils', 'logActions', 'messageMap', 'modalBox', 'modalUtils', 'Session', 'UriUtils',
+        function($cookies, $log, $q, $rootScope, $window, AlertsService, DataUtils, logActions, messageMap, modalBox, modalUtils, Session, UriUtils) {
 
         var viewModel = {};
         var GV_recordEditModel = {},
@@ -229,6 +229,12 @@
 
                     }
                 }).catch(function(exception) {
+                    if (exception instanceof ERMrest.ConflictError) {
+                        Session.getSession().then(function (session) {
+                            if (!session) throw new ERMrest.UnauthorizedError(messageMap.unauthorizedErrorCode, (messageMap.unauthorizedMessage + messageMap.reportErrorToAdmin));
+                        });
+                    }
+
                     viewModel.submissionButtonDisabled = false;
                     if (exception instanceof ERMrest.NoDataChangedError) {
                         AlertsService.addAlert(exception.message, 'warning');

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -229,18 +229,18 @@
 
                     }
                 }).catch(function(exception) {
-                    if (exception instanceof ERMrest.ConflictError) {
-                        Session.getSession().then(function (session) {
-                            if (!session) throw new ERMrest.UnauthorizedError(messageMap.unauthorizedErrorCode, (messageMap.unauthorizedMessage + messageMap.reportErrorToAdmin));
-                        });
-                    }
-
                     viewModel.submissionButtonDisabled = false;
-                    if (exception instanceof ERMrest.NoDataChangedError) {
-                        AlertsService.addAlert(exception.message, 'warning');
-                    } else {
-                        AlertsService.addAlert(exception.message, 'error');
-                    }
+                    // non-expensive query, no need to check for exception type before checking for session expired
+                    // this is for creating/update callback, so a session should exist
+                    Session.getSession().then(function (session) {
+                        if (exception instanceof ERMrest.ConflictError && !session) {
+                            Session.loginInAModal();
+                        } else if (exception instanceof ERMrest.NoDataChangedError) {
+                            AlertsService.addAlert(exception.message, 'warning');
+                        } else {
+                            AlertsService.addAlert(exception.message, 'error');
+                        }
+                    });
                 });
 
             });


### PR DESCRIPTION
When records are created or updated, and we receive an error, we weren't checking to make sure the user still had an active session. When the user doesn't have an active session (and it's a conflict error... maybe this should be generalized but the use case was for a conflict error), we are now presenting a popup modal for them to go through the login flow.

Note: This reloads the page. There's some refactoring that needs to be done for the session service so this can work without reloading the page.