### PR TITLE
Added "max-width: none;" to the bootstrap table on Record edit page.

### DIFF
--- a/recordedit/recordEdit.css
+++ b/recordedit/recordEdit.css
@@ -82,6 +82,7 @@ td.entity-value {
 #formEdit > table {
   overflow: hidden;
   margin-bottom: 0px;
+  max-width: none;
 }
 
 #formEdit > table > tbody > tr >  td:first-child {


### PR DESCRIPTION
This was required because by default, the table was assigned "max-width: 100%;" which prevented the horizontal scroll from being displayed. 
Tested this change on all browsers : Internet Explorer, Edge, Firefox, Safari and Chrome.