### PR TITLE
apps work without chaise config

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -1298,6 +1298,10 @@
     }])
 
     .factory("ConfigUtils", ['$rootScope', '$window', 'defaultChaiseConfig', function($rootScope, $window, defaultConfig) {
+        function getConfigJSON() {
+            return $rootScope.chaiseConfig;
+        };
+
         function setConfigJSON() {
             $rootScope.chaiseConfig = {};
             if (typeof chaiseConfig != 'undefined') $rootScope.chaiseConfig = Object.assign({}, chaiseConfig);
@@ -1313,9 +1317,9 @@
                 }
             }
 
-            if (Array.isArray(chaiseConfig.configRules)) {
+            if (Array.isArray($rootScope.chaiseConfig.configRules)) {
                 // loop through each config rule and look for a set that matches the current host
-                chaiseConfig.configRules.forEach(function (ruleset) {
+                $rootScope.chaiseConfig.configRules.forEach(function (ruleset) {
                     // we have 1 host
                     if (typeof ruleset.host == "string") {
                         var arr = [];
@@ -1340,6 +1344,7 @@
         }
 
         return {
+            getConfigJSON: getConfigJSON,
             setConfigJSON: setConfigJSON
         }
     }])

--- a/lib/login/login.app.js
+++ b/lib/login/login.app.js
@@ -17,7 +17,8 @@ function loadModule() {
             .config(['$cookiesProvider', '$uibTooltipProvider', '$logProvider', function ($cookiesProvider, $uibTooltipProvider, $logProvider) {
                 $cookiesProvider.defaults.path = '/';
                 $uibTooltipProvider.options({ appendToBody: true });
-                $logProvider.debugEnabled(chaiseConfig.debug === true);
+                ConfigUtilsProvider.$get().setConfigJSON();
+                $logProvider.debugEnabled(ConfigUtilsProvider.$get().getConfigJSON().debug === true);
             }])
 
             .run(['AlertsService', 'messageMap', 'Session', 'ERMrest', 'UiUtils', 'UriUtils',
@@ -46,7 +47,7 @@ function loadModule() {
     })();
 }
 var chaisePath = "/chaise/";
-if (typeof chaiseConfig === "object" && chaiseConfig['chaiseBasePath'] !== undefined) {
+if (typeof chaiseConfig != 'undefined' && typeof chaiseConfig === "object" && chaiseConfig['chaiseBasePath'] !== undefined) {
     chaisePath = chaiseConfig['chaiseBasePath'];
 }
 

--- a/lib/navbar/navbar.app.js
+++ b/lib/navbar/navbar.app.js
@@ -18,8 +18,8 @@ function loadModule() {
             .config(['$cookiesProvider', '$uibTooltipProvider', '$logProvider', 'ConfigUtilsProvider', function ($cookiesProvider, $uibTooltipProvider, $logProvider, ConfigUtilsProvider) {
                 $cookiesProvider.defaults.path = '/';
                 $uibTooltipProvider.options({ appendToBody: true });
-                $logProvider.debugEnabled(chaiseConfig.debug === true);
                 ConfigUtilsProvider.$get().setConfigJSON();
+                $logProvider.debugEnabled(ConfigUtilsProvider.$get().getConfigJSON().debug === true);
             }])
 
             .run(['AlertsService', 'messageMap', 'Session', 'ERMrest', 'UiUtils', 'UriUtils',
@@ -48,7 +48,7 @@ function loadModule() {
     })();
 }
 var chaisePath = "/chaise/";
-if (typeof chaiseConfig === "object" && chaiseConfig['chaiseBasePath'] !== undefined) {
+if (typeof chaiseConfig != 'undefined' && typeof chaiseConfig === "object" && chaiseConfig['chaiseBasePath'] !== undefined) {
     chaisePath = chaiseConfig['chaiseBasePath'];
 }
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -50,14 +50,13 @@
         // full regex: "/^\s*(https?|ftp|mailto|tel|file|blob):/"
         $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|blob):/);
         $cookiesProvider.defaults.path = '/';
-        $logProvider.debugEnabled(chaiseConfig && chaiseConfig.debug === true);
         // Configure all tooltips to be attached to the body by default. To attach a
         // tooltip on the element instead, set the `tooltip-append-to-body` attribute
         // to `false` on the element.
         $uibTooltipProvider.options({appendToBody: true});
-
         // chaise configurations
         ConfigUtilsProvider.$get().setConfigJSON();
+        $logProvider.debugEnabled(ConfigUtilsProvider.$get().getConfigJSON().debug === true);
     }])
 
     .run(['AlertsService', 'DataUtils', 'ERMrest', 'FunctionUtils', 'headInjector', '$log', 'MathUtils', 'messageMap', 'recordAppUtils',  '$rootScope', 'Session', '$timeout', 'UiUtils', 'UriUtils', '$window',

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -55,15 +55,14 @@
         // full regex: "/^\s*(https?|ftp|mailto|tel|file|blob):/"
         $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|blob):/);
         $cookiesProvider.defaults.path = '/';
-        //  Enable log system, if in debug mode
-        $logProvider.debugEnabled(chaiseConfig && chaiseConfig.debug === true);
         // Configure all tooltips to be attached to the body by default. To attach a
         // tooltip on the element instead, set the `tooltip-append-to-body` attribute
         // to `false` on the element.
         $uibTooltipProvider.options({appendToBody: true});
-
         // chaise configurations
         ConfigUtilsProvider.$get().setConfigJSON();
+        //  Enable log system, if in debug mode
+        $logProvider.debugEnabled(ConfigUtilsProvider.$get().getConfigJSON().debug === true);
     }])
 
     .config(function($provide) {

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -56,15 +56,14 @@
         // full regex: "/^\s*(https?|ftp|mailto|tel|file|blob):/"
         $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|blob):/);
         $cookiesProvider.defaults.path = '/';
-        //  Enable log system, if in debug mode
-        $logProvider.debugEnabled(chaiseConfig && chaiseConfig.debug === true);
         // Configure all tooltips to be attached to the body by default. To attach a
         // tooltip on the element instead, set the `tooltip-append-to-body` attribute
         // to `false` on the element.
         $uibTooltipProvider.options({appendToBody: true});
-
         // chaise configurations
         ConfigUtilsProvider.$get().setConfigJSON();
+        //  Enable log system, if in debug mode
+        $logProvider.debugEnabled(ConfigUtilsProvider.$get().getConfigJSON().debug === true);
     }])
 
     // Register the 'recordsetModel' object, which can be accessed by other

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -7,15 +7,14 @@
     .controller('recordsetController', ['context', 'DataUtils', 'recordsetModel', 'Session', 'UiUtils', 'UriUtils', '$document', '$log', '$rootScope', '$scope', '$timeout', '$window', 'messageMap', function(context, DataUtils, recordsetModel, Session, UiUtils, UriUtils, $document, $log, $rootScope, $scope, $timeout, $window, messageMap) {
 
         var ctrl = this;
-
-        ctrl.showExportButton = (chaiseConfig && chaiseConfig.showExportButton === true);
-
-        $scope.vm = recordsetModel;
-        recordsetModel.RECORDEDIT_MAX_ROWS = 200;
         var chaiseConfig = Object.assign({}, $rootScope.chaiseConfig);
-        $scope.navbarBrand = (chaiseConfig['navbarBrand'] !== undefined? chaiseConfig.navbarBrand : "");
-        $scope.navbarBrandImage = (chaiseConfig['navbarBrandImage'] !== undefined? chaiseConfig.navbarBrandImage : "");
-        $scope.navbarBrandText = (chaiseConfig['navbarBrandText'] !== undefined? chaiseConfig.navbarBrandText : "Chaise");
+        $scope.vm = recordsetModel;
+
+        recordsetModel.RECORDEDIT_MAX_ROWS = 200;
+        ctrl.showExportButton = (chaiseConfig.showExportButton === true);
+        $scope.navbarBrand = (chaiseConfig.navbarBrand !== undefined ?  chaiseConfig.navbarBrand : "");
+        $scope.navbarBrandImage = (chaiseConfig.navbarBrandImage !== undefined ? chaiseConfig.navbarBrandImage : "");
+        $scope.navbarBrandText = (chaiseConfig.navbarBrandText !== undefined ? chaiseConfig.navbarBrandText : "Chaise");
         var mainBodyEl;
         $scope.tooltip = messageMap.tooltip;
 


### PR DESCRIPTION
Made changes to enforce an idiom I think we should follow going forward. We should never directly consume `chaiseConfig` from the global scope. Instead, we should always make sure the `configProvider` sets the `chaiseConfig` on the `$rootScope`. 

In the cases that we need to rely on it outside of an angular app, make sure to check for `typeof chaiseConfig != 'undefined'` first. I added a new function to `ConfigUtils` so the `logProvider` can be set up properly.