### PR TITLE
update record page on delete/unlink

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -783,17 +783,6 @@
                 _callonSelectedRowsChanged(scope, [tuple], isSelected);
             };
 
-            scope.$on('record-deleted', function() {
-                console.log('catching the record deleted');
-                // if there is a parent reference then this is for related
-                if (scope.parentReference) {
-                    scope.vm.logObject = {action: logActions.recordRelatedUpdate};
-                } else {
-                    scope.vm.logObject = {action: logActions.recordsetUpdate};
-                }
-                update(scope.vm, true, false, false);
-            });
-
             scope.$watch(function () {
                 return (scope.vm && scope.vm.reference) ? scope.vm.reference.columns : null;
             }, function (newValue, oldValue) {

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -426,6 +426,10 @@
             editRecordRequests[args.id] = {"schema": args.schema, "table": args.table};
         });
 
+        $scope.$on('record-deleted', function (event, args) {
+            recordAppUtils.updateRecordPage(true);
+        });
+
         // When page gets focus, check cookie for completed requests
         // re-read the records for that table
         $window.onfocus = function() {

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -811,6 +811,14 @@ exports.testRelatedTable = function (params, pageReadyCondition) {
 							return confirmButton.click();
 						}).then(function () {
 							chaisePage.waitForElementInverse(element(by.id("spinner")));
+
+                            // make sure the rows are updated
+                            browser.wait(function() {
+                                return chaisePage.recordPage.getRelatedTableRows(params.displayname, params.isInline).count().then(function(ct) {
+                                    return (ct == currentCount-1);
+                                });
+                            }, browser.params.defaultTimeout);
+
 							return chaisePage.recordPage.getRelatedTableRows(params.displayname, params.isInline).count();
 						}).then(function (count) {
 							expect(count).toBe(currentCount-1, "count didn't change.");


### PR DESCRIPTION
We're updating the record page after users edit/create the related entities. But this is not happening for delete and we're only updating the table itself. This PR fixes this.

To do so, I just had to add a listener to record app for the event that ellipses directive sends when a rows is getting deleted. I also had to remove the event listener from table directive itself since the update is going to happen on the caller (record or recordset). I'm not sure why we had this listener in both table and recordset to begin with. Anyways, now the updating of table after create/edit/delete are handled the same way by the caller in both places (record and recordset) and not the table directive itself.

I cannot test this feature since the updating of other parts of the app is usually done by triggers, but I could see the requests being generated in the network tab.

Issue: #1648