### PR TITLE
Table header missing in recordedit resultset

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -254,9 +254,7 @@
          * be resolved with `true` if the request was successful.
          */
         function _readMainEntity (vm, hideSpinner, counterer) {
-            if (!vm.columnModels) {
-                _attachExtraAttributes(vm);
-            }
+            _attachExtraAttributes(vm);
 
             // cancel timeout loop that may still be running and hide the spinner and "Loading ..."
             $timeout.cancel(pushMore);
@@ -595,6 +593,8 @@
          * In this case, columnModels is the attribute that need to be updated.
          */
         function _attachExtraAttributes(vm) {
+            if (vm.attributesAlreadyAttached) return;
+            vm.attributesAlreadyAttached = true;
             vm.columnModels = [];
             vm.reference.columns.forEach(function (col) {
                 vm.columnModels.push({
@@ -792,7 +792,7 @@
             scope.$watch(function () {
                 return (scope.vm && scope.vm.reference) ? scope.vm.reference.columns : null;
             }, function (newValue, oldValue) {
-                if(angular.equals(newValue, oldValue) || !newValue){
+                if(!newValue){
                     return;
                 }
                 _attachExtraAttributes(scope.vm);
@@ -1022,7 +1022,7 @@
             scope.$watch(function () {
                 return (scope.vm && scope.vm.reference) ? scope.vm.reference.columns : null;
             }, function (newValue, oldValue) {
-                if(angular.equals(newValue, oldValue) || !newValue){
+                if(!newValue){
                     return;
                 }
                 _attachExtraAttributes(scope.vm);

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -12,6 +12,7 @@ var testParams = {
         table_name: "accommodation",
         table_displayname: "Accommodations",
         table_comment: "List of different types of accommodations",
+        not_travis: true,
         primary_keys: ["id"],
         columns: [
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
@@ -21,27 +22,27 @@ var testParams = {
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", type: "longtext", nullok: false},
             { name: "description", title: "Description", type: "markdown"},
+            { name: "json_col", title: "json_col", type:"json"},
             { name: "no_of_rooms", title: "Number of Rooms", type: "int2"},
             { name: "opened_on", title: "Operational Since", type: "timestamptz", nullok: false },
             { name: "date_col", title: "date_col", type: "date"},
-            { name: "luxurious", title: "Is Luxurious", type: "boolean" },
-            { name: "json_col", title: "json_col", type:"json"}
+            { name: "luxurious", title: "Is Luxurious", type: "boolean" }
         ],
         inputs: [
             {"title": "new title 1", "website": "https://example1.com", "category": {index: 0, value: "Hotel"},
-             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1",
+             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1", "json_col": JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2),
              "no_of_rooms": "1", "opened_on": moment("2017-01-01 01:01:01", "YYYY-MM-DD hh:mm:ss"), "date_col": "2017-01-01", "luxurious": false},
             {"title": "new title 2", "website": "https://example2.com", "category": {index: 1, value: "Ranch"},
-             "rating": "2",  "summary": "This is the summary of this column 2.", "description": "## Description 2",
+             "rating": "2",  "summary": "This is the summary of this column 2.", "description": "## Description 2", "json_col": JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2),
              "no_of_rooms": "2", "opened_on": moment("2017-02-02 02:02:02", "YYYY-MM-DD hh:mm:ss"), "date_col": "2017-02-02", "luxurious":  true}
         ],
         formsAfterInput: 3,
         result_columns: [
-            "title", "website", "product-add_fk_category", "rating", "summary", "description", "no_of_rooms", "opened_on", "date_col", "luxurious"
+            "title", "website", "product-add_fk_category", "rating", "summary", "description", "json_col", "no_of_rooms", "opened_on", "date_col", "luxurious"
         ],
         results: [
-            ["new title 1",  {"link":"https://example1.com/", "value":"Link to Website"}, {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-add:category/term=Hotel", "value":"Hotel"}, "1.0000", "This is the summary of this column 1.", "Description 1", "1", "2017-01-01 01:01:01", "2017-01-01", "false"],
-            ["new title 2",  {"link":"https://example2.com/", "value":"Link to Website"}, {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-add:category/term=Ranch", "value":"Ranch"}, "2.0000", "This is the summary of this column 2.", "Description 2", "2", "2017-02-02 02:02:02", "2017-02-02", "true"]
+            ["new title 1",  {"link":"https://example1.com/", "value":"Link to Website"}, {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-add:category/term=Hotel", "value":"Hotel"}, "1.0000", "This is the summary of this column 1.", "Description 1", JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2), "1", "2017-01-01 01:01:01", "2017-01-01", "false"],
+            ["new title 2",  {"link":"https://example2.com/", "value":"Link to Website"}, {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-add:category/term=Ranch", "value":"Ranch"}, "2.0000", "This is the summary of this column 2.", "Description 2", JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2), "2", "2017-02-02 02:02:02", "2017-02-02", "true"]
         ],
         files: []
     }, {
@@ -49,6 +50,7 @@ var testParams = {
        table_name: "file",
        table_displayname: "file",
        table_comment: "asset/object",
+       not_travis: !process.env.TRAVIS,
        primary_keys: ["id"],
        columns: [
            { name: "fileid", title: "fileid", type: "int4" },

--- a/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
@@ -17,6 +17,7 @@ var testParams = {
         table_displayname: "Accommodations",
         table_comment: "List of different types of accommodations",
         key: { name: "id", value: "2000", operator: "="},
+        not_travis: true,
         primary_keys: ["id"],
         columns: [
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
@@ -26,31 +27,31 @@ var testParams = {
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", nullok: false, type: "longtext"},
             { name: "description", title: "Description", type: "markdown"},
+            { name: "json_col", title: "json_col", value:JSON.stringify({"name": "testing"},undefined,2) , type: "json" },
             { name: "no_of_rooms", title: "Number of Rooms", type: "int2"},
             { name: "opened_on", title: "Operational Since", type: "timestamptz", nullok: false },
             { name: "date_col", title: "date_col", type: "date"},
-            { name: "luxurious", title: "Is Luxurious", type: "boolean" },
-            { name: "json_col", title: "json_col", value:JSON.stringify({"name": "testing"},undefined,2) , type: "json" }
+            { name: "luxurious", title: "Is Luxurious", type: "boolean" }
         ],
         values: [
             {"id": "2000", "title": "Sherathon Hotel", "website": "http://www.starwoodhotels.com/sheraton/index.html", "category": "Castle", "rating": "4.3",
              "summary": "Sherathon Hotels is an international hotel company with more than 990 locations in 73 countries. The first Radisson Hotel was built in 1909 in Minneapolis, Minnesota, US. It is named after the 17th-century French explorer Pierre-Esprit Radisson.",
-             "description": "**CARING. SHARING. DARING.**", "no_of_rooms": "23", "opened_on": moment("12/9/2008, 12:00:00 AM", "MM/DD/YYYY, HH:mm:ss A"),
+             "description": "**CARING. SHARING. DARING.**",  "json_col": null, "no_of_rooms": "23", "opened_on": moment("12/9/2008, 12:00:00 AM", "MM/DD/YYYY, HH:mm:ss A"),
              "date_col": "2008-12-09", "luxurious": "true"
             }
         ],
         inputs: [
             {"title": "new title 1", "website": "https://example1.com", "category": {index: 1, value: "Ranch"},
-             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1",
+             "rating": "1", "summary": "This is the summary of this column 1.", "description": "## Description 1", "json_col": JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2),
              "no_of_rooms": "1", "opened_on": moment("2017-01-01 01:01:01", "YYYY-MM-DD hh:mm:ss"), "date_col": "2017-01-01", "luxurious": false},
         ],
         result_columns: [
-            "title", "website", "product-edit_fk_category", "rating", "summary", "description", "no_of_rooms", "opened_on", "date_col", "luxurious"
+            "title", "website", "product-edit_fk_category", "rating", "summary", "description", "json_col", "no_of_rooms", "opened_on", "date_col", "luxurious"
         ],
         results: [
             ["new title 1",  {"link":"https://example1.com/", "value":"Link to Website"},
             {"link":"{{{chaise_url}}}/record/#{{catalog_id}}/product-edit:category/id=10004", "value":"Castle"},
-            "1.0000", "This is the summary of this column 1.", "Description 1", "1", "2017-01-01 01:01:01", "2017-01-01", "false"]
+            "1.0000", "This is the summary of this column 1.", "Description 1", JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2), "1", "2017-01-01 01:01:01", "2017-01-01", "false"]
         ],
         files: []
     }, {
@@ -59,6 +60,7 @@ var testParams = {
        record_displayname: "90008", //since this is in single-edit, displayname is rowname.
        table_displayname: "File",
        table_comment: "asset/object",
+       not_travis: !process.env.TRAVIS,
        primary_keys: ["id"],
        key: { name: "id", value: "90008", operator: "="},
        columns: [

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1076,6 +1076,10 @@ var recordsetPage = function() {
         return element(by.id('permalink'));
     };
 
+    this.getTableHeader = function () {
+        return element(by.tagName("thead"));
+    }
+
     this.getRecordsetColumnHeader = function (name) {
         return element(by.id(name + "-header"));
     };

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -5,74 +5,6 @@ var chance = require('chance').Chance();
 var exec = require('child_process').execSync;
 var EC = protractor.ExpectedConditions;
 
-//test params for markdownPreview
-var markdownTestParams = [{
-    "raw": "RBK Project ghriwvfw nwoeifwiw qb2372b wuefiquhf pahele kabhi na phelke kabhiy gqeequhwqh",
-    "markdown": "<h3>RBK Project ghriwvfw nwoeifwiw qb2372b wuefiquhf pahele kabhi na phelke kabhiy gqeequhwqh</h3>\n",
-    "comm":"Ctrl+H"
-},
-  {
-    "raw":"E15.5 embryonic kidneys for sections\n" +
-          "- E18.5 embryonic kidneys for cDNA synthesis\n"+
-          "- Sterile PBS\n" +
-          "- QIAShredder columns (Qiagen, cat no. 79654)\n" +
-          "- DEPC-Treated Water",
-   "markdown":  "<ul>\n"+
-                "<li>E15.5 embryonic kidneys for sections</li>\n" +
-                "<li>E18.5 embryonic kidneys for cDNA synthesis</li>\n" +
-                "<li>Sterile PBS</li>\n" +
-                "<li>QIAShredder columns (Qiagen, cat no. 79654)</li>\n" +
-                "<li>DEPC-Treated Water</li>\n" +
-                "</ul>\n",
-    "comm":"Ctrl+U"
-  },
-  {
-    "raw": "This is bold text. nuf2uh3498hcuh23uhcu29hh  nfwnfi2nfn k2mr2ijri. Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru",
-    "markdown": "<p><strong>This is bold text. nuf2uh3498hcuh23uhcu29hh  nfwnfi2nfn k2mr2ijri. Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru</strong></p>\n",
-    "comm":"Ctrl+B"
-  },
-  {
-    "raw":"This is italic text fcj2ij3ijjcn 2i3j2ijc3roi2joicj. Hum ja rahal chi gaam ta pher kail aaib. Khana kha ka aib rehal chi parson tak.",
-    "markdown":"<p><em>This is italic text fcj2ij3ijjcn 2i3j2ijc3roi2joicj. Hum ja rahal chi gaam ta pher kail aaib. Khana kha ka aib rehal chi parson tak.</em></p>\n",
-    "comm":"Ctrl+I"
-  },
-  {
-    "raw":"~~Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru~~",
-    "markdown":"<p><s>Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru</s></p>\n",
-    "comm":" "
-  },
-  {
-    "raw": "X^2^+Y^2^+Z^2^=0",
-    "markdown": "<p>X<sup>2</sup>+Y<sup>2</sup>+Z<sup>2</sup>=0</p>\n",
-    "comm":" "
-  }
-];
-
-var JSONTestParams=[
-    {
-        stringVal:"{}",
-    },
-    {
-        stringVal:"{\"name\":\"tester\"}",
-    },
-    {
-        stringVal:"6534.9987",
-    },
-    {
-        stringVal:"null",
-    },
-    {
-        stringVal:"          ",
-    },
-    {
-        stringVal:JSON.stringify({"items": {"qty": 6,"product": "apple"},"customer": "Nitish Sahu"},undefined,2),
-        expectedValue:true
-    }
-
-];
-
-
-
 /**
  * Test presentation, validation, and inputting a value for different column types in recordedit app.
  *
@@ -193,7 +125,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
             });
         });
     });
-    
+
     if (tableParams.table_name === "accommodation") {
         it("should give a warning when leaving the edit page with unsaved changes", function (done) {
             var EC = protractor.ExpectedConditions;
@@ -212,7 +144,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
             });
         });
     }
-    
+
     var testMultipleRecords = function(recordIndex) {
 
         // helper functions:
@@ -364,43 +296,101 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
             if (jsonCols.length > 0) {
                 describe("JSON fields, ", function () {
+                    var JSONTestParams=[
+                        { stringVal:"{}" },
+                        { stringVal:"{\"name\":\"tester\"}" },
+                        { stringVal:"6534.9987" },
+                        { stringVal:"null" },
+                        { stringVal:"          "}
+                    ];
+
                     it("should show textarea input for JSON datatype and then set the value", function() {
                         jsonCols.forEach(function(c) {
-                        chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
-                            expect(jsonTxtArea.isDisplayed()).toBeTruthy();
-                            jsonTxtArea.column = c;
+                            chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
+                                expect(jsonTxtArea.isDisplayed()).toBeTruthy();
+                                jsonTxtArea.column = c;
 
-                            JSONDataTypeFields.push(jsonTxtArea);
-                            var value = getRecordValue(c.name);
+                                JSONDataTypeFields.push(jsonTxtArea);
+                                var value = getRecordValue(c.name);
 
-                            if (value != undefined) {
-                                expect(jsonTxtArea.getAttribute('value')).toBe(value, colError(c.name , "Doesn't have the expected value."));
-                            }
+                                if (value != undefined) {
+                                    expect(jsonTxtArea.getAttribute('value')).toBe(value, colError(c.name , "Doesn't have the expected value."));
+                                }
+                            });
                         });
                     });
-                 });
 
-                 it("should only allow valid JSON values", function(){
-                     jsonCols.forEach(function(c) {
-                         chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
-                             for (i = 0; i < JSONTestParams.length; i++) {
-                                 jsonTxtArea.clear();
-                                 (function(input){
-                                     c._value = input;
-                                     jsonTxtArea.sendKeys(input);
-                                     chaisePage.recordEditPage.getJSONInputErrorMessage(jsonTxtArea, 'json').then(function(error){
-                                         expect(error).toBe(null, colError(c.name , "Some Valid JSON Values were not accepted"));
-                                     });
-                                 })(JSONTestParams[i].stringVal);
-                             }//for
-                         });
-                     });
-                 });
-             });
-         }
+                    it("should only allow valid JSON values", function(){
+                        jsonCols.forEach(function(c) {
+                            chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
+                                for (i = 0; i < JSONTestParams.length; i++) {
+                                    jsonTxtArea.clear();
+                                    (function(input){
+                                        c._value = input;
+                                        jsonTxtArea.sendKeys(input);
+                                        chaisePage.recordEditPage.getJSONInputErrorMessage(jsonTxtArea, 'json').then(function(error){
+                                            expect(error).toBe(null, colError(c.name , "Some Valid JSON Values were not accepted"));
+                                        });
+                                    })(JSONTestParams[i].stringVal);
+                                }//for
+                            });
+                        });
+                    });
+
+                    it("set the correct value.", function () {
+                        jsonCols.forEach(function(c) {
+                            chaisePage.recordEditPage.getTextAreaForAcolumn(c.name, recordIndex).then(function(jsonTxtArea) {
+                                jsonTxtArea.clear();
+                                var input = getRecordInput(c.name, "");
+                                c._value = input;
+                                jsonTxtArea.sendKeys(input);
+                                expect(jsonTxtArea.getAttribute('value')).toEqual(input, colError(c.name, "Couldn't change the value."));
+                            });
+                        });
+                    });
+                });
+            }
 
             if (markdownCols.length > 0) {
                 describe("Markdown fields, ", function () {
+                    //test params for markdownPreview
+                    var markdownTestParams = [{
+                            "raw": "RBK Project ghriwvfw nwoeifwiw qb2372b wuefiquhf pahele kabhi na phelke kabhiy gqeequhwqh",
+                            "markdown": "<h3>RBK Project ghriwvfw nwoeifwiw qb2372b wuefiquhf pahele kabhi na phelke kabhiy gqeequhwqh</h3>\n",
+                            "comm":"Ctrl+H"
+                        }, {
+                            "raw":"E15.5 embryonic kidneys for sections\n" +
+                                "- E18.5 embryonic kidneys for cDNA synthesis\n"+
+                                "- Sterile PBS\n" +
+                                "- QIAShredder columns (Qiagen, cat no. 79654)\n" +
+                                "- DEPC-Treated Water",
+                            "markdown":  "<ul>\n"+
+                                "<li>E15.5 embryonic kidneys for sections</li>\n" +
+                                "<li>E18.5 embryonic kidneys for cDNA synthesis</li>\n" +
+                                "<li>Sterile PBS</li>\n" +
+                                "<li>QIAShredder columns (Qiagen, cat no. 79654)</li>\n" +
+                                "<li>DEPC-Treated Water</li>\n" +
+                                "</ul>\n",
+                            "comm":"Ctrl+U"
+                        }, {
+                            "raw": "This is bold text. nuf2uh3498hcuh23uhcu29hh  nfwnfi2nfn k2mr2ijri. Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru",
+                            "markdown": "<p><strong>This is bold text. nuf2uh3498hcuh23uhcu29hh  nfwnfi2nfn k2mr2ijri. Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru</strong></p>\n",
+                            "comm":"Ctrl+B"
+                        }, {
+                            "raw":"This is italic text fcj2ij3ijjcn 2i3j2ijc3roi2joicj. Hum ja rahal chi gaam ta pher kail aaib. Khana kha ka aib rehal chi parson tak.",
+                            "markdown":"<p><em>This is italic text fcj2ij3ijjcn 2i3j2ijc3roi2joicj. Hum ja rahal chi gaam ta pher kail aaib. Khana kha ka aib rehal chi parson tak.</em></p>\n",
+                            "comm":"Ctrl+I"
+                        }, {
+                            "raw":"~~Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru~~",
+                            "markdown":"<p><s>Strikethrough wnnfw nwn wnf wu2h2h3hr2hrf13hu u 2u3h u1ru31r 1n3r uo13ru1ru</s></p>\n",
+                            "comm":" "
+                        }, {
+                            "raw": "X^2^+Y^2^+Z^2^=0",
+                            "markdown": "<p>X<sup>2</sup>+Y<sup>2</sup>+Z<sup>2</sup>=0</p>\n",
+                            "comm":" "
+                        }
+                    ];
+
                     it('should have the correct value.', function () {
                         markdownCols.forEach(function(c) {
                             var inp = chaisePage.recordEditPage.getInputById(recordIndex, c.title);
@@ -1387,9 +1377,14 @@ exports.testSubmission = function (tableParams, isEditMode) {
             });
 
             //NOTE: in travis we're not uploading the file and therefore this test case will fail
-            if (!process.env.TRAVIS && tableParams.files.length > 0) {
-                it('table must show correct resutls.', function() {
-                    chaisePage.recordsetPage.getRows().then(function(rows) {
+            if (tableParams.not_travis) {
+                it('table must show correct results.', function() {
+
+                    chaisePage.recordsetPage.getTableHeader().all(by.tagName("th")).then(function (headerCells) {
+                        expect(headerCells.length).toBe(tableParams.result_columns.length, "number of cells in table header is incorrect");
+
+                        return chaisePage.recordsetPage.getRows();
+                    }).then(function(rows) {
                         // same row count
                         expect(rows.length).toBe(tableParams.results.length, "number of rows are not as expected.");
 


### PR DESCRIPTION
Fixed a bug with table.js that would hide the table header for multi-create and multi-edit resultset view. This was introduced by the 400-QTE PR being merged into master when we removed one of the cases that "initialized" the columnModels.