### PR TITLE
Error spec random failures resolved

### DIFF
--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -63,12 +63,10 @@ describe('Error related test cases,', function() {
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
                 expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
-            }).catch(function (err) {
-                done.fail(err);
-            });
+            }).catch(catchError(done));
         });
 
-        it('On click of OK button the page should redirect to recordset/search page', function(done){
+        it('On click of OK button the page should redirect to recordset page', function(done){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
                 return btn.click();
             }).then (function (){
@@ -77,12 +75,9 @@ describe('Error related test cases,', function() {
               var newapplink = url.replace("record", "recordset"),
                   lastSlash = newapplink.lastIndexOf("/"),
                   recordsetUrl = newapplink.slice(0, lastSlash);
-                expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+                expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
                 done();
-            }).catch( function(err) {
-                console.log(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
+            }).catch(catchError(done));
         });
     });
 
@@ -108,7 +103,7 @@ describe('Error related test cases,', function() {
 
         it('On click of OK button the page should redirect Home page', function(done){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                return browser.executeScript("arguments[0].click();",btn);
+                return chaisePage.clickButton(btn);
             }).then (function (){
                 return browser.driver.getCurrentUrl();
             }).then (function(currentUrl) {
@@ -120,11 +115,7 @@ describe('Error related test cases,', function() {
                   }
                 expect(currentUrl).toBe(homePage, "The redirection from record page to Home page failed");
                 done();
-            }).catch( function(err) {
-                console.log(err);
-                done.fail(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
+            }).catch(catchError(done));
         });
     });
 
@@ -156,12 +147,10 @@ describe('Error related test cases,', function() {
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
                 expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
-            }).catch(function (err) {
-                done.fail(err);
-            });
+            }).catch(catchError(done));
         });
 
-        it('On click of OK button the page should redirect to recordset/search page', function(done){
+        it('On click of OK button the page should redirect to recordset page', function(done){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
                 return btn.click();
             }).then (function (){
@@ -170,11 +159,9 @@ describe('Error related test cases,', function() {
                 var newapplink = url.replace("record", "recordset"),
                     lastSlash = newapplink.lastIndexOf("/"),
                     recordsetUrl = newapplink.slice(0, lastSlash);
-                expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+                expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
                 done();
-            }).catch( function(err) {
-                done.fail(err);
-            });
+            }).catch(catchError(done));
         });
     });
 
@@ -212,10 +199,7 @@ describe('Error related test cases,', function() {
                   }
                  expect(currentUrl).toBe(homePage, "The redirection from recordset page to Home page failed");
                  done();
-            }).catch( function(err) {
-                console.log(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
+            }).catch(catchError(done));
         });
     });
 
@@ -245,11 +229,7 @@ describe('Error related test cases,', function() {
                 // Added OR case to avoid discrepancy in error message when table is deleted
                 expect(errorText == testParams.conflictRecordEditErrorBooking || errorText == testParams.conflictRecordEditErrorAccommodationImg ).toBe(true, "409 Conflict could not be matched! Check conflict during deletion in RecordEdit.");
                 done();
-            }).catch(function(error) {
-                console.log(error);
-                done.fail(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
+            }).catch(catchError(done));
         });
 
         it('On click of Reload button the page should reload itself in Recordedit app', function(done){
@@ -260,11 +240,7 @@ describe('Error related test cases,', function() {
             }).then (function(currentUrl) {
                 expect(currentUrl).toBe(currentUrl, "Reload button could not refresh the recordedit page.");
                 done();
-            }).catch( function(err) {
-                console.log(err);
-                done.fail(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
+            }).catch(catchError(done));
         });
     }).pend("no button on Recordedit for delete");
 
@@ -289,25 +265,19 @@ describe('Error related test cases,', function() {
               return modalTitle.getText();
           }).then(function (text) {
               expect(text).toBe("Confirm Delete", "Deleteion confirmation pop-up could not be opened!");
-              return chaisePage.recordPage.getConfirmDeleteButton().click().then(function() {
-                errModalClass =  chaisePage.recordPage.getModalText();
-                return chaisePage.waitForElement(errModalClass).then(function() {
-                  return errModalClass.getText();
-                });
-              });
+              return chaisePage.recordPage.getConfirmDeleteButton().click();
+          }).then(function() {
+            errModalClass =  chaisePage.recordPage.getModalText();
+            return chaisePage.waitForElement(errModalClass);
+          }).then(function() {
+            return errModalClass.getText();
           }).then(function (errorText) {
               // Added OR case to avoid discrepancy in error message when table is deleted
               expect(errorText == testParams.deletionErrTextBooking || errorText == testParams.deletionErrTextAccommodationImg).toBe(true, "409 Conflict could not be matched! Check conflict during deletion.");
               done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail(err);
-              expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-          });
+          }).catch(catchError(done));
       });
-
     });
-
 
     describe("History for errorneous Url", function(){
 
@@ -328,9 +298,7 @@ describe('Error related test cases,', function() {
             }).then (function(currentUrl) {
                 expect(currentUrl).toContain('id=269111', "The back button failed to go back to previous page.");
                 done();
-            }).catch(function(error) {
-                done.fail(error);
-            });
+            }).catch(catchError(done));
         });
 
     });
@@ -354,9 +322,7 @@ describe('Error related test cases,', function() {
                 chaisePage.waitForElement(closeModal);
                 expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
                 done();
-            }).catch(function(error) {
-                done.fail(error);
-            });
+            }).catch(catchError(done));
         });
     });
 
@@ -378,10 +344,7 @@ describe('Error related test cases,', function() {
               chaisePage.waitForElement(closeModal);
               expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
               done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
     });
@@ -405,10 +368,7 @@ describe('Error related test cases,', function() {
           }).then(function (errorText) {
               expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
               done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
       it('On click of OK button the page should reload the page without paging condition but with invalid filter conditions', function(done){
@@ -423,10 +383,7 @@ describe('Error related test cases,', function() {
            }).then(function (errorText) {
                expect(errorText).toBe(testParams.facetErrorstext.invalidFilterOperatorErrorBody, "Error action text did not match");
                done();
-          }).catch( function(err) {
-              console.log(err);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
       it('On click of OK button the page should redirect to RecordSet', function(done){
@@ -437,10 +394,7 @@ describe('Error related test cases,', function() {
              recordsetWithoutFacetUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name + "/";
              expect(currentUrl).toBe(recordsetWithoutFacetUrl, "The redirection to Recordset page failed");
              done();
-          }).catch( function(err) {
-              console.log(err);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
     });
@@ -458,7 +412,6 @@ describe('Error related test cases,', function() {
 
       it("should be returned Invalid Page Criteria", function (done) {
 
-
           var modalActionBody = chaisePage.recordEditPage.getModalActionBody();
 
           chaisePage.waitForElement(modalTitle).then(function(){
@@ -469,10 +422,7 @@ describe('Error related test cases,', function() {
           }).then(function (errorText) {
               expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
               done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
       it('On click of OK button the page should reload the page without paging conditions', function(done){
@@ -484,10 +434,7 @@ describe('Error related test cases,', function() {
              recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
              expect(currentUrl).toBe(recordsetPage, "The redirection to RecordEdit page failed");
              done();
-          }).catch( function(err) {
-              console.log(err);
-              done.fail();
-          });
+          }).catch(catchError(done));
       });
 
     });
@@ -512,24 +459,18 @@ describe('Error related test cases,', function() {
               }).then(function (errorText) {
                   expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
                   done();
-              }).catch(function(error) {
-                  console.log(error);
-                  done.fail();
-              });
+              }).catch(catchError(done));
           });
 
           it('On click of OK button the page should reload the page without paging conditions', function(done){
               chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                  browser.executeScript("arguments[0].click();",btn);
+                  chaisePage.clickButton(btn);
                   return browser.driver.getCurrentUrl();
               }).then (function(currentUrl) {
                  recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
                  expect(currentUrl).toBe(recordsetPage, "The redirection to Recordset page failed");
                  done();
-              }).catch( function(err) {
-                  console.log(err);
-                  done.fail();
-              });
+              }).catch(catchError(done));
           });
 
         });
@@ -545,28 +486,24 @@ describe('Error related test cases,', function() {
 
             it('An error modal window should appear with Record Not Found title', function(done){
               chaisePage.waitForElement(element(by.css('.modal-dialog '))).then(function() {
-                chaisePage.recordPage.getErrorModalTitle().then(function(modalTitle) {
+                  return chaisePage.recordPage.getErrorModalTitle();
+                }).then(function(modalTitle) {
                   expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
                   done();
-                });
-              });
+                }).catch(catchError(done));
             });
 
-            it('On click of OK button the page should redirect to recordset/search page', function(done){
+            it('On click of OK button the page should redirect to recordset page', function(done){
                 chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                    browser.executeScript("arguments[0].click();",btn);
+                    chaisePage.clickButton(btn);
                     return browser.driver.getCurrentUrl();
                 }).then (function(currentUrl) {
                     var newapplink = url.replace("recordedit", "recordset"),
                         lastSlash = newapplink.lastIndexOf("/"),
                         recordsetUrl = newapplink.slice(0, lastSlash);
-                    expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+                    expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
                     done();
-                }).catch( function(err) {
-                    console.log(err);
-                    done.fail(err);
-                    expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-                });
+                }).catch(catchError(done));
             });
         });
 
@@ -601,15 +538,12 @@ describe('Error related test cases,', function() {
                       recordsetUrl = newapplink.slice(0, lastSlash);
                     expect(currentUrl).toBe(recordsetUrl, "The redirection from recordedit page to recordset failed");
                     done();
-                }).catch( function(err) {
-                    console.log(err);
-                    done.fail(err);
-                    expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-                });
+                }).catch(catchError(done));
             });
         });
-
-
-
-
+        var catchError =function (done) {
+          return function (err) {
+           done.fail(err);
+         }
+        }
 });

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -38,7 +38,7 @@ describe('Error related test cases,', function() {
     describe("For no record found in Record app", function() {
 
         beforeAll(function() {
-          browser.ignoreSynchronization=true;
+          browser.ignoreSynchronization = true;
             url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
             browser.get(url);
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));
@@ -297,9 +297,6 @@ describe('Error related test cases,', function() {
               });
           }).then(function (errorText) {
               // Added OR case to avoid discrepancy in error message when table is deleted
-              console.log(errorText);
-              console.log(testParams.deletionErrTextBooking);
-              console.log(testParams.deletionErrTextAccommodationImg);
               expect(errorText == testParams.deletionErrTextBooking || errorText == testParams.deletionErrTextAccommodationImg).toBe(true, "409 Conflict could not be matched! Check conflict during deletion.");
               done();
           }).catch(function(error) {

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -56,16 +56,19 @@ describe('Error related test cases,', function() {
 
         it('Error modal should Show Error Details', function(done){
             var showDetails = chaisePage.errorModal.getToggleDetailsLink();
+            var errorDetails = chaisePage.errorModal.getErrorDetails();
+            chaisePage.waitForElement(showDetails);
             showDetails.click().then(function(){
+                chaisePage.waitForElement(errorDetails);
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
-                expect(chaisePage.errorModal.getErrorDetails().getText()).toContain("Error", "error missmatch.");
+                expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
             }).catch(function (err) {
                 done.fail(err);
             });
         });
 
-        it('On click of OK button the page should redirect to recordset/search page', function(){
+        it('On click of OK button the page should redirect to recordset/search page', function(done){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
                 return btn.click();
             }).then (function (){
@@ -75,8 +78,51 @@ describe('Error related test cases,', function() {
                   lastSlash = newapplink.lastIndexOf("/"),
                   recordsetUrl = newapplink.slice(0, lastSlash);
                 expect(currentUrl).toBe(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+                done();
             }).catch( function(err) {
                 console.log(err);
+                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
+            });
+        });
+    });
+
+    describe("For table not found error in Record app", function() {
+
+        beforeAll(function() {
+          browser.ignoreSynchronization = true;
+            url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.tableNotFound +  "/id=10007";
+            browser.refresh();
+            browser.get(url);
+            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
+        });
+
+        it('An error modal window should appear with Item Not Found title', function(){
+            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
+            expect(modalTitle).toBe("Item Not Found", "The title of no table error pop is not correct");
+        });
+
+        it('Error modal text indicates users about error and provides them with navigation options', function(){
+            var modalText = chaisePage.recordPage.getModalText();
+            expect(modalText.getText()).toBe(testParams.tableNotFoundModalText(), "The message in modal pop is not correct");
+        });
+
+        it('On click of OK button the page should redirect Home page', function(done){
+            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                return browser.executeScript("arguments[0].click();",btn);
+            }).then (function (){
+                return browser.driver.getCurrentUrl();
+            }).then (function(currentUrl) {
+              var homeAppUrl = browser.params.url,
+                  homePage =   homeAppUrl.slice(0, homeAppUrl.slice(0, homeAppUrl.lastIndexOf("/")).lastIndexOf("/") + 1);
+                  //Travis local URL has different structure
+                  if (process.env.TRAVIS) {
+                      homePage = currentUrl;
+                  }
+                expect(currentUrl).toBe(homePage, "The redirection from record page to Home page failed");
+                done();
+            }).catch( function(err) {
+                console.log(err);
+                done.fail(err);
                 expect('Something went wrong with this promise chain.').toBe('Please see error message.');
             });
         });
@@ -85,7 +131,7 @@ describe('Error related test cases,', function() {
     describe("For multiple records error in Record app", function() {
 
         beforeAll(function() {
-          browser.ignoreSynchronization=true;
+          browser.ignoreSynchronization = true;
             url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable +  "/id=10007";
             browser.get(url);
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));
@@ -103,9 +149,12 @@ describe('Error related test cases,', function() {
 
         it('Error modal should Show Error Details', function(done){
             var showDetails = chaisePage.errorModal.getToggleDetailsLink();
+            var errorDetails = chaisePage.errorModal.getErrorDetails();
+            chaisePage.waitForElement(showDetails);
             showDetails.click().then(function(){
+                chaisePage.waitForElement(errorDetails);
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
-                expect(chaisePage.errorModal.getErrorDetails().getText()).toContain("Error", "error missmatch.");
+                expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
             }).catch(function (err) {
                 done.fail(err);
@@ -129,50 +178,12 @@ describe('Error related test cases,', function() {
         });
     });
 
-    describe("For table not found error in Record app", function() {
-
-        beforeAll(function() {
-          browser.ignoreSynchronization=true;
-            url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.tableNotFound +  "/id=10007";
-            browser.get(url);
-            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
-        });
-
-        it('An error modal window should appear with Item Not Found title', function(){
-            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
-            expect(modalTitle).toBe("Item Not Found", "The title of no table error pop is not correct");
-        });
-
-        it('Error modal text indicates users about error and provides them with navigation options', function(){
-            var modalText = chaisePage.recordPage.getModalText();
-            expect(modalText.getText()).toBe(testParams.tableNotFoundModalText(), "The message in modal pop is not correct");
-        });
-
-        it('On click of OK button the page should redirect Home page', function(){
-            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                return btn.click();
-            }).then (function (){
-                return browser.driver.getCurrentUrl();
-            }).then (function(currentUrl) {
-              var homeAppUrl = browser.params.url,
-                  homePage =   homeAppUrl.slice(0, homeAppUrl.slice(0, homeAppUrl.lastIndexOf("/")).lastIndexOf("/") + 1);
-                  //Travis local URL has different structure
-                  if (process.env.TRAVIS) {
-                      homePage = currentUrl;
-                  }
-                expect(currentUrl).toBe(homePage, "The redirection from record page to Home page failed");
-            }).catch( function(err) {
-                console.log(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
-        });
-    });
-
     describe("For negative page size in schema definition in Recordset app", function() {
 
         beforeAll(function() {
-          browser.ignoreSynchronization=true;
+          browser.ignoreSynchronization = true;
             url = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable;
+            browser.refresh();
             browser.get(url);
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));
         });
@@ -187,7 +198,7 @@ describe('Error related test cases,', function() {
             expect(modalText.getText()).toBe(testParams.negativeLimitErrorText, "The message in modal pop is not correct");
         });
 
-        it('On click of OK button the page should redirect to Home page', function(){
+        it('On click of OK button the page should redirect to Home page', function(done){
             chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
                 return btn.click();
             }).then (function (){
@@ -200,6 +211,7 @@ describe('Error related test cases,', function() {
                       homePage = currentUrl;
                   }
                  expect(currentUrl).toBe(homePage, "The redirection from recordset page to Home page failed");
+                 done();
             }).catch( function(err) {
                 console.log(err);
                 expect('Something went wrong with this promise chain.').toBe('Please see error message.');
@@ -207,52 +219,17 @@ describe('Error related test cases,', function() {
         });
     });
 
-    describe("For negative page limit in Recordedit app", function() {
-
-        beforeAll(function() {
-          browser.ignoreSynchronization=true;
-            url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable +"/?limit=-1";
-            browser.get(url);
-            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
-        });
-
-        it('An error modal window should appear with Invalid Input title', function(){
-            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
-            expect(modalTitle).toBe("Invalid Input", "The title of Invalid Input error pop is not correct");
-        });
-
-        it('Error modal text indicates users about error and provides them with navigation options to Home Page', function(){
-            var modalText = chaisePage.recordPage.getModalText();
-            expect(modalText.getText()).toBe(testParams.sizeNotValidModalText(), "The message in modal pop is not correct");
-        });
-
-        it('On click of OK button the page should redirect to RecordSet', function(){
-            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                return btn.click();
-            }).then (function (){
-                return browser.driver.getCurrentUrl();
-            }).then (function(currentUrl) {
-              var newapplink = url.replace("recordedit", "recordset"),
-                  lastSlash = newapplink.lastIndexOf("/"),
-                  recordsetUrl = newapplink.slice(0, lastSlash);
-                expect(currentUrl).toBe(recordsetUrl, "The redirection from recordedit page to recordset failed");
-            }).catch( function(err) {
-                console.log(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
-        });
-    });
 
     describe("For reload button to start over in Recordedit app", function() {
 
         beforeAll(function() {
-          browser.ignoreSynchronization=true;
+          browser.ignoreSynchronization = true;
             url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +"/id=2002";
             browser.get(url);
             chaisePage.waitForElement(chaisePage.recordEditPage.getEntityTitleElement());
         });
 
-        it("An error modal window should appear with Conflict.", function () {
+        it("An error modal window should appear with Conflict.", function (done) {
             var modalTitle = chaisePage.recordPage.getConfirmDeleteTitle(),
                 deleteReccordBtn = chaisePage.recordEditPage.getDeleteRecordButton();
             deleteReccordBtn.click().then(function () {
@@ -267,65 +244,40 @@ describe('Error related test cases,', function() {
             }).then(function (errorText) {
                 // Added OR case to avoid discrepancy in error message when table is deleted
                 expect(errorText == testParams.conflictRecordEditErrorBooking || errorText == testParams.conflictRecordEditErrorAccommodationImg ).toBe(true, "409 Conflict could not be matched! Check conflict during deletion in RecordEdit.");
+                done();
             }).catch(function(error) {
                 console.log(error);
+                done.fail(err);
                 expect('Something went wrong with this promise chain.').toBe('Please see error message.');
             });
         });
 
-        it('On click of Reload button the page should reload itself in Recordedit app', function(){
+        it('On click of Reload button the page should reload itself in Recordedit app', function(done){
             chaisePage.recordPage.getErrorModalReloadButton().then(function(btn){
                 return btn.click();
             }).then (function (){
                 return browser.driver.getCurrentUrl();
             }).then (function(currentUrl) {
                 expect(currentUrl).toBe(currentUrl, "Reload button could not refresh the recordedit page.");
+                done();
             }).catch( function(err) {
                 console.log(err);
+                done.fail(err);
                 expect('Something went wrong with this promise chain.').toBe('Please see error message.');
             });
         });
     }).pend("no button on Recordedit for delete");
 
-    describe("For no record found in RecordEdit app", function() {
-
-        beforeAll(function() {
-          browser.ignoreSynchronization=true;
-            url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
-            browser.get(url);
-            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
-        });
-
-        it('An error modal window should appear with Record Not Found title', function(){
-            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
-            expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
-        });
-
-        it('On click of OK button the page should redirect to recordset/search page', function(){
-            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                return btn.click();
-            }).then (function (){
-                return browser.driver.getCurrentUrl();
-            }).then (function(currentUrl) {
-                var newapplink = url.replace("recordedit", "recordset"),
-                    lastSlash = newapplink.lastIndexOf("/"),
-                    recordsetUrl = newapplink.slice(0, lastSlash);
-                expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
-            }).catch( function(err) {
-                console.log(err);
-                expect('Something went wrong with this promise chain.').toBe('Please see error message.');
-            });
-        });
-    });
-
     describe("Error formatting during 409 check", function(){
 
       beforeAll(function() {
-          var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002";
-          browser.get(url);
+        browser.ignoreSynchronization = true;
+        var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002";
+        browser.get(url);
       });
 
-      it("should be returned as a 409 error with deletion conflict.", function () {
+      it("should be returned as a 409 error with deletion conflict.", function (done) {
+
           var modalTitle = chaisePage.recordPage.getConfirmDeleteTitle(),
               deleteReccordBtn = chaisePage.recordPage.getDeleteRecordButton();
 
@@ -337,98 +289,100 @@ describe('Error related test cases,', function() {
               return modalTitle.getText();
           }).then(function (text) {
               expect(text).toBe("Confirm Delete", "Deleteion confirmation pop-up could not be opened!");
-              chaisePage.recordPage.getConfirmDeleteButton().click();
-              errModalClass =  chaisePage.recordPage.getModalText();
-              chaisePage.waitForElement(errModalClass);
-              return errModalClass.getText();
+              return chaisePage.recordPage.getConfirmDeleteButton().click().then(function() {
+                errModalClass =  chaisePage.recordPage.getModalText();
+                return chaisePage.waitForElement(errModalClass).then(function() {
+                  return errModalClass.getText();
+                });
+              });
           }).then(function (errorText) {
               // Added OR case to avoid discrepancy in error message when table is deleted
+              console.log(errorText);
+              console.log(testParams.deletionErrTextBooking);
+              console.log(testParams.deletionErrTextAccommodationImg);
               expect(errorText == testParams.deletionErrTextBooking || errorText == testParams.deletionErrTextAccommodationImg).toBe(true, "409 Conflict could not be matched! Check conflict during deletion.");
+              done();
           }).catch(function(error) {
               console.log(error);
+              done.fail(err);
               expect('Something went wrong with this promise chain.').toBe('Please see error message.');
           });
       });
 
     });
 
-    describe("Error check for invalid paging changes in RecordSet", function(){
 
-      beforeAll(function() {
-          pageTestUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
-          browser.get(pageTestUrl);
-      });
+    describe("History for errorneous Url", function(){
 
-      it("should be returned Invalid Page Criteria", function (done) {
-          var modalTitle = chaisePage.recordEditPage.getModalTitle(),
-              modalActionBody = chaisePage.recordEditPage.getModalActionBody();
+        beforeAll(function() {
+            browser.ignoreSynchronization = true;
+            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=269111";
+            browser.get(url);
+            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
+        });
 
-          chaisePage.waitForElement(modalTitle).then(function(){
-              return modalTitle.getText();
-          }).then(function (text) {
-              expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
-              return modalActionBody.getText();
-          }).then(function (errorText) {
-              expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
-              done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail();
-          });
-      });
-
-      it('On click of OK button the page should reload the page without paging conditions', function(done){
-          chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-              btn.click();
-              return browser.driver.getCurrentUrl();
-          }).then (function(currentUrl) {
-             recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
-             expect(currentUrl).toBe(recordsetPage, "The redirection to Recordset page failed");
-             done()
-          }).catch( function(err) {
-              console.log(err);
-              done.fail();
-          });
-      });
+        it('After clicking back button initial page should appear', function(done){
+            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                return btn.click();
+            }).then (function (){
+                return browser.navigate().back();
+            }).then(function (){
+                return browser.driver.getCurrentUrl();
+            }).then (function(currentUrl) {
+                expect(currentUrl).toContain('id=269111', "The back button failed to go back to previous page.");
+                done();
+            }).catch(function(error) {
+                done.fail(error);
+            });
+        });
 
     });
 
-    describe("Error check for invalid paging changes in RecordEdit", function(){
+    describe("Dismissible Error Modal when using Navbar Delete button", function(){
+
+        beforeAll(function() {
+            browser.ignoreSynchronization = true;
+            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002";
+            browser.get(url);
+            deleteBtn  = chaisePage.recordPage.getDeleteRecordButton();
+        });
+
+        it('Error modal is dismissible in case of conflict/forbidden error', function(done){
+            chaisePage.waitForElement(deleteBtn).then(function(){
+                return deleteBtn.click();
+            }).then(function () {
+                return chaisePage.recordPage.getConfirmDeleteButton().click();
+            }).then (function() {
+                closeModal = chaisePage.recordEditPage.getModalCloseBtn();
+                chaisePage.waitForElement(closeModal);
+                expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
+                done();
+            }).catch(function(error) {
+                done.fail(error);
+            });
+        });
+    });
+
+    // delete from ellipses
+    describe("Dismissible Error Modal when using Ellipses delete button", function(){
 
       beforeAll(function() {
-          pageTestUrl = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
-          browser.get(pageTestUrl);
+          browser.ignoreSynchronization = true;
+          var url = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.fileTable;
+          browser.get(url);
+          deleteBtnEllipses  = chaisePage.recordsetPage.getDeleteActionButtons().first();
+          chaisePage.waitForElement(deleteBtnEllipses);
       });
-
-      it("should be returned Invalid Page Criteria", function (done) {
-          var modalTitle = chaisePage.recordEditPage.getModalTitle(),
-              modalActionBody = chaisePage.recordEditPage.getModalActionBody();
-
-          chaisePage.waitForElement(modalTitle).then(function(){
-              return modalTitle.getText();
-          }).then(function (text) {
-              expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
-              return modalActionBody.getText();
-          }).then(function (errorText) {
-              expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
+        it('Error modal is dismissible in case of conflict/forbidden error while deleting from ellipses', function(done){
+            deleteBtnEllipses.click().then(function(){;
+              return chaisePage.recordsetPage.getConfirmDeleteButton().click();
+            }).then (function() {
+              closeModal = chaisePage.recordEditPage.getModalCloseBtn();
+              chaisePage.waitForElement(closeModal);
+              expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
               done();
           }).catch(function(error) {
               console.log(error);
-              done.fail();
-          });
-      });
-
-      it('On click of OK button the page should reload the page without paging conditions', function(done){
-          chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-              return btn.click();
-          }).then(function () {
-              return browser.driver.getCurrentUrl();
-          }).then (function(currentUrl) {
-             recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
-             expect(currentUrl).toBe(recordsetPage, "The redirection to RecordEdit page failed");
-             done();
-          }).catch( function(err) {
-              console.log(err);
               done.fail();
           });
       });
@@ -438,6 +392,7 @@ describe('Error related test cases,', function() {
     describe("Error check for invalid filter in RecordEdit", function(){
 
       beforeAll(function() {
+          browser.ignoreSynchronization = true;
           pageTestUrl = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id::gt:2002@after()";
           browser.get(pageTestUrl);
           modalTitle = chaisePage.recordEditPage.getModalTitle();
@@ -493,23 +448,29 @@ describe('Error related test cases,', function() {
 
     });
 
-    describe("Error check for invalid facet filter changes", function(){
+    describe("Error check for invalid paging changes in RecordEdit", function(){
+
       beforeAll(function() {
-          facetTestUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/*::facets::N14IghgdgJiBcDaoDOB7ArgJwMYFM7i1ySQEsUIQAaELACxRKLnhADEAhABm+4EZOALCAC6AXzFA@sort(release_date::desc::,id)";
-          browser.get(facetTestUrl);
+        browser.ignoreSynchronization = true;
+        pageTestUrl = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
+        browser.refresh();
+        browser.get(pageTestUrl);
+        modalTitle = chaisePage.recordEditPage.getModalTitle();
+        chaisePage.waitForElement(element(by.css('.modal-dialog ')));
       });
 
       it("should be returned Invalid Page Criteria", function (done) {
-          var modalTitle = chaisePage.recordEditPage.getModalTitle(),
-              modalActionBody = chaisePage.recordEditPage.getModalActionBody();
+
+
+          var modalActionBody = chaisePage.recordEditPage.getModalActionBody();
 
           chaisePage.waitForElement(modalTitle).then(function(){
               return modalTitle.getText();
           }).then(function (text) {
-              expect(text).toBe(testParams.facetErrorstext.invalidFacetFilterTitle, "Invalid Facet Filters error pop-up could not be opened!");
+              expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
               return modalActionBody.getText();
           }).then(function (errorText) {
-              expect(errorText).toBe(testParams.facetErrorstext.invalidFacetFilterBody, "Error action text did not match");
+              expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
               done();
           }).catch(function(error) {
               console.log(error);
@@ -517,94 +478,140 @@ describe('Error related test cases,', function() {
           });
       });
 
-      it('On click of OK button the page should reload the page without facet filter conditions', function(done){
+      it('On click of OK button the page should reload the page without paging conditions', function(done){
           chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-              btn.click();
+              return btn.click();
+          }).then(function () {
               return browser.driver.getCurrentUrl();
           }).then (function(currentUrl) {
-             recordsetWithoutFacetUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/@sort(release_date::desc::,id)"
-             expect(currentUrl).toBe(recordsetWithoutFacetUrl, "The redirection to Recordset page failed");
+             recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
+             expect(currentUrl).toBe(recordsetPage, "The redirection to RecordEdit page failed");
              done();
           }).catch( function(err) {
               console.log(err);
               done.fail();
           });
       });
-    });
-
-    describe("History for errorneous Url", function(){
-
-        beforeAll(function() {
-            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=269111";
-            browser.get(url);
-            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
-        });
-
-        it('After clicking back button initial page should appear', function(done){
-            chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
-                return btn.click();
-            }).then (function (){
-                return browser.navigate().back();
-            }).then(function (){
-                return browser.driver.getCurrentUrl();
-            }).then (function(currentUrl) {
-                expect(currentUrl).toContain('id=269111', "The back button failed to go back to previous page.");
-                done();
-            }).catch(function(error) {
-                done.fail(error);
-            });
-        });
 
     });
 
-    describe("Dismissible Error Modal when using Navbar Delete button", function(){
+        describe("Error check for invalid paging changes in RecordSet", function(){
 
-        beforeAll(function() {
-            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002";
-            browser.get(url);
-            deleteBtn  = chaisePage.recordPage.getDeleteRecordButton();
-        });
-
-        it('Error modal is dismissible in case of conflict/forbidden error', function(done){
-            chaisePage.waitForElement(deleteBtn).then(function(){
-                return deleteBtn.click();
-            }).then(function () {
-                return chaisePage.recordPage.getConfirmDeleteButton().click();
-            }).then (function() {
-                closeModal = chaisePage.recordEditPage.getModalCloseBtn();
-                chaisePage.waitForElement(closeModal);
-                expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
-                done();
-            }).catch(function(error) {
-                done.fail(error);
-            });
-        });
-    });
-
-    // delete from ellipses
-    describe("Dismissible Error Modal when using Ellipses delete button", function(){
-
-      beforeAll(function() {
-          var url = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.fileTable;
-          browser.get(url);
-          deleteBtnEllipses  = chaisePage.recordsetPage.getDeleteActionButtons().first();
-          chaisePage.waitForElement(deleteBtnEllipses);
-      });
-        it('Error modal is dismissible in case of conflict/forbidden error while deleting from ellipses', function(done){
-            deleteBtnEllipses.click().then(function(){;
-              return chaisePage.recordsetPage.getConfirmDeleteButton().click();
-            }).then (function() {
-              closeModal = chaisePage.recordEditPage.getModalCloseBtn();
-              chaisePage.waitForElement(closeModal);
-              expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
-              done();
-          }).catch(function(error) {
-              console.log(error);
-              done.fail();
+          beforeAll(function() {
+            browser.ignoreSynchronization = true;
+              pageTestUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
+              browser.get(pageTestUrl);
           });
-      });
 
-    });
+          it("should be returned Invalid Page Criteria", function (done) {
+              var modalTitle = chaisePage.recordEditPage.getModalTitle(),
+                  modalActionBody = chaisePage.recordEditPage.getModalActionBody();
+
+              chaisePage.waitForElement(modalTitle).then(function(){
+                  return modalTitle.getText();
+              }).then(function (text) {
+                  expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
+                  return modalActionBody.getText();
+              }).then(function (errorText) {
+                  expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
+                  done();
+              }).catch(function(error) {
+                  console.log(error);
+                  done.fail();
+              });
+          });
+
+          it('On click of OK button the page should reload the page without paging conditions', function(done){
+              chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                  browser.executeScript("arguments[0].click();",btn);
+                  return browser.driver.getCurrentUrl();
+              }).then (function(currentUrl) {
+                 recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
+                 expect(currentUrl).toBe(recordsetPage, "The redirection to Recordset page failed");
+                 done();
+              }).catch( function(err) {
+                  console.log(err);
+                  done.fail();
+              });
+          });
+
+        });
+
+        describe("For no record found in RecordEdit app", function() {
+
+            beforeAll(function() {
+              browser.ignoreSynchronization = true;
+                url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
+                browser.refresh();
+                browser.get(url);
+            });
+
+            it('An error modal window should appear with Record Not Found title', function(done){
+              chaisePage.waitForElement(element(by.css('.modal-dialog '))).then(function() {
+                chaisePage.recordPage.getErrorModalTitle().then(function(modalTitle) {
+                  expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
+                  done();
+                });
+              });
+            });
+
+            it('On click of OK button the page should redirect to recordset/search page', function(done){
+                chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                    browser.executeScript("arguments[0].click();",btn);
+                    return browser.driver.getCurrentUrl();
+                }).then (function(currentUrl) {
+                    var newapplink = url.replace("recordedit", "recordset"),
+                        lastSlash = newapplink.lastIndexOf("/"),
+                        recordsetUrl = newapplink.slice(0, lastSlash);
+                    expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset/search in case of multiple records failed");
+                    done();
+                }).catch( function(err) {
+                    console.log(err);
+                    done.fail(err);
+                    expect('Something went wrong with this promise chain.').toBe('Please see error message.');
+                });
+            });
+        });
+
+        describe("For negative page limit in Recordedit app", function() {
+
+            beforeAll(function() {
+              browser.ignoreSynchronization = true;
+                url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable +"/?limit=-1";
+                browser.refresh();
+                browser.get(url);
+                chaisePage.waitForElement(element(by.css('.modal-dialog ')));
+            });
+
+            it('An error modal window should appear with Invalid Input title', function(){
+                var modalTitle = chaisePage.recordPage.getErrorModalTitle();
+                expect(modalTitle).toBe("Invalid Input", "The title of Invalid Input error pop is not correct");
+            });
+
+            it('Error modal text indicates users about error and provides them with navigation options to Home Page', function(){
+                var modalText = chaisePage.recordPage.getModalText();
+                expect(modalText.getText()).toBe(testParams.sizeNotValidModalText(), "The message in modal pop is not correct");
+            });
+
+            it('On click of OK button the page should redirect to RecordSet', function(done){
+                chaisePage.recordPage.getErrorModalOkButton().then(function(btn){
+                    return btn.click();
+                }).then (function (){
+                    return browser.driver.getCurrentUrl();
+                }).then (function(currentUrl) {
+                  var newapplink = url.replace("recordedit", "recordset"),
+                      lastSlash = newapplink.lastIndexOf("/"),
+                      recordsetUrl = newapplink.slice(0, lastSlash);
+                    expect(currentUrl).toBe(recordsetUrl, "The redirection from recordedit page to recordset failed");
+                    done();
+                }).catch( function(err) {
+                    console.log(err);
+                    done.fail(err);
+                    expect('Something went wrong with this promise chain.').toBe('Please see error message.');
+                });
+            });
+        });
+
 
 
 


### PR DESCRIPTION
Following modifications have been done to fix the issue : 
1. btn.click() was not getting registered in some cases so changed it to browser.executeScript("arguments[0].click();",btn);
2. Fixed chaining issues in some of the it blocks.
3. waitForElement(element) added in some of the failing test cases.
4. browser.ignoreSynchronization added for all describe blocks.
5. done() added in it blocks with chaining.
6. browser.refresh() added in the beforeAll() blocks of all the describe
blocks following a redirect to the recordset page. [This needs to be
investigated further]. This is the case where (sometimes) there is
timeout because on redirecting to the recordset page, it stays on the
app for too long causing the next describe block to fail.
7. Reordered the describe blocks for some fixing some test cases.