### PR TITLE
add tooltips to facets

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -79,7 +79,7 @@ a .glyphicon-trash {
     color: #428bca;
 }
 
-span[uib-tooltip] {
+span[uib-tooltip], .show-tooltip-border[uib-tooltip] {
     border-bottom: 1px dotted black;
 }
 

--- a/common/templates/faceting/faceting.html
+++ b/common/templates/faceting/faceting.html
@@ -4,10 +4,10 @@
             <!-- TODO test this last active  -->
             <div uib-accordion-group ng-repeat="fc in vm.reference.facetColumns track by $index" is-open="vm.facetModels[$index].isOpen" id="fc-{{$index}}" class="{{lastActiveFacet == $index ? 'focused': ''}}">
                     <uib-accordion-heading>
-                        <h3 class="panel-title accordion-toggle ellipsis" id="fc-heading-{{$index}}" ng-click="toggleFacet($index)" tooltip-enable="tooltipEnabled" uib-tooltip-html="fc.displayname.value" tooltip-placement="bottom" chaise-enable-tooltip-width>
+                        <h3 class="panel-title accordion-toggle ellipsis" id="fc-heading-{{$index}}" ng-click="toggleFacet($index)">
                             <i class="pull-left glyphicon toggle-icon" ng-class="{'glyphicon-chevron-down': vm.facetModels[$index].isOpen, 'glyphicon-chevron-right': !vm.facetModels[$index].isOpen}"></i>
 
-                            <a>
+                            <a class="show-tooltip-border" tooltip-class="facet-header-tooltip" ng-attr-uib-tooltip="{{::(fc.comment) ? fc.comment : undefined}}" ng-attr-tooltip-placement="{{::(fc.comment) ? 'right' : undefined}}">
                                 <span ng-if="::fc.displayname.isHTML" ng-bind-html="::fc.displayname.value"></span>
                                 <span ng-if="::!fc.displayname.isHTML" ng-bind="::fc.displayname.value"></span>
                             </a>

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -139,22 +139,22 @@
                     "compact": ["id"],
                     "filter": {
                         "and": [
-                            {"source": "id", "ux_mode": "choices", "choices": ["1"]},
-                            {"source": "int_col", "ranges": [{"min": "-2"}], "bar_plot": false},
+                            {"source": "id", "ux_mode": "choices", "choices": ["1"], "comment": "ID comment"},
+                            {"source": "int_col", "ranges": [{"min": "-2"}], "bar_plot": false, "comment": "int comment"},
                             {"source": "float_col", "bar_plot": false},
                             {"source": "date_col", "bar_plot": false},
-                            {"source": "timestamp_col", "bar_plot": false},
+                            {"source": "timestamp_col", "bar_plot": false, "comment": "timestamp column"},
                             {"source": "shorttext_col"},
                             {"source": "text_col"},
-                            {"source": "longtext_col"},
+                            {"source": "longtext_col", "comment": "A lengthy comment for the facet of the longtext_col. This should be displyed properly in the facet."},
                             {"source": "markdown_col"},
                             {"source": "boolean_col"},
                             {"source": "jsonb_col"},
                             {"source": [{"outbound": ["faceting", "main_fk1"]}, "id"], "markdown_name": "**F1**"},
-                            {"source": [{"outbound": ["faceting", "main_fk2"]}, "id"], "open": true},
+                            {"source": [{"outbound": ["faceting", "main_fk2"]}, "id"], "open": true, "comment": "open facet"},
                             {"source": [{"inbound": ["faceting", "main_f3_assoc_fk1"]}, {"outbound": ["faceting", "main_f3_assoc_fk2"]}, "term"]},
                             {"source": [{"inbound": ["faceting", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "choices"},
-                            {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term"},
+                            {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term", "comment": "F1 with Term comment"},
                             {"source": "col_w_long_values"}
                         ]
                     }

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -42,7 +42,8 @@ var testParams = {
             option: 2,
             filter: "id: 3",
             numRows: 1,
-            options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10' ]
+            options: [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '10' ],
+            comment: "ID comment"
         },
         {
             name: "int_col",
@@ -65,7 +66,8 @@ var testParams = {
                 max: 12,
                 filter: "int_col: ≤ 12",
                 numRows: 15
-            }
+            },
+            comment: "int comment"
         },
         {
             name: "float_col",
@@ -142,7 +144,8 @@ var testParams = {
                 time: "17:26:12",
                 filter: "timestamp_col: ≤ 2007-12-06 17:26:12",
                 numRows: 15
-            }
+            },
+            comment: "timestamp column"
         },
         {
             name: "text_col",
@@ -160,7 +163,8 @@ var testParams = {
             option: 2,
             filter: "longtext_col: two",
             numRows: 5,
-            options: [ 'Empty', 'one', 'two', 'No Value', 'eight', 'eleven', 'five', 'four', 'nine', 'seven' ]
+            options: [ 'Empty', 'one', 'two', 'No Value', 'eight', 'eleven', 'five', 'four', 'nine', 'seven' ],
+            comment: "A lengthy comment for the facet of the longtext_col. This should be displyed properly in the facet."
         },
         {
             name: "markdown_col",
@@ -205,7 +209,8 @@ var testParams = {
             option: 0,
             filter: "to_name: one",
             numRows: 10,
-            options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
+            options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ],
+            comment: "open facet"
         },
         {
             name: "f3 (term)",
@@ -232,7 +237,8 @@ var testParams = {
             option: 1,
             filter: "F1 with Term : two",
             numRows: 10,
-            options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ]
+            options: [ 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten' ],
+            comment: "F1 with Term comment"
         }
     ],
     multipleFacets: [
@@ -474,7 +480,7 @@ describe("Viewing Recordset with Faceting,", function() {
                 });
             });
 
-            it("should have 1 row selected in show more popup for entity.", function () {
+            it("should have 1 row selected in show more popup for entity.", function (done) {
                 var showMore = chaisePage.recordsetPage.getShowMore(11);
 
                 chaisePage.clickButton(chaisePage.recordsetPage.getFacetOption(11, 0)).then(function () {
@@ -508,7 +514,33 @@ describe("Viewing Recordset with Faceting,", function() {
                 }).then(function (ct) {
                     expect(ct).toBe(15, "Number of visible rows after selecting a second option from the modal is incorrect");
 
-                    return chaisePage.recordsetPage.getClearAllFilters().click();
+                    return chaisePage.clickButton(chaisePage.recordsetPage.getClearAllFilters());
+                }).then(function () {
+                    done();
+                }).catch(function (err) {
+                    done.fail(err);
+                });
+            });
+
+            it("should show correct tooltip for the facets.", function () {
+                testParams.facets.forEach(function (facetParams, idx) {
+                    var facetHeader = chaisePage.recordsetPage.getFacetHeaderById(idx);
+                    var tooltip = chaisePage.getTooltipDiv();
+
+                    // move mouse over the facet header to show the tooltip
+                    browser.actions().mouseMove(facetHeader).perform();
+                    if (facetParams.comment) {
+                        chaisePage.waitForElement(tooltip).then(function () {
+                            expect(tooltip.getText()).toBe(facetParams.comment, "comment missmatch for facet index=" + idx);
+                        }).catch(function (err) {
+                            console.log("error while waiting for tooltip")
+                            console.log(err);
+                        });
+                    }
+
+                    // move mouse to somewhere that doesn't have tooltip just to clear the tooltip from page
+                    browser.actions().mouseMove(chaisePage.recordsetPage.getTotalCount()).perform();
+                    chaisePage.waitForElementInverse(tooltip);
                 });
             });
 

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1021,6 +1021,10 @@ var recordsetPage = function() {
         return element(by.id("fc-heading-" + idx));
     }
 
+    this.getFacetHeaderById = function (idx) {
+        return element(by.id("fc-heading-" + idx)).element(by.css('a'));
+    };
+
     this.getFacetCollapse = function (idx) {
         return element(by.id("fc-" + idx)).element(by.css("div[aria-expanded=true]"));
     }


### PR DESCRIPTION
This PR adds tooltips to facets. Two points of discussion here:

- The placement of facets. At first I went with `bottom`. The same way we are having it for the other parts of the facet panel. But the problem with having it in bottom is that if comment is long, it might go outside the viewport. I could hack it, but decided to go against it and change it to `right`. It's consistent with other tooltips that we're showing on the left side of the page (page title, facet toggle button). Most probably we are showing those on right for the same reason.

- Testing. At first I didn't want to test this like we are doing it in most places (just looking at the uib-tooltip attribute). But as @jrchudy pointed out, I could do the same thing that we're doing for testing permalink tooltips. That's what I did. I am going through all the facets, hovering the mouse over the title and checking for the title. The only issue is that I cannot test the lack of comment. I cannot test that in some cases we shouldn't show the tooltip. The reason behind it is the wait condition. Even when we hover over the title, we're waiting for the tooltip to show up. We cannot test it right away. I left testing this out for now.


issue: #1569 #1484