### PR TITLE
Overriding max-width of tooltip & removing space before comma in tooltip

### DIFF
--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -126,6 +126,7 @@ span[uib-tooltip], .show-tooltip-border[uib-tooltip] {
 
 .tooltip-inner {
     text-align: left;
+    max-width: none;
 }
 
 .filters-tooltip {

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -113,7 +113,7 @@
                                 <span ng-if="::filter.displayname.value && !filter.displayname.isHTML" ng-bind="::filter.displayname.value"></span>
                                 <span ng-if="::filter.displayname.value == ''" ng-bind-html="defaultDisplayname.empty"></span>
                                 <span ng-if="::filter.displayname.value == null" ng-bind-html="defaultDisplayname.null"></span>
-                                <span>{{$last ? '': ','}}</span>
+                                <span style="margin-left:-4px">{{$last ? '': ','}}</span>
                             </span>
                         </span>
                         <script type="text/ng-template" id="filtersTooltipTemplate.html">


### PR DESCRIPTION
- The change in app.css solves the tooltip overflow issue (#1651) for custom filters
Sample Link - https://dev.rebuildingakidney.org/~divyatas/chaise/recordset/#2/Gene_Expression:Specimen/RID=N-H950;Stage_Ordinal=21;Stage_Ordinal=20;RID=N-GHRW@sort(Stage_Ordinal,RID)
- The change in recordset.html is to correct the format of tooltips for filters other than custom filters 
Sample Link - https://dev.rebuildingakidney.org/~divyatas/chaise/recordset/#2/RNASeq:Experiment/*::facets::N4IghgdgJiBcDaoDOB7ArgJwMYFM4gEEIwAXFAWwE8QAaELACxQEtck54QBzNKcsAA4BaDACMA1rACMAFiEA2ABoA5AEq0QAUQCyBAAoFYAJgDs8o1I08+gkROlylATnV1r-YWMmyFip9pAAXQBfEKA@sort(RMT::desc::,RCT::desc::,RID)