### PR TITLE
Manual test for checking placement of tooltips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ FullFeaturesParallel=test/e2e/specs/all-features/protractor.conf.js
 FullFeaturesConfirmationParallel=test/e2e/specs/all-features-confirmation/protractor.conf.js
 DeleteProhibitedParallel=test/e2e/specs/delete-prohibited/protractor.conf.js
 DefaultConfigParallel=test/e2e/specs/default-config/protractor.conf.js
+# Setup for manual tests
+Manualrecordset=test/manual/specs/recordset.conf.js
 
 
 NAVBAR_TESTS=$(E2Enavbar) $(E2EnavbarHeadTitle)
@@ -77,6 +79,8 @@ PARALLEL_TESTS=$(FullFeaturesParallel) $(FullFeaturesConfirmationParallel) $(Del
 VIEWER_TESTS=$(E2EDviewer)
 
 ALL_TESTS=$(NAVBAR_TESTS) $(RECORD_TESTS) $(RECORDSET_TESTS) $(RECORDADD_TESTS) $(RECORDEDIT_TESTS) $(PERMISSIONS_TESTS) $(FOOTER_TESTS) $(ERRORS_TESTS)
+
+ALL_MANUAL_TESTS=$(Manualrecordset)
 
 define make_test
 	rc=0; \
@@ -153,6 +157,10 @@ testfooter: test-FOOTER_TESTS
 #Rule to run the default chaise configuration tests in parallel
 .PHONY: testerrors
 testerrors: test-ERRORS_TESTS
+
+# Rule to setup schema and data for manual tests
+.PHONY: testmanually
+testmanually: test-ALL_MANUAL_TESTS
 
 # Rule to run tests
 .PHONY: test

--- a/test/e2e/utils/protractor.configuration.js
+++ b/test/e2e/utils/protractor.configuration.js
@@ -43,7 +43,11 @@ exports.getConfig = function(options) {
   var testConfiguration = options.testConfiguration;
   if (options.configFileName) {
     var configFileName = options.configFileName;
-    testConfiguration =  require('../data_setup/config/' + configFileName);
+    if(options.manualTestConfig) {
+      testConfiguration =  require('../../manual/data_setup/config/' + configFileName);
+    } else {
+      testConfiguration =  require('../data_setup/config/' + configFileName);
+    }
   }
 
   var dataSetup = require('./protractor.parameterize.js');
@@ -53,7 +57,11 @@ exports.getConfig = function(options) {
   for (var i = 0; i < schemaConfigs.length; i++) {
       var schemaConfig = schemaConfigs[i];
       if (typeof schemaConfig === 'string') {
+        if(options.manualTestConfig) {
+          schemaConfigs[i] = require(process.env.PWD + "/test/manual/data_setup/config/" + schemaConfig);
+        } else {
           schemaConfigs[i] = require(process.env.PWD + "/test/e2e/data_setup/config/" + schemaConfig);
+        }
       }
   }
 

--- a/test/manual/data_setup/config/config-recordset.json
+++ b/test/manual/data_setup/config/config-recordset.json
@@ -1,0 +1,15 @@
+{
+    "catalog": {},
+    "schema": {
+        "name": "product-recordset",
+        "createNew": true,
+        "path": "test/manual/data_setup/schema/product-recordset.json"
+    },
+    "tables": {
+        "createNew": true
+    },
+    "entities": {
+        "createNew": true,
+        "path": "test/manual/data_setup/data/recordset"
+    }
+}

--- a/test/manual/data_setup/config/dev-recordset.json
+++ b/test/manual/data_setup/config/dev-recordset.json
@@ -1,0 +1,9 @@
+{
+    "setup": {
+        "schemaConfigurations": [
+            "config-recordset.json"
+        ],
+        "schema": "product-recordset"
+    },
+    "cleanup" : true
+}

--- a/test/manual/data_setup/data/recordset/accommodation.json
+++ b/test/manual/data_setup/data/recordset/accommodation.json
@@ -1,0 +1,13 @@
+[{
+    "id": 2001,
+    "no_of_rooms": 46,
+    "title": "Radisson Hotel",
+    "website": "http://www.radisson.com/",
+    "rating": 4.7,
+    "summary": "Radisson Hotels is an international hotel company with more than 990 locations in 73 countries. The first Radisson Hotel was built in 1909 in Minneapolis, Minnesota, US. It is named after the 17th-century French explorer Pierre-Esprit Radisson.",
+    "description": "** CARING. SHARING. DARING.**\nRadisson^®^ is synonymous with outstanding levels of service and comfort delivered with utmost style. And today, we deliver even more to make sure we maintain our position at the forefront of the hospitality industry now and in the future.\nOur hotels are service driven, responsible, socially and locally connected and demonstrate a modern friendly attitude in everything we do. Our aim is to deliver our outstanding `Yes I Can!` ^SM^ service, comfort and style where you need us.\n\n**THE RADISSON^®^ WAY** Always positive, always smiling and always professional, Radisson people set Radisson apart. Every member of the team has a dedication to `Yes I Can!` ^SM^ hospitality – a passion for ensuring the total wellbeing and satisfaction of each individual guest. Imaginative, understanding and truly empathetic to the needs of the modern traveler, they are people on a special mission to deliver exceptional Extra Thoughtful Care.",
+    "opened_on": "2002-01-22T00:00:00-08:00",
+    "json_col":{"name":"testing_json"},
+    "luxurious": true
+   }]
+  

--- a/test/manual/data_setup/schema/product-recordset.json
+++ b/test/manual/data_setup/schema/product-recordset.json
@@ -1,0 +1,247 @@
+{
+    "tables": {
+      "accommodation": {
+        "comment": "List of different types of accommodations",
+        "kind": "table",
+        "entityCount": 0,
+        "keys": [
+          {
+            "comment": null,
+            "annotations": {},
+            "unique_columns": [
+              "id"
+            ]
+          }
+        ],
+        "foreign_keys": [],
+        "table_name": "accommodation",
+        "schema_name": "product-recordset",
+        "column_definitions": [
+          {
+            "name": "id",
+            "nullok": false,
+            "type": {
+              "typename": "serial4"
+            },
+            "annotations": {
+              "comment": [
+                "hidden"
+              ],
+              "tag:misd.isi.edu,2015:display": {
+                "name" : "Id"
+              },
+              "tag:isrd.isi.edu,2016:generated": null,
+              "tag:isrd.isi.edu,2016:immutable": null
+            }
+          },
+          {
+            "comment": "Name of the Accomodation",
+            "name": "title",
+            "nullok": false,
+            "type": {
+              "typename": "text"
+            },
+            "annotations": {
+              "comment": [
+                "title",
+                "top",
+                "orderby"
+              ],
+              "description": {
+                "display": "Name of Accommodation"
+              },
+              "tag:misd.isi.edu,2015:display" : {
+                "name" : "Name of Accommodation"
+              },
+              "facetOrder": [
+                "1"
+              ]
+            }
+          },
+          {
+            "comment": "A valid url of the accommodation",
+            "name": "website",
+            "default": null,
+            "nullok": true,
+            "type": {
+              "typename": "text"
+            },
+            "annotations": {
+              "comment": [
+                "url"
+              ],
+              "description": {
+                "display": "Website"
+              },
+              "tag:misd.isi.edu,2015:url" : {
+                "url" : "{cname}"
+              },
+              "tag:isrd.isi.edu,2016:column-display" : {
+                "*": {
+                  "markdown_pattern" : "[Link to Website]({{website}})"
+                }
+              },
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Website"
+              }
+            }
+          },
+          {
+            "comment": "Average of the ratings given by all the users.",
+            "name": "rating",
+            "nullok": false,
+            "type": {
+              "typename": "float4"
+            },
+            "annotations": {
+              "comment": ["top"],
+              "description": {
+                "display": "User Rating"
+              },
+              "facetOrder": [
+                "3"
+              ],
+              "tag:misd.isi.edu,2015:display": {
+                "name": "User Rating"
+              }
+            }
+          },
+          {
+            "comment": "To summarize",
+            "name": "summary",
+            "nullok": false,
+            "type": {
+              "typename": "longtext"
+            },
+            "annotations": {
+              "comment": [
+                "text",
+                "unsortable",
+                "summary",
+                "hidden"
+              ],
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Summary"
+              }
+            }
+          },
+          {
+            "comment": "Description of the Accomodation",
+            "name": "description",
+            "default": null,
+            "nullok": true,
+            "type": {
+              "typename": "markdown"
+            },
+            "annotations": {
+              "comment": [
+                "text",
+                "unsortable",
+                "html",
+                "hidden"
+              ],
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Description"
+              }
+            }
+          },
+          {
+            "name": "json_col",
+            "default": null,
+            "nullok": true,
+            "type": {
+              "typename": "json"
+            },
+            "annotations": {}
+          },
+          {
+            "comment": "Number of rooms present in this accomodation. Text to make the tooltip long. Text to make the tooltip long. Text to make the tooltip long. Text to make the tooltip long. Text to make the tooltip long.",
+            "name": "no_of_rooms",
+            "default": null,
+            "nullok": true,
+            "type": {
+              "typename": "int4"
+            },
+            "annotations": {
+              "comment" : ["top"],
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Number of Rooms"
+              }
+            }
+          },
+          {
+            "comment": "Date of opening of this place. Text to make the tooltip long. Text to make the tooltip long. Text to make the tooltip long.Text to make the tooltip long.",
+            "name": "opened_on",
+            "default": null,
+            "nullok": false,
+            "type": {
+              "typename": "timestamptz"
+            },
+            "annotations": {
+              "comment": [
+                "bottom"
+              ],
+              "description": {
+                "display": "Operational Since"
+              },
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Operational Since"
+              }
+            }
+          },
+          {
+            "comment": "Can this accomodation be categorized as luxurious?",
+            "name": "luxurious",
+            "default": null,
+            "nullok": true,
+            "type": {
+              "typename": "boolean"
+            },
+            "annotations": {
+              "comment": ["top"],
+              "description": {
+                "display": "Luxurious"
+              },
+              "tag:misd.isi.edu,2015:display": {
+                "name": "Is Luxurious"
+              },
+              "tag:isrd.isi.edu,2016:ignore" : ["record"]
+            }
+          }
+        ],
+        "annotations": {
+          "comment": [
+            "default"
+          ],
+          "tag:misd.isi.edu,2015:display": {
+            "name": "Accommodations"
+          },
+          "description": {
+            "display": "Accommodations",
+            "top_columns": ["title", "rating", "opened_on"]
+          },
+          "tag:isrd.isi.edu,2016:visible-columns" : {
+            "detailed" : ["id", "website", "rating", "summary", "description","json_col", "opened_on", "luxurious"],
+            "entry/create": ["id", "title", "website", "rating", "summary", "description","json_col", "no_of_rooms", "opened_on", "luxurious"],
+            "entry/edit": ["id", "title", "website", "rating", "summary", "description", "json_col", "no_of_rooms", "opened_on", "luxurious"],
+            "compact" : ["title", "website", "rating", "summary","description", "opened_on", "luxurious","json_col", "no_of_rooms"]
+          },
+          "tag:isrd.isi.edu,2016:table-display": {
+            "compact": {
+              "page_size": 15
+            }
+          }
+        }
+      }
+    },
+    "table_names": [
+      "accommodation"
+    ],
+    "annotations": {
+      "tag:misd.isi.edu,2015:display": {
+        "name": "accommodation"
+      }
+    },
+    "schema_name": "product-recordset"
+  }
+  

--- a/test/manual/specs/recordset.conf.js
+++ b/test/manual/specs/recordset.conf.js
@@ -1,0 +1,15 @@
+var pConfig = require('./../../e2e/utils/protractor.configuration.js');
+
+var config = pConfig.getConfig({
+    manualTestConfig: true,
+    configFileName: 'dev-recordset.json',
+    specs: [
+        "recordset.spec.js"
+    ],
+    setBaseUrl: function(browser, data) {
+        browser.params.url = process.env.CHAISE_BASE_URL;
+        return browser.params.url;
+    }
+});
+
+exports.config = config;

--- a/test/manual/specs/recordset.spec.js
+++ b/test/manual/specs/recordset.spec.js
@@ -1,0 +1,21 @@
+var chaisePage = require('./../../e2e/utils/chaise.page.js');
+
+describe('View recordset,', function () {
+    var waitTime = {
+        small: 15000,
+        medium: 30000,
+        large: 120000
+    }
+    beforeAll(function () {
+        browser.ignoreSynchronization = true;
+        browser.get(browser.params.url + "/recordset/#" + browser.params.catalogId + "/product-recordset:accommodation");
+
+        chaisePage.waitForElement(element(by.id("divRecordSet")));
+        chaisePage.recordsetPage.waitForAggregates();
+    });
+
+    // test to setup recordset table with long tooltip text and check the placement of tooltips manually
+    it("should have correct placement of longer tooltip texts on column headers", function () {
+        browser.sleep(waitTime.large);
+    });
+});

--- a/test/manual/specs/recordset.spec.js
+++ b/test/manual/specs/recordset.spec.js
@@ -1,11 +1,6 @@
 var chaisePage = require('./../../e2e/utils/chaise.page.js');
 
 describe('View recordset,', function () {
-    var waitTime = {
-        small: 15000,
-        medium: 30000,
-        large: 120000
-    }
     beforeAll(function () {
         browser.ignoreSynchronization = true;
         browser.get(browser.params.url + "/recordset/#" + browser.params.catalogId + "/product-recordset:accommodation");
@@ -16,6 +11,7 @@ describe('View recordset,', function () {
 
     // test to setup recordset table with long tooltip text and check the placement of tooltips manually
     it("should have correct placement of longer tooltip texts on column headers", function () {
-        browser.sleep(waitTime.large);
+        browser.pause();
+        expect(true).toBeTruthy();
     });
 });


### PR DESCRIPTION
- Created a manual test for checking the placement of tooltips over column headers in the recordset app
- Added a command "make testmanually", in Makefile, to run manual tests 
- Updated  test/e2e/utils/protractor.configuration.js, to reuse its functions for specs in the manual test folder
- Updated documentation for the manual tests at https://github.com/informatics-isi-edu/chaise/wiki/Manual-UX-and-E2E-Testing#recordset---tooltip-on-column-headers 