### PR TITLE
Export error modal

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -188,7 +188,7 @@
                 appName: appName,
                 pageName: pageName,
                 exception: exception,
-                errorStatus: errorStatus ? errorStatus : exception.status,
+                errorStatus: exception.status ? exception.status : "Terminal Error",
                 message: message ? message : exception.message,
                 subMessage: subMessage,
                 canClose: false,
@@ -276,7 +276,6 @@
             } else {
                 logError(exception);
                 message = errorMessages.systemAdminMessage;
-                if (!errorStatus) errorStatus = "Terminal Error";
                 subMessage = exception.message;
             }
 

--- a/common/export.js
+++ b/common/export.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.export', ['chaise.utils'])
 
-    .directive('export', ['AlertsService', 'DataUtils', 'logActions', 'modalUtils', '$timeout', 'UriUtils', function (AlertsService, DataUtils, logActions, modalUtils, $timeout, UriUtils) {
+    .directive('export', ['AlertsService', 'DataUtils', 'ErrorService', 'logActions', 'modalUtils', '$timeout', 'UriUtils', function (AlertsService, DataUtils, ErrorService, logActions, modalUtils, $timeout, UriUtils) {
 
         /**
          * Cancel the current export request
@@ -88,12 +88,10 @@
                         error.subMessage = error.message;
                         error.message = "Export failed. Please report this problem to your system administrators.";
                         ErrorService.handleException(error, true);
-                        // AlertsService.addAlert("Export failed. Please report this problem to your system administrators. Details: " + error.message, "error");
                     });
                     break;
                 default:
                     ErrorService.handleException(new Error("Unsupported export format: " + formatType + ". Please report this problem to your system administrators."), true);
-                    // AlertsService.addAlert("Unsupported export format: " + formatType + ". Please report this problem to your system administrators.");
             }
         }
 

--- a/common/export.js
+++ b/common/export.js
@@ -85,11 +85,15 @@
                         console.timeEnd('External export duration');
                         scope.progressModal.close("Done");
                         scope.isLoading = false;
-                        AlertsService.addAlert("Export failed. Please report this problem to your system administrators. Details: " + error.message, "error");
+                        error.subMessage = error.message;
+                        error.message = "Export failed. Please report this problem to your system administrators.";
+                        ErrorService.handleException(error, true);
+                        // AlertsService.addAlert("Export failed. Please report this problem to your system administrators. Details: " + error.message, "error");
                     });
                     break;
                 default:
-                    AlertsService.addAlert("Unsupported export format: " + formatType + ". Please report this problem to your system administrators.");
+                    ErrorService.handleException(new Error("Unsupported export format: " + formatType + ". Please report this problem to your system administrators."), true);
+                    // AlertsService.addAlert("Unsupported export format: " + formatType + ". Please report this problem to your system administrators.");
             }
         }
 


### PR DESCRIPTION
This PR changes the error sequence for export so that when an error occurs, it is shown to the user regardless of where on the page the user is looking. This is applied to most error cases for export (I didn't change the cancel case. If the user clicks cancel, it will continue to display an alert).