### PR TITLE
update main entity on updating the record page

### DIFF
--- a/record/record.utils.js
+++ b/record/record.utils.js
@@ -187,6 +187,9 @@
             if (!isUpdate) {
                 $rootScope.recordFlowControl.occupiedSlots = 0;
                 $rootScope.recordFlowControl.counter = 0;
+            } else {
+                // we want to update the main entity on update
+                $rootScope.isMainDirty = true;
             }
             $rootScope.recordFlowControl.counter++;
 


### PR DESCRIPTION
As the title suggests, we should update the main entity when we're updating the record page. It's a very simple change, but I'm not sure how we can actually test this.