### PR TITLE
common 409 bug

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -254,16 +254,6 @@
                 return;
             }
 
-            // If Conflict Error and user was previously logged in
-            // AND if session is invalid, ask user to login rather than throw an error
-            if (ERMrest && exception instanceof ERMrest.ConflictError && Session.getSessionValue()) {
-                // validate session will never throw an error, so it's safe to not write a reject callback or catch clause
-                Session.validateSession().then(function (session) {
-                    if (!session) Session.loginInAModal();
-                });
-                return;
-            }
-
             if (exception instanceof Errors.multipleRecordError || exception instanceof Errors.noRecordError){
                 // change defaults
                 pageName = "Recordset";


### PR DESCRIPTION
Upon merging PR #1544 to fix issue #1539, a bug was introduced. This created a broken login loop when an error should have been presented. This was found because the test cases stopped passing in travis.

This happened because of a generalization of the Conflict Error logic and if the user had a previous session. We originally decided (in the issue) to just apply this logic to the `recordedit` application. 

We thought it would make more sense to generalize this to all of the apps so that if a conflict error was reached from a different app (read request) we would handle it in a similar way (prompt the user to login first to verify if it was an issue because of their login state).

What this caused though, was a case where a terminal error was never being thrown if you got a conflict error while being logged in, in `record` or `recordset`. It would do the validate session check and then just swallow up the error.