### PR TITLE
hide plotly when the range picker is closed

### DIFF
--- a/common/templates/faceting/range-picker.html
+++ b/common/templates/faceting/range-picker.html
@@ -1,7 +1,7 @@
 <div class="range-picker">
     <record-list on-row-click="onSelect" range-options="rangeOptions" rows="ranges"></record-list>
     <range-inputs type="rangeOptions.type" add-range-cb="rangeOptions.callback" abs-min="rangeOptions.absMin" abs-max="rangeOptions.absMax" model="rangeOptions.model"></range-inputs>
-    <div ng-if="showHistogram()">
+    <div ng-if="facetModel.initialized && facetModel.isOpen && facetPanelOpen && showHistogram()">
         <div class="divider"></div>
         <div class="plotly-actions btn-group pull-right" style="z-index: 1">
             <button type="button" class="plotly-how-to btn btn-xs btn-primary btn-inverted btn-no-focus" tooltip-placement="bottom" uib-tooltip-html="'<p>You can interact with the histogram in 2 ways: zooming and panning.</p><p>Clicking and holding anywhere in the graph display will allow you to zoom into a smaller subset of data. Drag the left or right bound to encapsulate the range of data you want to zoom into to get more clarity.</p><p>Clicking and holding in the middle of the x axis of the graph will allow you to pan that axis. By clicking on either end, you can stretch that axis to get a wider range of data.</p><p>Interacting with the histogram does not automatically apply the filter, it will fill in the min/max input fields for you based on the histogram\'s current range.</p>'">

--- a/test/e2e/specs/delete-prohibited/recordset/histogram-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/histogram-facet.spec.js
@@ -104,20 +104,19 @@ describe("Viewing Recordset with Faceting,", function() {
                                 // wait for facet to open
                                 browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
                                 browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getRangeSubmit(idx)), browser.params.defaultTimeout);
-                                // browser.pause();
-                                chaisePage.recordsetPage.getHistogram(idx).isDisplayed().then(function (bool) {
-                                    expect(bool).toBeTruthy();
 
-                                    minDateInput = chaisePage.recordsetPage.getRangeMinInput(idx, "ts-date-range-min");
-                                    minTimeInput = chaisePage.recordsetPage.getRangeMinInput(idx, "ts-time-range-min");
-                                    maxDateInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "ts-date-range-max");
-                                    maxTimeInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "ts-time-range-max");
+                                // wait for histogram
+                                browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getHistogram(idx)), browser.params.defaultTimeout);
 
-                                    expect(minDateInput.getAttribute("value")).toBe(facetParams.absMin.date, "initial min date value is incorrect");
-                                    expect(minTimeInput.getAttribute("value")).toBe(facetParams.absMin.time, "initial min time value is incorrect");
-                                    expect(maxDateInput.getAttribute("value")).toBe(facetParams.absMax.date, "initial max date value is incorrect");
-                                    expect(maxTimeInput.getAttribute("value")).toBe(facetParams.absMax.time, "initial max time value is incorrect");
-                                });
+                                minDateInput = chaisePage.recordsetPage.getRangeMinInput(idx, "ts-date-range-min");
+                                minTimeInput = chaisePage.recordsetPage.getRangeMinInput(idx, "ts-time-range-min");
+                                maxDateInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "ts-date-range-max");
+                                maxTimeInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "ts-time-range-max");
+
+                                expect(minDateInput.getAttribute("value")).toBe(facetParams.absMin.date, "initial min date value is incorrect");
+                                expect(minTimeInput.getAttribute("value")).toBe(facetParams.absMin.time, "initial min time value is incorrect");
+                                expect(maxDateInput.getAttribute("value")).toBe(facetParams.absMax.date, "initial max date value is incorrect");
+                                expect(maxTimeInput.getAttribute("value")).toBe(facetParams.absMax.time, "initial max time value is incorrect");
                             });
 
                             it("unzoom should be disabled, clicking zoom should zoom in and enable the unzoom button.", function () {
@@ -208,16 +207,15 @@ describe("Viewing Recordset with Faceting,", function() {
                                 // wait for facet to open
                                 browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getFacetCollapse(idx)), browser.params.defaultTimeout);
                                 browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getRangeSubmit(idx)), browser.params.defaultTimeout);
-                                // browser.pause();
-                                chaisePage.recordsetPage.getHistogram(idx).isDisplayed().then(function (bool) {
-                                    expect(bool).toBeTruthy();
 
-                                    minInput = chaisePage.recordsetPage.getRangeMinInput(idx, "range-min");
-                                    maxInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "range-max");
+                                // wait for histogram
+                                browser.wait(EC.visibilityOf(chaisePage.recordsetPage.getHistogram(idx)), browser.params.defaultTimeout);
 
-                                    expect(minInput.getAttribute("value")).toBe(facetParams.absMin, "initial min value is incorrect");
-                                    expect(maxInput.getAttribute("value")).toBe(facetParams.absMax, "initial max value is incorrect");
-                                });
+                                minInput = chaisePage.recordsetPage.getRangeMinInput(idx, "range-min");
+                                maxInput = chaisePage.recordsetPage.getRangeMaxInput(idx, "range-max");
+
+                                expect(minInput.getAttribute("value")).toBe(facetParams.absMin, "initial min value is incorrect");
+                                expect(maxInput.getAttribute("value")).toBe(facetParams.absMax, "initial max value is incorrect");
                             });
 
                             it("unzoom should be disabled, clicking zoom should zoom in and enable the unzoom button.", function () {


### PR DESCRIPTION
This is a very simple change. When the facet is closed, we don't need to show the plotly.

I created this PR just to make sure test cases are passing in travis.