### PR TITLE
Use ok button to dismiss instead of redirect

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -137,13 +137,14 @@
         /**
          * CustomError - throw custom error from Apps outside Chaise.
          *
-         * @param  {string} header       Header of the Error Modal         * 
-         * @param  {string} message      Error message to display in Modal body. Can include HTML tags.
-         * @param  {string} redirectUrl  URL to redirect to on clicking ok.
+         * @param  {string} header              Header of the Error Modal         * 
+         * @param  {string} message             Error message to display in Modal body. Can include HTML tags.
+         * @param  {string} redirectUrl         URL to redirect to on clicking ok.
          * @param  {string} clickActionMessage  Message to display for the OK button. Can include HTML tags.
-         * @return {object}              Error Object
+         * @param  {string} clickOkToDismiss    Set true to dismiss the error modal on clicking the OK button
+         * @return {object}                     Error Object
          */
-        function CustomError(header, message, redirectUrl, clickActionMessage){  
+        function CustomError(header, message, redirectUrl, clickActionMessage, clickOkToDismiss){  
             /**
              * @type {string}
              * @desc Text to display in the Error Modal Header
@@ -173,6 +174,12 @@
              * @desc Action message to display for click of the OK button
              */
             this.errorData.clickActionMessage = clickActionMessage;
+
+            /**
+             * @type {boolean}
+             * @desc Set true to dismiss the error modal on clicking the OK button
+             */
+            this.clickOkToDismiss = clickOkToDismiss;
         }
         CustomError.prototype = Object.create(Error.prototype);
         CustomError.prototype.constructor = CustomError;

--- a/common/modal.js
+++ b/common/modal.js
@@ -121,6 +121,11 @@
         };
 
         vm.ok = function () {
+            var dismiss = exception.clickOkToDismiss;
+            if(dismiss != null && dismiss != undefined && dismiss){
+                $uibModalInstance.dismiss('cancel');
+                return;
+            }            
             $uibModalInstance.close();
         };
 

--- a/common/modal.js
+++ b/common/modal.js
@@ -114,18 +114,14 @@
         // <p> tag is added to maintain the space between click action message and buttons
         // Also maintains consistency  in their placement irrespective of reload message
         vm.clickActionMessage += reloadMessage;
-
+        
+        vm.clickOkToDismiss = exception.clickOkToDismiss;
         vm.showDetails = function() {
             vm.displayDetails = !vm.displayDetails;
             vm.linkText = (vm.displayDetails) ? messageMap.hideErrDetails : messageMap.showErrDetails;
         };
 
         vm.ok = function () {
-            var dismiss = exception.clickOkToDismiss;
-            if(dismiss != null && dismiss != undefined && dismiss){
-                $uibModalInstance.dismiss('cancel');
-                return;
-            }            
             $uibModalInstance.close();
         };
 

--- a/common/templates/errorDialog.modal.html
+++ b/common/templates/errorDialog.modal.html
@@ -22,5 +22,5 @@
 </div>
 <div class="modal-footer">
     <button ng-show="ctrl.showReloadBtn" class="btn btn-default" type="button" ng-click="ctrl.reload()">Reload</button>
-    <button class="btn btn-danger" type="button" ng-click="ctrl.ok()">OK</button>
+    <button class="btn btn-danger" type="button" ng-click="ctrl.clickOkToDismiss ? ctrl.cancel() : ctrl.ok()">OK</button>
 </div>


### PR DESCRIPTION
- In the boolean-search app there is a requirement to dismiss the error modal on clicking the ok button