### PR TITLE
Facet order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ before_install:
   - cd ..
   - git clone https://github.com/informatics-isi-edu/ermrestjs.git
   - cd ermrestjs
-  - git checkout attgroup-column-order
   - sudo npm install
   - bower install
   - sudo make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ before_install:
   - cd ..
   - git clone https://github.com/informatics-isi-edu/ermrestjs.git
   - cd ermrestjs
+  - git checkout attgroup-column-order
   - sudo npm install
   - bower install
   - sudo make build

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -912,7 +912,7 @@
                     scope.reference = scope.facetColumn.sourceReference.contextualize.compactSelect;
                     scope.columnName = scope.facetColumn.column.name;
                 } else {
-                    scope.reference = scope.facetColumn.column.groupAggregate.entityCounts(scope.facetColumn.sortColumns, scope.facetColumn.hideNumOccurences);
+                    scope.reference = scope.facetColumn.scalarValuesReference;
                     // the first column will be the value column
                     scope.columnName = scope.reference.columns[0].name;
                 }

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -912,7 +912,7 @@
                     scope.reference = scope.facetColumn.sourceReference.contextualize.compactSelect;
                     scope.columnName = scope.facetColumn.column.name;
                 } else {
-                    scope.reference = scope.facetColumn.column.groupAggregate.entityCounts;
+                    scope.reference = scope.facetColumn.column.groupAggregate.entityCounts(scope.facetColumn.sortColumns, scope.facetColumn.hideNumOccurences);
                     // the first column will be the value column
                     scope.columnName = scope.reference.columns[0].name;
                 }

--- a/common/table.js
+++ b/common/table.js
@@ -86,8 +86,8 @@
      * modified. ellipses will fire this event and recordset directive will use it.
      */
     .factory('recordTableUtils',
-            ['AlertsService', '$document', 'modalBox', 'DataUtils', '$timeout','Session', '$q', 'tableConstants', '$rootScope', '$log', '$window', '$cookies', 'defaultDisplayname', 'MathUtils', 'UriUtils', 'logActions',
-            function(AlertsService, $document, modalBox, DataUtils, $timeout, Session, $q, tableConstants, $rootScope, $log, $window, $cookies, defaultDisplayname, MathUtils, UriUtils, logActions) {
+            ['AlertsService', '$document', 'messageMap', 'modalBox', 'DataUtils', '$timeout','Session', '$q', 'tableConstants', '$rootScope', '$log', '$window', '$cookies', 'defaultDisplayname', 'MathUtils', 'UriUtils', 'logActions',
+            function(AlertsService, $document, messageMap, modalBox, DataUtils, $timeout, Session, $q, tableConstants, $rootScope, $log, $window, $cookies, defaultDisplayname, MathUtils, UriUtils, logActions) {
 
         function FlowControlObject(maxRequests) {
             this.maxRequests = maxRequests || tableConstants.MAX_CONCURENT_REQUEST;
@@ -596,9 +596,11 @@
         function registerTableCallbacks(scope, elem, attr) {
             if (!scope.vm) scope.vm = {};
 
+            scope.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
             scope.noSelect = modalBox.noSelect;
             scope.singleSelect = modalBox.singleSelectMode;
             scope.multiSelect = modalBox.multiSelectMode;
+            scope.tooltip = messageMap.tooltip;
 
             scope.$root.checkReferenceURL = function (ref) {
                 var refUri = ref.isAttributeGroup ? ref.ermrestPath : ref.location.ermrestPath;
@@ -1043,7 +1045,7 @@
         };
     }])
 
-    .directive('recordTable', ['DataUtils', 'recordTableUtils', 'messageMap', 'UriUtils', function(DataUtils, recordTableUtils, messageMap, UriUtils) {
+    .directive('recordTable', ['recordTableUtils', 'UriUtils', function(recordTableUtils, UriUtils) {
 
         return {
             restrict: 'E',
@@ -1060,9 +1062,6 @@
             },
             link: function (scope, elem, attr) {
                 recordTableUtils.registerTableCallbacks(scope, elem, attr);
-
-                scope.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
-                scope.tooltip = messageMap.tooltip;
             }
         };
     }])

--- a/common/utils.js
+++ b/common/utils.js
@@ -941,7 +941,7 @@
         * @param {String} string
         * @return {String} a string suitable for use in the `id` attributes of HTML elements
         */
-        function makeSafeIdAttr(string) {
+        function makeSafeIdAttr(string, val) {
             return String(string)
                 .replace(/&/g, '&amp;')
                 .replace(/\s/g, '&nbsp;') // any whitespace

--- a/test/e2e/data_setup/data/faceting/main.json
+++ b/test/e2e/data_setup/data/faceting/main.json
@@ -2,190 +2,190 @@
     {
         "id": "1", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**" ,
-        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
         "text_col_2": "value"
     },
     {
         "id": "2", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
         "text_col_2": "value"
     },
     {
         "id": "3", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003",
         "text_col_2": "value"
     },
     {
         "id": "4", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004",
         "text_col_2": "value"
     },
     {
         "id": "5", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
-        "boolean_col": true, "jsonb_col": {"key": "one"},
+        "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005",
         "text_col_2": "value"
     },
     {
         "id": "6", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006",
         "text_col_2": "value"
     },
     {
         "id": "7", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007",
         "text_col_2": "value"
     },
     {
         "id": "8", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008",
         "text_col_2": "value"
     },
     {
         "id": "9", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009",
         "text_col_2": "value"
     },
     {
         "id": "10", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
-        "boolean_col": true, "jsonb_col": {"key": "two"},
+        "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010"
     },
     {
         "id": "11", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 3, "float_col": 3.3, "date_col": "2003-03-03", "timestamp_col": "2003-03-03T03:03:03-07:00", "text_col": "three", "shorttext_col": "three", "longtext_col": "three", "markdown_col": "**three**",
-        "boolean_col": false, "jsonb_col": {"key": "three"},
+        "boolean_col": false, "jsonb_col": {"key": "three"}, "jsonb_sort_col": "03",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011"
     },
     {
         "id": "12", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 4, "float_col": 4.4, "date_col": "2004-04-04", "timestamp_col": "2004-04-04T04:04:04-07:00", "text_col": "four", "shorttext_col": "four", "longtext_col": "four", "markdown_col": "**four**",
-        "boolean_col": false, "jsonb_col": {"key": "four"},
+        "boolean_col": false, "jsonb_col": {"key": "four"}, "jsonb_sort_col": "04",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012"
     },
     {
         "id": "13", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 5, "float_col": 5.5, "date_col": "2005-05-05", "timestamp_col": "2005-05-05T05:05:05-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "five", "markdown_col": "**five**",
-        "boolean_col": false, "jsonb_col": {"key": "five"},
+        "boolean_col": false, "jsonb_col": {"key": "five"}, "jsonb_sort_col": "05",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013"
     },
     {
         "id": "14", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 6, "float_col": 6.6, "date_col": "2006-06-06", "timestamp_col": "2006-06-06T06:06:06-07:00", "text_col": "six", "shorttext_col": "six", "longtext_col": "six", "markdown_col": "**six**",
-        "boolean_col": false, "jsonb_col": {"key": "six"},
+        "boolean_col": false, "jsonb_col": {"key": "six"}, "jsonb_sort_col": "06",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014"
     },
     {
         "id": "15", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 7, "float_col": 7.7, "date_col": "2007-07-07", "timestamp_col": "2007-07-07T07:07:07-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "seven", "markdown_col": "**seven**",
-        "boolean_col": false, "jsonb_col": {"key": "seven"},
+        "boolean_col": false, "jsonb_col": {"key": "seven"}, "jsonb_sort_col": "07",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "16", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 8, "float_col": 8.8, "date_col": "2008-08-08", "timestamp_col": "2008-08-08T08:08:08-07:00", "text_col": "eight", "shorttext_col": "eight", "longtext_col": "eight", "markdown_col": "**eight**",
-        "boolean_col": false, "jsonb_col": {"key": "eight"},
+        "boolean_col": false, "jsonb_col": {"key": "eight"}, "jsonb_sort_col": "08",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "17", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 9, "float_col": 9.9, "date_col": "2009-09-09", "timestamp_col": "2009-09-09T09:09:09-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "nine", "markdown_col": "**nine**",
-        "boolean_col": false, "jsonb_col": {"key": "nine"},
+        "boolean_col": false, "jsonb_col": {"key": "nine"}, "jsonb_sort_col": "09",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "18", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 10, "float_col": 10.10, "date_col": "2010-10-10", "timestamp_col": "2010-10-10T10:10:10-07:00", "text_col": "ten", "shorttext_col": "ten", "longtext_col": "ten", "markdown_col": "**ten**",
-        "boolean_col": false, "jsonb_col": {"key": "ten"},
+        "boolean_col": false, "jsonb_col": {"key": "ten"}, "jsonb_sort_col": "10",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "19", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 11, "float_col": 11.11, "date_col": "2011-11-11", "timestamp_col": "2011-11-11T11:11:11-07:00", "text_col": "elevens", "shorttext_col": "elevens", "longtext_col": "eleven", "markdown_col": "**eleven**",
-        "boolean_col": false, "jsonb_col": {"key": "eleven"},
+        "boolean_col": false, "jsonb_col": {"key": "eleven"}, "jsonb_sort_col": "11",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "20", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 12, "float_col": 12.12, "date_col": "2012-12-12", "timestamp_col": "2012-12-12T12:12:12-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "twelve", "markdown_col": "**twelve**",
-        "boolean_col": false, "jsonb_col": {"key": "twelve"},
+        "boolean_col": false, "jsonb_col": {"key": "twelve"}, "jsonb_sort_col": "12",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "21", "fk_to_f1": "3", "fk_to_f2": "4",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "22", "fk_to_f1": "4", "fk_to_f2": "5",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "23", "fk_to_f1": "5", "fk_to_f2": "6",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "24", "fk_to_f1": "6", "fk_to_f2": "7",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "25", "fk_to_f1": "7", "fk_to_f2": "8",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "26", "fk_to_f1": "8", "fk_to_f2": "9",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "27", "fk_to_f1": "9", "fk_to_f2": "10",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "28", "fk_to_f1": "10", "fk_to_f2": "11",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "29", "fk_to_f1": "11", "fk_to_f2": "12",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     },
     {
         "id": "30", "fk_to_f1": "12", "fk_to_f2": "13",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
-        "boolean_col": null, "jsonb_col": null,
+        "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
     }
 ]

--- a/test/e2e/data_setup/data/faceting/main.json
+++ b/test/e2e/data_setup/data/faceting/main.json
@@ -4,188 +4,218 @@
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**" ,
         "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "13", "col_w_column_order_column_order" : "01","col_w_column_order_false": "07", "col_w_column_order_false_facet_order": "01"
     },
     {
         "id": "2", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
         "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "13", "col_w_column_order_column_order" : "01","col_w_column_order_false": "06", "col_w_column_order_false_facet_order": "02"
     },
     {
         "id": "3", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
         "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "13", "col_w_column_order_column_order" : "01", "col_w_column_order_false": "06", "col_w_column_order_false_facet_order": "02"
     },
     {
         "id": "4", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
         "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "13", "col_w_column_order_column_order" : "01", "col_w_column_order_false": "05", "col_w_column_order_false_facet_order": "03"
     },
     {
         "id": "5", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 11, "float_col": 11.11, "date_col": "2001-01-01", "timestamp_col": "2001-01-01T01:01:01-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "one", "markdown_col": "**one**",
         "boolean_col": true, "jsonb_col": {"key": "one"}, "jsonb_sort_col": "01",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "13", "col_w_column_order_column_order" : "01", "col_w_column_order_false": "05", "col_w_column_order_false_facet_order": "03"
     },
     {
         "id": "6", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
         "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "12", "col_w_column_order_column_order" : "02", "col_w_column_order_false": "05", "col_w_column_order_false_facet_order": "03"
     },
     {
         "id": "7", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
         "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000007",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "12", "col_w_column_order_column_order" : "02", "col_w_column_order_false": "04", "col_w_column_order_false_facet_order": "04"
     },
     {
         "id": "8", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
         "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "12", "col_w_column_order_column_order" : "02", "col_w_column_order_false": "04", "col_w_column_order_false_facet_order": "04"
     },
     {
         "id": "9", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
         "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
         "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009",
-        "text_col_2": "value"
+        "text_col_2": "value",
+        "col_w_column_order": "12", "col_w_column_order_column_order" : "02", "col_w_column_order_false": "04", "col_w_column_order_false_facet_order": "04"
     },
     {
         "id": "10", "fk_to_f1": "1", "fk_to_f2": "1",
         "int_col": 22, "float_col": 22.22, "date_col": "2002-02-02", "timestamp_col": "2002-02-02T02:02:02-07:00", "text_col": "two", "shorttext_col": "two", "longtext_col": "two", "markdown_col": "**two**",
         "boolean_col": true, "jsonb_col": {"key": "two"}, "jsonb_sort_col": "02",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010",
+        "col_w_column_order": "12", "col_w_column_order_column_order" : "02", "col_w_column_order_false": "04", "col_w_column_order_false_facet_order": "04"
     },
     {
         "id": "11", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 3, "float_col": 3.3, "date_col": "2003-03-03", "timestamp_col": "2003-03-03T03:03:03-07:00", "text_col": "three", "shorttext_col": "three", "longtext_col": "three", "markdown_col": "**three**",
         "boolean_col": false, "jsonb_col": {"key": "three"}, "jsonb_sort_col": "03",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011",
+        "col_w_column_order": "11", "col_w_column_order_column_order" : "03", "col_w_column_order_false": "03", "col_w_column_order_false_facet_order": "05"
     },
     {
         "id": "12", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 4, "float_col": 4.4, "date_col": "2004-04-04", "timestamp_col": "2004-04-04T04:04:04-07:00", "text_col": "four", "shorttext_col": "four", "longtext_col": "four", "markdown_col": "**four**",
         "boolean_col": false, "jsonb_col": {"key": "four"}, "jsonb_sort_col": "04",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000012",
+        "col_w_column_order": "10", "col_w_column_order_column_order" : "04", "col_w_column_order_false": "03", "col_w_column_order_false_facet_order": "05"
     },
     {
         "id": "13", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 5, "float_col": 5.5, "date_col": "2005-05-05", "timestamp_col": "2005-05-05T05:05:05-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "five", "markdown_col": "**five**",
         "boolean_col": false, "jsonb_col": {"key": "five"}, "jsonb_sort_col": "05",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000013",
+        "col_w_column_order": "09", "col_w_column_order_column_order" : "05", "col_w_column_order_false": "03", "col_w_column_order_false_facet_order": "05"
     },
     {
         "id": "14", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 6, "float_col": 6.6, "date_col": "2006-06-06", "timestamp_col": "2006-06-06T06:06:06-07:00", "text_col": "six", "shorttext_col": "six", "longtext_col": "six", "markdown_col": "**six**",
         "boolean_col": false, "jsonb_col": {"key": "six"}, "jsonb_sort_col": "06",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014",
+        "col_w_column_order": "08", "col_w_column_order_column_order" : "06", "col_w_column_order_false": "03", "col_w_column_order_false_facet_order": "05"
     },
     {
         "id": "15", "fk_to_f1": "2", "fk_to_f2": "2",
         "int_col": 7, "float_col": 7.7, "date_col": "2007-07-07", "timestamp_col": "2007-07-07T07:07:07-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "seven", "markdown_col": "**seven**",
         "boolean_col": false, "jsonb_col": {"key": "seven"}, "jsonb_sort_col": "07",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "07", "col_w_column_order_column_order" : "07", "col_w_column_order_false": "03", "col_w_column_order_false_facet_order": "05"
     },
     {
         "id": "16", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 8, "float_col": 8.8, "date_col": "2008-08-08", "timestamp_col": "2008-08-08T08:08:08-07:00", "text_col": "eight", "shorttext_col": "eight", "longtext_col": "eight", "markdown_col": "**eight**",
         "boolean_col": false, "jsonb_col": {"key": "eight"}, "jsonb_sort_col": "08",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "06", "col_w_column_order_column_order" : "08", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "17", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 9, "float_col": 9.9, "date_col": "2009-09-09", "timestamp_col": "2009-09-09T09:09:09-07:00", "text_col": "one", "shorttext_col": "one", "longtext_col": "nine", "markdown_col": "**nine**",
         "boolean_col": false, "jsonb_col": {"key": "nine"}, "jsonb_sort_col": "09",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "05", "col_w_column_order_column_order" : "09", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "18", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 10, "float_col": 10.10, "date_col": "2010-10-10", "timestamp_col": "2010-10-10T10:10:10-07:00", "text_col": "ten", "shorttext_col": "ten", "longtext_col": "ten", "markdown_col": "**ten**",
         "boolean_col": false, "jsonb_col": {"key": "ten"}, "jsonb_sort_col": "10",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "04", "col_w_column_order_column_order" : "10", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "19", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 11, "float_col": 11.11, "date_col": "2011-11-11", "timestamp_col": "2011-11-11T11:11:11-07:00", "text_col": "elevens", "shorttext_col": "elevens", "longtext_col": "eleven", "markdown_col": "**eleven**",
         "boolean_col": false, "jsonb_col": {"key": "eleven"}, "jsonb_sort_col": "11",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "03", "col_w_column_order_column_order" : "11", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "20", "fk_to_f1": "2", "fk_to_f2": "3",
         "int_col": 12, "float_col": 12.12, "date_col": "2012-12-12", "timestamp_col": "2012-12-12T12:12:12-07:00", "text_col": "seven", "shorttext_col": "seven", "longtext_col": "twelve", "markdown_col": "**twelve**",
         "boolean_col": false, "jsonb_col": {"key": "twelve"}, "jsonb_sort_col": "12",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "02", "col_w_column_order_column_order" : "12", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "21", "fk_to_f1": "3", "fk_to_f2": "4",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "02", "col_w_column_order_false_facet_order": "06"
     },
     {
         "id": "22", "fk_to_f1": "4", "fk_to_f2": "5",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "23", "fk_to_f1": "5", "fk_to_f2": "6",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "24", "fk_to_f1": "6", "fk_to_f2": "7",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "25", "fk_to_f1": "7", "fk_to_f2": "8",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": "", "shorttext_col": "", "longtext_col": "", "markdown_col": "",
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "26", "fk_to_f1": "8", "fk_to_f2": "9",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "27", "fk_to_f1": "9", "fk_to_f2": "10",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "28", "fk_to_f1": "10", "fk_to_f2": "11",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "29", "fk_to_f1": "11", "fk_to_f2": "12",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     },
     {
         "id": "30", "fk_to_f1": "12", "fk_to_f2": "13",
         "int_col": null, "float_col": null, "date_col": null, "timestamp_col": null, "text_col": null, "shorttext_col": null, "longtext_col": null, "markdown_col": null,
         "boolean_col": null, "jsonb_col": null, "jsonb_sort_col": "13",
-        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015"
+        "col_w_long_values": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000015",
+        "col_w_column_order": "01", "col_w_column_order_column_order" : "13", "col_w_column_order_false": "01", "col_w_column_order_false_facet_order": "07"
     }
 ]

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -155,6 +155,44 @@
                     "type": {
                         "typename": "text"
                     }
+                },
+                {
+                    "name": "col_w_column_order",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:column-display": {
+                            "compact/select": {
+                                "column_order": ["col_w_column_order_column_order"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "col_w_column_order_false",
+                    "type": {
+                        "typename": "text"
+                    },
+                    "annotations": {
+                        "tag:isrd.isi.edu,2016:column-display": {
+                            "compact/select": {
+                                "column_order": false
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "col_w_column_order_false_facet_order",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "col_w_column_order_column_order",
+                    "type": {
+                        "typename": "text"
+                    }
                 }
             ],
             "annotations": {
@@ -183,6 +221,8 @@
                             {"source": [{"inbound": ["faceting", "f4_fk1"]}, "id"], "entity": false, "ux_mode": "choices"},
                             {"source": [{"outbound": ["faceting", "main_fk1"]}, "term"], "markdown_name": "F1 with Term", "comment": "F1 with Term comment"},
                             {"source": "text_col_2", "ux_mode": "check_presence", "markdown_name": "Check Presence Text"},
+                            {"source": "col_w_column_order_false", "order": [{"column": "col_w_column_order_false_facet_order", "descending": true}]},
+                            {"source": "col_w_column_order", "hide_num_occurrences": true},
                             {"source": "col_w_long_values"}
                         ]
                     }

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -149,6 +149,12 @@
                     "type": {
                         "typename": "text"
                     }
+                },
+                {
+                    "name": "jsonb_sort_col",
+                    "type": {
+                        "typename": "text"
+                    }
                 }
             ],
             "annotations": {
@@ -170,7 +176,7 @@
                             {"source": "longtext_col", "comment": "A lengthy comment for the facet of the longtext_col. This should be displyed properly in the facet."},
                             {"source": "markdown_col"},
                             {"source": "boolean_col"},
-                            {"source": "jsonb_col"},
+                            {"source": "jsonb_col", "order": [{"num_occurrences": true, "descending": true}, "jsonb_sort_col"]},
                             {"source": [{"outbound": ["faceting", "main_fk1"]}, "id"], "markdown_name": "**F1**"},
                             {"source": [{"outbound": ["faceting", "main_fk2"]}, "id"], "open": true, "comment": "open facet"},
                             {"source": [{"inbound": ["faceting", "main_f3_assoc_fk1"]}, {"outbound": ["faceting", "main_f3_assoc_fk2"]}, "term"]},

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -193,10 +193,10 @@ var testParams = {
             name: "jsonb_col",
             type: "choice",
             totalNumOptions: 11,
-            option: 7,
+            option: 5,
             filter: 'jsonb_col: { "key": "four" }',
             numRows: 1,
-            options: [ 'All Records With Value', 'No Value', '{"key":"one"}', '{"key":"two"}', '{"key":"eight"}', '{"key":"eleven"}', '{"key":"five"}', '{"key":"four"}', '{"key":"nine"}', '{"key":"seven"}', '{"key":"six"}' ]
+            options: [ 'All Records With Value', 'No Value', '{"key":"one"}', '{"key":"two"}', '{"key":"three"}', '{"key":"four"}', '{"key":"five"}', '{"key":"six"}', '{"key":"seven"}', '{"key":"eight"}', '{"key":"nine"}' ]
         },
         {
             name: "F1",

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -7,8 +7,11 @@ var testParams = {
     schema_name: "faceting",
     table_name: "main",
     sort: "@sort(id)",
-    totalNumFacets: 17,
-    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col", "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1", "to_name", "f3 (term)", "from_name", "F1 with Term", "Check Presence Text", "col_w_long_values" ],
+    totalNumFacets: 19,
+    facetNames: [ "id", "int_col", "float_col", "date_col", "timestamp_col", "text_col",
+                  "longtext_col", "markdown_col", "boolean_col", "jsonb_col", "F1",
+                  "to_name", "f3 (term)", "from_name", "F1 with Term", "Check Presence Text",
+                  "col_w_column_order_false", "col_w_column_order", "col_w_long_values" ],
     defaults: {
         openFacetNames: [ "id", "int_col", "to_name" ],
         numFilters: 2,
@@ -252,6 +255,15 @@ var testParams = {
             notNullFilter: "Check Presence Text : All Records With Value",
             nullNumRows: 21,
             nullFilter: "Check Presence Text : No Value"
+        },
+        {
+            name: "col_w_column_order_false",
+            type: "choice",
+            totalNumOptions: 8,
+            option: 1,
+            filter: "col_w_column_order_false: 01",
+            numRows: 9,
+            options: [ 'All Records With Value', '01', '02', '03', '04', '05', '06', '07']
         }
     ],
     multipleFacets: [

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -912,6 +912,23 @@ var recordsetPage = function() {
         return element.all(by.css('.modal-body .table-row'));
     };
 
+    this.getModalColumnNames = function() {
+        return element.all(by.css(".modal-body .table-column-displayname > span"));
+    };
+
+    this.waitForInverseModalSpinner = function () {
+        var locator = element(by.css(".modal-body #spinner"));
+        return browser.wait(protractor.ExpectedConditions.invisibilityOf(locator), browser.params.defaultTimeout);
+    };
+
+    this.getModalFirstColumnValues = function () {
+        return browser.executeScript('return $(".modal-body .table-row td:nth-child(2)").map(function (i, a) { return a.textContent.trim(); });');
+    };
+
+    this.getModalCloseBtn = function() {
+        return element(by.css(".modal-close"));
+    };
+
     this.getNoResultsRow = function() {
         return element(by.id("no-results-row"));
     };


### PR DESCRIPTION
The [recent change in ermrsetjs](https://github.com/informatics-isi-edu/ermrestjs/pull/694) will break the existing test cases because the `jsonb` column types are not sortable in ermrestjs. I had to defined the `order` attribute for that facet.

Also I had to change the API call for getting the scalar values to pass the two new APIs that are added to faceting.