### PR TITLE
Warn on leaving recordedit page with unsaved changes

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -229,11 +229,10 @@
                 editOrCopy = true,
                 form = vm.formContainer,
                 model = vm.recordEditModel;
-
+            form.$setSubmitted()
             if (form.$invalid) {
                 vm.readyToSubmit = false;
                 AlertsService.addAlert('Sorry, the data could not be submitted because there are errors on the form. Please check all fields and try again.', 'error');
-                form.$setSubmitted();
                 return;
             }
 
@@ -800,6 +799,13 @@
             $timeout(function() {
                   resizeColumns();
             }, TIMER_INTERVAL, false);
+        });
+
+        $window.addEventListener("beforeunload", function(e) {
+            if(vm.formContainer.$submitted){
+                return undefined;
+            }
+            e.returnValue = "Do you want to leave this page? Changes you have made will not be saved.";
         });
     }]);
 })();


### PR DESCRIPTION
- Warn the user when he's about to leave the recordEdit page with unsaved changes.
- Checked on Chrome, Firefox, Safari, and Edge. All 4 of them display their own messages and have stopped the support for displaying custom messages. (https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload#Browser_compatibility)
- Stopped this event from triggering on form-submit event