### PR TITLE
Record app export feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ RECORD_SHARED_JS_DEPS=$(JS)/vendor/jquery-latest.min.js \
 	$(COMMON)/authen.js \
 	$(COMMON)/delete-link.js \
 	$(COMMON)/errors.js \
+	$(COMMON)/export.js \
 	$(COMMON)/faceting.js \
 	$(COMMON)/filters.js \
 	$(COMMON)/modal.js \

--- a/common/export.js
+++ b/common/export.js
@@ -100,7 +100,7 @@
             templateUrl:  UriUtils.chaiseDeploymentPath() + 'common/templates/export.html',
             scope: {
                 reference: "=",
-                hasValues: "=",
+                allowExport: "=",
                 disabled: "="
             },
             link: function (scope, element, attributes) {
@@ -125,7 +125,7 @@
                     _doExport(scope, template);
                 };
 
-                scope.$watch('hasValues', function (newValue, oldValue) {
+                scope.$watch('allowExport', function (newValue, oldValue) {
                     if (newValue && scope.exportOptions.supportedFormats.length === 1) {
                         _updateExportFormats(scope);
                     }

--- a/common/templates/export.html
+++ b/common/templates/export.html
@@ -1,10 +1,10 @@
-<button ng-if="hasValues" class="dropdown-toggle btn-primary btn btn-inverted btn-no-boundry" data-toggle="dropdown" ng-disabled="disabled"
+<button ng-if="allowExport" class="dropdown-toggle btn-primary btn btn-inverted btn-no-boundry" data-toggle="dropdown" ng-disabled="disabled"
    tooltip-placement="left" uib-tooltip= "Click to choose an export format.">
     <span class="glyphicon" ng-class="{'glyphicon-export': !isLoading, 'glyphicon-refresh glyphicon-refresh-animate': isLoading}"></span>
     <strong>Export </strong>
     <span class="caret"></span>
 </button>
-<ul ng-if="hasValues" class="dropdown-menu" style="min-width:unset; top:20px;">
+<ul ng-if="allowExport" class="dropdown-menu" style="min-width:unset; top:20px;">
     <li ng-repeat="template in exportOptions.supportedFormats">
         <a class="export-{{::makeSafeIdAttr(template.format_name)}}" ng-click="submit(template)">{{template.format_name}}</a>
     </li>

--- a/common/templates/export.html
+++ b/common/templates/export.html
@@ -1,5 +1,5 @@
 <button ng-if="hasValues" class="dropdown-toggle btn-primary btn btn-inverted btn-no-boundry" data-toggle="dropdown" ng-disabled="disabled"
-   tooltip-placement="left" uib-tooltip= "Click to choose an export format.">
+   tooltip-placement="bottom" uib-tooltip= "Click to choose an export format.">
     <span class="glyphicon" ng-class="{'glyphicon-export': !isLoading, 'glyphicon-refresh glyphicon-refresh-animate': isLoading}"></span>
     <strong>Export </strong>
     <span class="caret"></span>

--- a/common/templates/export.html
+++ b/common/templates/export.html
@@ -1,5 +1,5 @@
 <button ng-if="hasValues" class="dropdown-toggle btn-primary btn btn-inverted btn-no-boundry" data-toggle="dropdown" ng-disabled="disabled"
-   tooltip-placement="bottom" uib-tooltip= "Click to choose an export format.">
+   tooltip-placement="left" uib-tooltip= "Click to choose an export format.">
     <span class="glyphicon" ng-class="{'glyphicon-export': !isLoading, 'glyphicon-refresh glyphicon-refresh-animate': isLoading}"></span>
     <strong>Export </strong>
     <span class="caret"></span>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -40,7 +40,7 @@
                     </strong>
                 </a>&nbsp;&nbsp;
                 <!-- download CSV included by default -->
-                <export has-values="recordValues.length>0" reference="reference" style="position:relative;" disabled="!displayReady"></export>
+                <export allow-export="displayReady" reference="reference" style="position:relative;" disabled="!displayReady"></export>
                 &nbsp;&nbsp;
                 <a id="share" ng-click="::ctrl.sharePopup()" uib-tooltip="Click here to show the share dialog." tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-share"></span><strong> Share</strong>

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -39,6 +39,9 @@
                         Related Records
                     </strong>
                 </a>&nbsp;&nbsp;
+                <!-- download CSV included by default -->
+                <export has-values="recordValues.length>0" reference="reference" style="position:relative;" disabled="!displayReady"></export>
+                &nbsp;&nbsp;
                 <a id="permalink" ng-href="{{::ctrl.permalink()}}" uib-tooltip={{::ctrl.tooltip.permalink}} tooltip-placement="bottom">
                     <span class="glyphicon glyphicon-bookmark"></span><strong> Permalink</strong>
                 </a>

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -9,6 +9,7 @@
         'chaise.alerts',
         'chaise.delete',
         'chaise.errors',
+        'chaise.export',
         'chaise.faceting',
         'chaise.modal',
         'chaise.navbar',

--- a/recordset/index.html.in
+++ b/recordset/index.html.in
@@ -33,7 +33,7 @@
                             <span class="glyphicon glyphicon-pencil"></span> <strong>Edit</strong>
                         </a>&nbsp;&nbsp;
                         <!-- download CSV included by default -->
-                        <export has-values="vm.rowValues.length>0" reference="vm.reference" style="position:relative;" disabled="!vm.hasLoaded || !vm.initialized"></export>
+                        <export allow-export="vm.rowValues.length>0" reference="vm.reference" style="position:relative;" disabled="!vm.hasLoaded || !vm.initialized"></export>
                         &nbsp;&nbsp;
                         <!-- permalink -->
                         <a id="permalink" ng-href="{{ permalink() }}" tooltip-placement="bottom" uib-tooltip={{::tooltip.permalink}}>

--- a/test/e2e/data_setup/schema/record/product.json
+++ b/test/e2e/data_setup/schema/record/product.json
@@ -408,6 +408,27 @@
               ["product-record", "fk_accommodation_image"],
               ["product-record", "fk_media_accommodation"]
           ]
+        },
+        "tag:isrd.isi.edu,2016:export": {
+          "templates": [
+            {
+              "outputs": [
+                {
+                  "source": {
+                    "table": "product-record:accommodation",
+                    "api": "entity"
+                  },
+                  "destination": {
+                    "type": "csv",
+                    "name": "Accommodations_Bag"
+                  }
+                }
+              ],
+              "name": "export_data_bag",
+              "format_name": "BDBag",
+              "format_type": "BAG"
+            }
+          ]
         }
       }
     },

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -1,5 +1,6 @@
 var chaisePage = require('../../../utils/chaise.page.js');
 var recordHelpers = require('../../../utils/record-helpers.js');
+var recordSetHelpers = require('../../../utils/recordset-helpers.js');
 var testParams = {
     table_name: "accommodation",
     key: {
@@ -11,6 +12,7 @@ var testParams = {
     subTitle: "Accommodations",
     tableComment: "List of different types of accommodations",
     tables_order: ["accommodation_image (showing first 2 results)", "media (no results found)"],
+    file_names: ["Accommodations.csv", "accommodation.zip"],
     related_table_name_with_page_size_annotation: "accommodation_image",
     page_size: 2,
     related_tables: [
@@ -186,7 +188,23 @@ describe('View existing record,', function() {
         });
 
         describe("Presentation ,", function() {
+            if (!process.env.TRAVIS) {
+                beforeAll(function() {
+                    // delete files that may have been downloaded before
+                    console.log("delete files");
+                    recordSetHelpers.deleteDownloadedFiles(testParams.file_names);
+                });
+            }
+
             recordHelpers.testPresentation(testParams);
+
+            if (!process.env.TRAVIS) {
+                afterAll(function() {
+                    // delete files that have been downloaded during tests
+                    console.log("delete files");
+                    recordSetHelpers.deleteDownloadedFiles(testParams.file_names);
+                });
+            }
         });
 
     });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -795,6 +795,10 @@ var recordPage = function() {
         return element(by.css(".modal-body"));
     };
 
+    this.getShareModal = function() {
+        return element(by.css(".share-citation"));
+    };
+
     this.getModalListElements = function() {
         return this.getModalText().all(by.tagName('li'));
     };

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -79,11 +79,11 @@ exports.testPresentation = function (tableParams) {
     it("should show the share dialog when clicking the share button with permalink and citation present.", function(done) {
         var shareButton = chaisePage.recordPage.getShareButton();
 
-        shareButton.click().then(function () {
-            var modalContent = element(by.css('.modal-content'));
+        browser.wait(EC.elementToBeClickable(shareButton), browser.params.defaultTimeout);
 
+        shareButton.click().then(function () {
             // wait for dialog to open
-            chaisePage.waitForElement(modalContent);
+            chaisePage.waitForElement(chaisePage.recordPage.getShareModal());
 
             // verify modal dialog contents
             expect(chaisePage.recordEditPage.getModalTitle().element(by.tagName("strong")).getText()).toBe("Share Citation", "Share citation modal title is incorrect");
@@ -99,9 +99,15 @@ exports.testPresentation = function (tableParams) {
             expect(chaisePage.recordPage.getCitationHeader().getText()).toBe("Citation", "Citation header is incorrect");
             expect(chaisePage.recordPage.getCitationText().getText()).toBe(tableParams.citationParams.citation, "citation text is incorrect");
 
+            return chaisePage.recordPage.getShareModal();
+        }).then(function (modal) {
+            // disable animations in modal so that it doesn't "fade out" (instead it instantly disappears when closed) which we can't track with waitFor conditions
+            modal.allowAnimations(false);
+
             // close dialog
             return chaisePage.recordEditPage.getModalTitle().element(by.tagName("button")).click();
         }).then(function () {
+
             done();
         }).catch(function(err){
             console.log(err);
@@ -110,7 +116,10 @@ exports.testPresentation = function (tableParams) {
     });
 
     it("should have '2' options in the dropdown menu.", function (done) {
-        chaisePage.recordsetPage.getExportDropdown().click().then(function () {
+        var exportButton = chaisePage.recordsetPage.getExportDropdown();
+        browser.wait(EC.elementToBeClickable(exportButton), browser.params.defaultTimeout);
+
+        chaisePage.clickButton(exportButton).then(function () {
             expect(chaisePage.recordsetPage.getExportOptions().count()).toBe(2, "incorrect number of export options");
             // close the dropdown
             return chaisePage.recordsetPage.getExportDropdown().click();


### PR DESCRIPTION
This PR adds export to `record` app. This adds a default download as CSV option that will always show up on `record` app now in the dropdown. If there is an existing export annotation for the table represented by the record page, the options defined by the annotation will show up in the dropdown menu.

A minor change also included was the use of `allowAnimations(false)` which can be called on any element found using protractor (angular) selectors. This removes the fade animation for when the modal is closed so that a click event that occurs in the next test case doesn't try to click on the modal or it's backdrop while it's fading out.