### PR TITLE
remove null filter from check presence facet

### DIFF
--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1429,7 +1429,7 @@
                     parentCtrl.register(currentCtrl, scope.facetColumn, scope.index);
                     scope.parentCtrl = parentCtrl;
 
-                    scope.checkboxRows = [facetingUtils.getNotNullFilter(), facetingUtils.getNullFilter()];
+                    scope.checkboxRows = [facetingUtils.getNotNullFilter()];
 
                     scope.updateFacetColumn = function () {
                         var defer = $q.defer();
@@ -1482,7 +1482,9 @@
                         }
 
                         if (row.selected) {
-                            scope.facetModel.appliedFilters.push(row.isNotNull ? facetingUtils.getNotNullFilter() : facetingUtils.getNullFilter());
+                            if (row.isNotNull) {
+                                scope.facetModel.appliedFilters.push(facetingUtils.getNotNullFilter());
+                            }
                         } else {
                             scope.facetModel.appliedFilters = scope.facetModel.appliedFilters.filter(function (f) {
                                 return f.uniqueId !== row.uniqueId;

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1441,11 +1441,11 @@
                             scope.facetModel.appliedFilters.push(facetingUtils.getNotNullFilter());
                         }
 
-                        scope.checkboxRows[1].selected = false;
-                        if (scope.facetColumn.hasNullFilter) {
-                            scope.checkboxRows[1].selected = true;
-                            scope.facetModel.appliedFilters.push(facetingUtils.getNullFilter());
-                        }
+                        // scope.checkboxRows[1].selected = false;
+                        // if (scope.facetColumn.hasNullFilter) {
+                        //     scope.checkboxRows[1].selected = true;
+                        //     scope.facetModel.appliedFilters.push(facetingUtils.getNullFilter());
+                        // }
 
                         return defer.resolve(true), defer.promise;
                     };

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -1108,7 +1108,7 @@ describe("Viewing Recordset with Faceting,", function() {
                                 }, browser.params.defaultTimeout);
 
                                 recordSetHelpers.openFacetAndTestFilterOptions(
-                                    testParams.name, idx, ['All Records With Value', 'No Value'], done
+                                    testParams.name, idx, ['All Records With Value'], done
                                 );
                             });
 
@@ -1116,9 +1116,9 @@ describe("Viewing Recordset with Faceting,", function() {
                                 recordSetHelpers.testSelectFacetOption(idx, 0, facetParams.name, facetParams.notNullFilter, facetParams.notNullNumRows, done);
                             });
 
-                            it("selecting the null option, should only show the applicable rows.", function (done) {
-                                recordSetHelpers.testSelectFacetOption(idx, 1, facetParams.name, facetParams.nullFilter, facetParams.nullNumRows, done);
-                            });
+                            // it("selecting the null option, should only show the applicable rows.", function (done) {
+                            //     recordSetHelpers.testSelectFacetOption(idx, 1, facetParams.name, facetParams.nullFilter, facetParams.nullNumRows, done);
+                            // });
 
                             it ("should close the facet.", function (done) {
                                 chaisePage.recordsetPage.getFacetById(idx).click().then(function () {

--- a/test/e2e/utils/recordset-helpers.js
+++ b/test/e2e/utils/recordset-helpers.js
@@ -18,7 +18,7 @@ exports.openFacetAndTestFilterOptions = function (name, facetIdx, filterOptions,
         // wait for facet checkboxes to load
         browser.wait(function () {
             return chaisePage.recordsetPage.getFacetOptions(facetIdx).count().then(function(ct) {
-                return ct == 2;
+                return ct == 1;
             });
         }, browser.params.defaultTimeout);
 


### PR DESCRIPTION
This removes the null facet option from the check presence facet. This was missed when the other changes for issue #1655 were made.