### PR TITLE
scroll to top after submitting 

### DIFF
--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -217,6 +217,7 @@
                 form = vm.formContainer,
                 model = vm.recordEditModel;
 
+            angular.element(document.getElementsByClassName('main-container')[0]).scrollTo(0, 0, 500);
             if (form.$invalid) {
                 vm.readyToSubmit = false;
                 AlertsService.addAlert('Sorry, the data could not be submitted because there are errors on the form. Please check all fields and try again.', 'error');


### PR DESCRIPTION
After submitting the content in recordedit, the page will scroll to the top (before sending the request). This will show the user the alert notification that is displayed regardless of a success or error.