### PR TITLE
Confirm form row removal modal

### DIFF
--- a/common/templates/delete-link/confirm_form_removal.modal.html
+++ b/common/templates/delete-link/confirm_form_removal.modal.html
@@ -1,0 +1,15 @@
+<div class="modal-header">
+    <h2 class="modal-title">Confirm Form Removal</h2>
+</div>
+<div class="modal-body">
+    <div style="margin-bottom: 20px">
+        Are you sure you want to remove this record from the edit form?
+    </div>
+    <div>
+        <b>Note:</b> Removing a record from this form, will not delete the record from the database.
+    </div>
+</div>
+<div class="modal-footer">
+    <button id="delete-confirmation" class="btn btn-danger btn-inverted" type="button" ng-click="ctrl.ok()">Remove</button>
+    <button class="btn btn-default" type="button" ng-click="ctrl.cancel()">Cancel</button>
+</div>

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -445,10 +445,9 @@
             }
 
             modalUtils.showModal({
-                templateUrl: UriUtils.chaiseDeploymentPath() + 'common/templates/delete-link/confirm_delete.modal.html',
+                templateUrl: UriUtils.chaiseDeploymentPath() + 'common/templates/delete-link/confirm_form_removal.modal.html',
                 controller: 'ConfirmDeleteController',
-                controllerAs: 'ctrl',
-                size: 'sm'
+                controllerAs: 'ctrl'
             }, function onSuccess() {
                 scope.$root.showSpinner = true;
                 return spliceRows(index);

--- a/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
+++ b/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
@@ -49,7 +49,6 @@ describe('Edit a record,', function() {
 
                 // check modal contents
                 var modalTitle = chaisePage.recordPage.getConfirmDeleteTitle();
-                console.log(testParams.remove_row_modal.title);
                 expect(modalTitle.getText()).toBe(testParams.remove_row_modal.title, "The title of the remove form row modal is incorrect.");
                 var modalText = chaisePage.recordPage.getModalText();
                 expect(modalText.getText()).toBe(testParams.remove_row_modal.body, "The message in remove form row modal is incorrect.");

--- a/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
+++ b/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
@@ -8,7 +8,12 @@ var testParams = {
         value: "23"
     },
     original_rows: 11,
-    rows_after: 9
+    rows_after: 9,
+    remove_row_modal:{
+        title: "Confirm Form Removal",
+        body: "Are you sure you want to remove this record from the edit form?\nNote: Removing a record from this form, will not delete the record from the database.",
+        button_text: "Remove"
+    }
 };
 
 describe('Edit a record,', function() {
@@ -39,7 +44,16 @@ describe('Edit a record,', function() {
             }).then(function (button) {
                 return chaisePage.clickButton(button);
             }).then(function () {
-                chaisePage.waitForElement(element(by.id('delete-confirmation')));
+                var removeButton = element(by.id('delete-confirmation'));
+                chaisePage.waitForElement(removeButton);
+
+                // check modal contents
+                var modalTitle = chaisePage.recordPage.getConfirmDeleteTitle();
+                console.log(testParams.remove_row_modal.title);
+                expect(modalTitle.getText()).toBe(testParams.remove_row_modal.title, "The title of the remove form row modal is incorrect.");
+                var modalText = chaisePage.recordPage.getModalText();
+                expect(modalText.getText()).toBe(testParams.remove_row_modal.body, "The message in remove form row modal is incorrect.");
+                expect(removeButton.getText()).toBe(testParams.remove_row_modal.button_text, "The button text in remove form row modal is incorrect.")
 
                 // confirm delete close
                 return chaisePage.recordEditPage.getDeleteModalButton();


### PR DESCRIPTION
- Made a new template for the modal to confirm removal of a record from the multi-record edit form
- Sample link: https://dev.rebuildingakidney.org/~divyatas/chaise/recordedit/#2/RNASeq:Experiment@sort(RMT::desc::,RCT::desc::,RID)?limit=25