### PR TITLE
Record simple view

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -624,6 +624,11 @@ th.multi-select-width {
     color: #333;
 }
 
+
+.hide-border>td {
+    border-bottom: none !important;
+}
+
 .entity-term {
     background-color: #428bca;
     font-size: .8em;

--- a/common/templates/record.html
+++ b/common/templates/record.html
@@ -1,6 +1,6 @@
 <table class="table table-fixed-layout" id="tblRecord">
-    <tr ng-repeat="col in columnModels" ng-if="showColumn($index) || showInlineTable($index)" id="{{'row-' + col.column.name}}">
-        <td class="entity-key col-xs-2">
+    <tr ng-repeat="col in columnModels" ng-if="showColumn($index) || showInlineTable($index)" id="{{'row-' + col.column.name}}" ng-class="{'hide-border': $root.hideColumnHeaders}">
+        <td ng-hide="$root.hideColumnHeaders" class="entity-key col-xs-2">
             <span class="column-displayname" ng-attr-uib-tooltip="{{::(col.column.comment) ? col.column.comment : undefined}}" ng-attr-tooltip-placement="{{::(col.column.comment) ? 'right' : undefined}}">
                 <span ng-if="::col.column.displayname.isHTML" ng-bind-html="::col.column.displayname.value"></span>
                 <span ng-if="::!col.column.displayname.isHTML" ng-bind="::col.column.displayname.value"></span>

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -22,7 +22,7 @@
         vm.sidePanToggleBtnIndicator = "Show";
 
         var chaiseConfig = Object.assign({}, $rootScope.chaiseConfig);
-        $scope.recordSidePanOpen = chaiseConfig.hideTableOfContents === true ? false : true;
+
         vm.tooltip = messageMap.tooltip;
         vm.queryTimeoutTooltip = messageMap.queryTimeoutTooltip;
         vm.gotoInlineTable = function(sectionId, index) {
@@ -414,6 +414,8 @@
             return $rootScope.displayReady;
         }, function (newValue, oldValue) {
             if (newValue) {
+                $rootScope.recordSidePanOpen = (chaiseConfig.hideTableOfContents === true || $rootScope.reference.display.collapseToc === true) ? false : true;
+                $rootScope.hideColumnHeaders = $rootScope.reference.display.hideColumnHeaders;
                 $timeout(setMainContainerHeight, 0);
             }
         });

--- a/test/e2e/data_setup/data/editable-id/fk-table.json
+++ b/test/e2e/data_setup/data/editable-id/fk-table.json
@@ -1,0 +1,1 @@
+[{"id": 1, "foreign_table":1}]

--- a/test/e2e/data_setup/data/editable-id/html-name-table.json
+++ b/test/e2e/data_setup/data/editable-id/html-name-table.json
@@ -1,1 +1,1 @@
-[{"id": 1, "text": "text", "int": 17}]
+[{"id": 1, "text": "text", "int": 17, "foreign_table": 1}]

--- a/test/e2e/data_setup/schema/record/editable-id.json
+++ b/test/e2e/data_setup/schema/record/editable-id.json
@@ -119,13 +119,90 @@
                 },
                 "tag:misd.isi.edu,2015:display" : {
                     "name": "<strong>Html Name</strong>"
+                },
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "detailed": {
+                        "collapse_toc_panel": true,
+                        "hide_column_headers": true
+                    }
+                }
+            }
+        },
+        "fk-table": {
+            "kind": "table",
+            "keys": [
+                {
+                    "comment": null,
+                    "annotations": {},
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [
+                {
+                  "comment": null,
+                  "names": [["editable-id", "foreign_table"]],
+                  "foreign_key_columns": [
+                    {
+                      "table_name": "fk-table",
+                      "schema_name": "editable-id",
+                      "column_name": "foreign_table"
+                    }
+                  ],
+                  "annotations": {},
+                  "referenced_columns": [
+                    {
+                      "table_name": "html-name-table",
+                      "schema_name": "editable-id",
+                      "column_name": "id"
+                    }
+                  ]
+                }
+            ],
+            "table_name": "fk-table",
+            "schema_name": "editable-id",
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "default": null,
+                    "nullok": false,
+                    "type": {
+                        "typename": "int"
+                    }
+                }, {
+                    "name": "text",
+                    "default": "default text",
+                    "nullok": true,
+                    "type": {
+                        "typename": "text"
+                    }
+                }, {
+                    "name": "int",
+                    "default": 100,
+                    "nullok": true,
+                    "type": {
+                        "typename": "int"
+                    }
+                }, {
+                    "name": "foreign_table",
+                    "nullok": true,
+                    "type": {
+                        "typename": "int"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:visible-columns" : {
+                    "*": ["text", "int"]
                 }
             }
         }
     },
     "table_names": [
         "editable-id-table",
-        "html-name-table"
+        "html-name-table",
+        "fk-table"
     ],
     "comment": null,
     "annotations": {}

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -54,7 +54,7 @@ describe('View existing record,', function() {
 
     });
 
-    // below are the tests for the copy button
+    // tests for subtitle link, resolverImplicitCatalog, and no citation in share modal
     describe("For table " + testParams.html_table_name + ",", function() {
 
         beforeAll(function() {
@@ -75,6 +75,13 @@ describe('View existing record,', function() {
         it("should load chaise-config.js and have resolverImplicitCatalog=false,", function() {
             browser.executeScript("return chaiseConfig;").then(function(chaiseConfig) {
                 expect(chaiseConfig.resolverImplicitCatalog).toBeFalsy();
+            });
+        });
+
+        it("should hide the column headers and collapse the table of contents based on table-display annotation.", function () {
+            chaisePage.recordPage.getColumns().then(function (cols) {
+                expect(cols[0].isDisplayed()).toBeFalsy("Column names are showing.");
+                expect(chaisePage.recordPage.getSidePanel().getAttribute("class")).toContain('close-panel', 'Side Panel is visible.');
             });
         });
 
@@ -107,6 +114,7 @@ describe('View existing record,', function() {
         });
     });
 
+    // below are the tests for the copy button
     describe("For table " + testParams.table_name + ",", function() {
 
         var table, record;


### PR DESCRIPTION
This PR adds the functionality for hiding the record app column headers as well as collapsing the table of contents panel by default.

Added a test case to an existing spec. Changed schema to add an inbound FK so that the ToC panel should be drawn in the page.