### PR TITLE
fix check presence bug

### DIFF
--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1426,7 +1426,7 @@
                         scope.checkboxRows[1].selected = false;
                         if (scope.facetColumn.hasNullFilter) {
                             scope.checkboxRows[1].selected = true;
-                            scope.facetModel.appliedFilters.push(facetingUtils.getNotNullFilter());
+                            scope.facetModel.appliedFilters.push(facetingUtils.getNullFilter());
                         }
 
                         return defer.resolve(true), defer.promise;


### PR DESCRIPTION
The list of filters that we're showing to the users is different from the actual list of filters that are used for faceting. It's chaise responsibility to keep them in sync. For check presence, I was always showing a `not-null` filter (breadcrumb) which this PR fixes it.