### PR TITLE
Support for Custom Error messages for deriva-webapps

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -101,7 +101,7 @@
 
             /**
             * @type {string}
-            * @desc   Error message 
+            * @desc   Error message
              */
             this.message = noDataMessageDesc;
 

--- a/common/errors.js
+++ b/common/errors.js
@@ -101,7 +101,7 @@
 
             /**
             * @type {string}
-            * @desc   Error message
+            * @desc   Error message 
              */
             this.message = noDataMessageDesc;
 
@@ -134,11 +134,55 @@
         InvalidInputError.prototype = Object.create(Error.prototype);
         InvalidInputError.prototype.constructor = InvalidInputError;
 
+        /**
+         * CustomError - throw custom error from Apps outside Chaise.
+         *
+         * @param  {string} header       Header of the Error Modal         * 
+         * @param  {string} message      Error message to display in Modal body. Can include HTML tags.
+         * @param  {string} redirectUrl  URL to redirect to on clicking ok.
+         * @param  {string} clickActionMessage  Message to display for the OK button. Can include HTML tags.
+         * @return {object}              Error Object
+         */
+        function CustomError(header, message, redirectUrl, clickActionMessage){  
+            /**
+             * @type {string}
+             * @desc Text to display in the Error Modal Header
+             */          
+            this.status = header;
+
+            /**
+             * @type {string}
+             * @desc Error message that shows in the Error modal body
+             */
+            this.message = message;
+
+            /**
+             * @type {object}
+             * @desc  custom object to store miscelleneous elements viz. redirectUrl, message for the ok button
+             */
+            this.errorData = {};
+
+            /**
+             * @type {string}
+             * @desc URL to redirect to when users click the OK button
+             */
+            this.errorData.redirectUrl = redirectUrl;
+
+            /**
+             * @type {string}
+             * @desc Action message to display for click of the OK button
+             */
+            this.errorData.clickActionMessage = clickActionMessage;
+        }
+        CustomError.prototype = Object.create(Error.prototype);
+        CustomError.prototype.constructor = CustomError;
+
         return {
             multipleRecordError: multipleRecordError,
             noRecordError:noRecordError,
             InvalidInputError: InvalidInputError,
-            MalformedUriError: MalformedUriError
+            MalformedUriError: MalformedUriError,
+            CustomError: CustomError
         };
     }])
 
@@ -275,6 +319,10 @@
                 if (DataUtils.isObjectAndKeyDefined(exception.errorData, 'gotoTableDisplayname')) pageName = exception.errorData.gotoTableDisplayname;
                 if (DataUtils.isObjectAndKeyDefined(exception.errorData, 'redirectUrl')) redirectLink = exception.errorData.redirectUrl;
                 if (exception instanceof ERMrest.NotFoundError && !Session.getSessionValue()) showLogin = true;
+            } else if (exception instanceof Errors.CustomError ) {
+                logError(exception);
+                message = exception.message;
+                redirectLink = exception.errorData.redirectUrl;
             } else {
                 logError(exception);
                 message = errorMessages.systemAdminMessage;

--- a/common/modal.js
+++ b/common/modal.js
@@ -95,6 +95,8 @@
             vm.clickActionMessage =  messageMap.recordAvailabilityError.multipleRecords;
         } else if (exception instanceof Errors.noRecordError) {
             vm.clickActionMessage = messageMap.recordAvailabilityError.noRecordsFound;
+        } else if (exception instanceof Errors.CustomError && exception.errorData.clickActionMessage) {
+            vm.clickActionMessage = exception.errorData.clickActionMessage;
         } else if (ERMrest && exception instanceof ERMrest.InvalidFilterOperatorError) {
             vm.clickActionMessage = messageMap.recordAvailabilityError.noRecordsFound;
         } else if (ERMrest && isErmrestErrorNeedReplace(exception)) {

--- a/common/utils.js
+++ b/common/utils.js
@@ -732,6 +732,10 @@
         // takes pathname attribute of window.location object and returns app name
         // path should be a string literal which appears before #catalog id in URL (/chaise/recordset/)
         function appNamefromUrlPathname(path){
+            if (path.includes("deriva-webapps")) {
+                var app = path.substring(path.indexOf("deriva-webapps"));
+                return app.substring(app.indexOf('/') + 1, app.lastIndexOf('/'));
+            }
           var newPath = path.slice(0, -1);
           var lastSlash = newPath.lastIndexOf('/');
           return newPath.substring(lastSlash + 1, newPath.length);

--- a/common/utils.js
+++ b/common/utils.js
@@ -732,10 +732,6 @@
         // takes pathname attribute of window.location object and returns app name
         // path should be a string literal which appears before #catalog id in URL (/chaise/recordset/)
         function appNamefromUrlPathname(path){
-            if (path.includes("deriva-webapps")) {
-                var app = path.substring(path.indexOf("deriva-webapps"));
-                return app.substring(app.indexOf('/') + 1, app.lastIndexOf('/'));
-            }
           var newPath = path.slice(0, -1);
           var lastSlash = newPath.lastIndexOf('/');
           return newPath.substring(lastSlash + 1, newPath.length);


### PR DESCRIPTION
- Added a new CustomError type to the "Errors" factory
- Currently, the CustomError has 4 parameters for error header, message,redirectUrl and ok button message.
- Didn't add support for loginLink as session management is not implemented in any of the deriva webapps currently. Also didn't add subMessage and stack trace.