### PR TITLE
Changes to support proper live link with version when no version is present

### DIFF
--- a/common/alerts.js
+++ b/common/alerts.js
@@ -63,7 +63,7 @@
         };
     }])
 
-    .directive('alerts', ['AlertsService', 'Session', 'UriUtils', '$window', function(AlertsService, Session, UriUtils, $window) {
+    .directive('alerts', ['AlertsService', 'Session', 'UriUtils', function(AlertsService, Session, UriUtils) {
 
         return {
             restrict: 'E',
@@ -74,7 +74,8 @@
             link: function (scope, elem, attr) {
                 scope.closeAlert = function(alert) {
                     AlertsService.deleteAlert(alert);
-                };
+                }
+
                 scope.login = function() {
                     Session.loginInAPopUp();
                 }

--- a/common/alerts.js
+++ b/common/alerts.js
@@ -63,7 +63,7 @@
         };
     }])
 
-    .directive('alerts', ['AlertsService', 'Session', 'UriUtils', function(AlertsService, Session, UriUtils) {
+    .directive('alerts', ['AlertsService', 'Session', 'UriUtils', '$window', function(AlertsService, Session, UriUtils, $window) {
 
         return {
             restrict: 'E',
@@ -77,6 +77,9 @@
                 };
                 scope.login = function() {
                   Session.loginInAPopUp();
+                }
+                scope.reload = function() {
+                    $window.location.reload();
                 }
             }
         };

--- a/common/alerts.js
+++ b/common/alerts.js
@@ -76,10 +76,13 @@
                     AlertsService.deleteAlert(alert);
                 };
                 scope.login = function() {
-                  Session.loginInAPopUp();
+                    Session.loginInAPopUp();
                 }
-                scope.reload = function() {
-                    $window.location.reload();
+                scope.liveLink = function() {
+                    return UriUtils.resolveLivePermalink(scope.$root.tuple, scope.$root.reference);
+                }
+                scope.versionedLink = function() {
+                    return UriUtils.resolveVersionedPermalink(scope.$root.tuple, scope.$root.reference);
                 }
             }
         };

--- a/common/alerts.js
+++ b/common/alerts.js
@@ -78,12 +78,6 @@
                 scope.login = function() {
                     Session.loginInAPopUp();
                 }
-                scope.liveLink = function() {
-                    return UriUtils.resolveLivePermalink(scope.$root.tuple, scope.$root.reference);
-                }
-                scope.versionedLink = function() {
-                    return UriUtils.resolveVersionedPermalink(scope.$root.tuple, scope.$root.reference);
-                }
             }
         };
     }]);

--- a/common/modal.js
+++ b/common/modal.js
@@ -296,16 +296,21 @@
         }
     }])
 
+    /**
+     * Params object values:
+     *   - {String} displayname - used for citation content and filename for bibtex download
+     *   - {String} permalink - link to the live catalog
+     *   - {String} versionLink - link to the current version of the live catalog
+     *   - {String} versionDate - version decoded to it's datetime
+     *   - {String} versionDateRelative - version decoded to it's datetime then presented as relative to today's date
+     *   - {boolean} showVersionWarning - decides whether to show "out of date content" warning
+     *   - {Object} citation - citation object returned from ERMrest.tuple.citation
+     *
+     */
     .controller('ShareCitationController', ['$uibModalInstance', '$window', 'AlertsService', 'params', function ($uibModalInstance, $window, AlertsService, params) {
         var vm = this;
-        vm.cancel = cancel;
-        vm.citation = params.citation;
-        vm.permalink = params.permalink;
-        vm.versionLink = params.versionLink;
-        vm.versionDate = params.versionDate;
-        vm.versionDateRelative = params.versionDateRelative;
-        vm.filename = params.displayname;
-        vm.showVersionWarning = params.showVersionWarning;
+        vm.params = params;
+        vm.warningMessage = "The displayed content may be stale due to recent changes made by other users. You may wish to review the changes prior to sharing the <a ng-href='{{ctrl.params.permalink}}'>live link</a> below. Or, you may share the older content using the <a ng-href='{{ctrl.params.versionLink}}'>historical link</a>.";
 
         vm.moreThanWeek = function () {
             var weekAgo = moment().subtract(7, 'days').startOf('day');
@@ -314,11 +319,6 @@
             return weekAgo.isAfter(versionMoment);
         }
 
-        if (params.showVersionWarning) {
-            vm.alerts = AlertsService.alerts;
-            vm.closeAlert = AlertsService.deleteAlert;
-            AlertsService.addAlert("The displayed content may be stale due to recent changes made by other users. You may wish to review the changes prior to sharing the <a ng-href='{{liveLink()}}'>live link</a> below. Or, you may share the older content using the <a ng-href='{{versionedLink()}}'>historical link</a>.", 'warning');
-        }
         // generate bibtex url from citation
         if (params.citation) {
             var citation = params.citation;
@@ -335,7 +335,11 @@
             vm.downloadBibtex = $window.URL.createObjectURL( bibtexBlob );
         }
 
-        function cancel() {
+        vm.closeAlert = function () {
+            vm.params.showVersionWarning = false;
+        }
+
+        vm.cancel = function() {
             $uibModalInstance.dismiss('cancel');
         }
     }])

--- a/common/modal.js
+++ b/common/modal.js
@@ -296,7 +296,7 @@
         }
     }])
 
-    .controller('ShareCitationController', ['$uibModalInstance', '$window', 'params', function ($uibModalInstance, $window, params) {
+    .controller('ShareCitationController', ['$uibModalInstance', '$window', 'AlertsService', 'params', function ($uibModalInstance, $window, AlertsService, params) {
         var vm = this;
         vm.cancel = cancel;
         vm.citation = params.citation;
@@ -305,12 +305,19 @@
         vm.versionDate = params.versionDate;
         vm.versionDateRelative = params.versionDateRelative;
         vm.filename = params.displayname;
+        vm.showVersionWarning = params.showVersionWarning;
 
         vm.moreThanWeek = function () {
             var weekAgo = moment().subtract(7, 'days').startOf('day');
             var versionMoment = moment(params.versionDate);
 
             return weekAgo.isAfter(versionMoment);
+        }
+
+        if (params.showVersionWarning) {
+            vm.alerts = AlertsService.alerts;
+            vm.closeAlert = AlertsService.deleteAlert;
+            AlertsService.addAlert("You are viewing old data. Click <a ng-click='reload()'>here</a> to reload the page and view the most recent data.", 'warning');
         }
         // generate bibtex url from citation
         if (params.citation) {

--- a/common/modal.js
+++ b/common/modal.js
@@ -317,7 +317,7 @@
         if (params.showVersionWarning) {
             vm.alerts = AlertsService.alerts;
             vm.closeAlert = AlertsService.deleteAlert;
-            AlertsService.addAlert("You are viewing old data. Click <a ng-click='reload()'>here</a> to reload the page and view the most recent data.", 'warning');
+            AlertsService.addAlert("The displayed content may be stale due to recent changes made by other users. You may wish to review the changes prior to sharing the <a ng-href='{{liveLink()}}'>live link</a> below. Or, you may share the older content using the <a ng-href='{{versionedLink()}}'>historical link</a>.", 'warning');
         }
         // generate bibtex url from citation
         if (params.citation) {

--- a/common/modal.js
+++ b/common/modal.js
@@ -307,7 +307,7 @@
      *   - {Object} citation - citation object returned from ERMrest.tuple.citation
      *
      */
-    .controller('ShareCitationController', ['$uibModalInstance', '$window', 'AlertsService', 'params', function ($uibModalInstance, $window, AlertsService, params) {
+    .controller('ShareCitationController', ['$uibModalInstance', '$window', 'params', function ($uibModalInstance, $window, params) {
         var vm = this;
         vm.params = params;
         vm.warningMessage = "The displayed content may be stale due to recent changes made by other users. You may wish to review the changes prior to sharing the <a ng-href='{{ctrl.params.permalink}}'>live link</a> below. Or, you may share the older content using the <a ng-href='{{ctrl.params.versionLink}}'>historical link</a>.";

--- a/common/templates/shareCitation.modal.html
+++ b/common/templates/shareCitation.modal.html
@@ -4,6 +4,7 @@
     </h2>
 </div>
 <div class="modal-body">
+    <alerts ng-if="ctrl.showVersionWarning" id="alerts-container" alerts="ctrl.alerts"></alerts>
     <ul>
         <li id="share-link">
             <h2><b>Share Link</b></h2>

--- a/common/templates/shareCitation.modal.html
+++ b/common/templates/shareCitation.modal.html
@@ -10,14 +10,13 @@
             <h2><b>Share Link</b></h2>
             <div ng-if="ctrl.versionLink">
                 <h3>
-                    <b>Data Snapshotted
-                        <span ng-if="ctrl.moreThanWeek()"> at </span>
-                        <span tooltip-placement="bottom" ng-attr-uib-tooltip="{{!ctrl.moreThanWeek() ? 'Data snapshotted at ' + ctrl.versionDate : undefined}}">{{ctrl.versionDateRelative}}</span>
+                    <b>Historical Link
+                        <span tooltip-placement="bottom" ng-attr-uib-tooltip="{{!ctrl.moreThanWeek() ? 'Data snapshotted at ' + ctrl.versionDate : undefined}}">({{ctrl.versionDateRelative}})</span>
                     </b>
                 </h3>
             </div>
             <a ng-if="ctrl.versionLink" id="version" ng-href="{{::ctrl.versionLink}}">{{::ctrl.versionLink}}</a>
-            <h3><b>Live Data</b></h3>
+            <h3><b>Live Link</b></h3>
             <a id="permalink" ng-href="{{::ctrl.permalink}}">{{::ctrl.permalink}}</a>
         </li>
         <li id="citation" ng-if="::ctrl.citation">

--- a/common/templates/shareCitation.modal.html
+++ b/common/templates/shareCitation.modal.html
@@ -4,30 +4,33 @@
     </h2>
 </div>
 <div class="modal-body">
-    <alerts ng-if="ctrl.showVersionWarning" id="alerts-container" alerts="ctrl.alerts"></alerts>
+    <div ng-if="ctrl.params.showVersionWarning" class="alert alert-dismissible alert-warning" role="alert">
+        <button type="button" class="close" ng-click="ctrl.closeAlert();" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <strong>Warning</strong> <span compile="ctrl.warningMessage"></span>
+    </div>
     <ul>
         <li id="share-link">
             <h2><b>Share Link</b></h2>
-            <div ng-if="ctrl.versionLink">
+            <div>
                 <h3>
                     <b>Historical Link
-                        <span tooltip-placement="bottom" ng-attr-uib-tooltip="{{!ctrl.moreThanWeek() ? 'Data snapshotted at ' + ctrl.versionDate : undefined}}">({{ctrl.versionDateRelative}})</span>
+                        <span tooltip-placement="bottom" ng-attr-uib-tooltip="{{!ctrl.moreThanWeek() ? 'Data snapshotted at ' + ctrl.params.versionDate : undefined}}">({{ctrl.params.versionDateRelative}})</span>
                     </b>
                 </h3>
             </div>
-            <a ng-if="ctrl.versionLink" id="version" ng-href="{{::ctrl.versionLink}}">{{::ctrl.versionLink}}</a>
+            <a id="version" ng-href="{{::ctrl.params.versionLink}}">{{::ctrl.params.versionLink}}</a>
             <h3><b>Live Link</b></h3>
-            <a id="permalink" ng-href="{{::ctrl.permalink}}">{{::ctrl.permalink}}</a>
+            <a id="permalink" ng-href="{{::ctrl.params.permalink}}">{{::ctrl.params.permalink}}</a>
         </li>
-        <li id="citation" ng-if="::ctrl.citation">
+        <li id="citation" ng-if="::ctrl.params.citation">
             <h2><b>Data Citation</b></h2>
             <div id="citation-text">
-                <span ng-if="::ctrl.citation.author">{{::ctrl.citation.author}} </span><span ng-if="::ctrl.citation.title">{{::ctrl.citation.title}} </span><i>{{::ctrl.citation.journal}}</i> <a ng-href="{{::ctrl.citation.url}}">{{::ctrl.citation.url}}</a> ({{::ctrl.citation.year}}).
+                <span ng-if="::ctrl.params.citation.author">{{::ctrl.params.citation.author}} </span><span ng-if="::ctrl.params.citation.title">{{::ctrl.params.citation.title}} </span><i>{{::ctrl.params.citation.journal}}</i> <a ng-href="{{::ctrl.params.citation.url}}">{{::ctrl.params.citation.url}}</a> ({{::ctrl.params.citation.year}}).
             </div>
         </li>
-        <li id="download-citation" ng-if="::ctrl.citation">
+        <li id="download-citation" ng-if="::ctrl.params.citation">
             <h3><b>Download Data Citation:</b></h3>
-            <a id="bibtex-download" download="{{::ctrl.filename}}.bib" ng-href="{{::ctrl.downloadBibtex}}">BibTex</a>
+            <a id="bibtex-download" download="{{::ctrl.params.displayname}}.bib" ng-href="{{::ctrl.downloadBibtex}}">BibTex</a>
         </li>
     </ul>
 </div>

--- a/common/utils.js
+++ b/common/utils.js
@@ -774,57 +774,29 @@
          *  - if undefined:                                 same as false
          *  - if resolverImplicitCatalog == currCatalog:    /id/RID
          *  - if resolverImplicitCatalog != currCatalog:    /id/currCatalog/RID
+         * @param {ERMrest.Tuple} tuple - the `ermrestJS` tuple object returned from the page object when data is read
+         * @param {ERMrest.Reference} reference - the `ermrestJS` reference object associated with this current page
+         * @param {String} version - the encoded version string prepended with the '@' character
          **/
-        function resolveLivePermalink(tuple, reference) {
+        function resolvePermalink(tuple, reference, version) {
             var resolverId = chaiseConfig.resolverImplicitCatalog;
             var currCatalog = reference.location.catalogId;
 
             // null or no RID
             if (resolverId === null || !tuple.data || !tuple.data.RID) {
                 // location.catalog will be in the form of `<id>` or `<id>@<version>`
-                return $window.location.href.replace('#' + reference.location.catalog, '#' + currCatalog);
+                return $window.location.href.replace('#' + reference.location.catalog, '#' + curreCatalog + (version ? version : ""));
             }
 
             // if it's a number (isNaN tries to parse to integer before checking)
             if (!isNaN(resolverId)) {
                 var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
-                return $window.location.origin + "/id/" + catalog + tuple.data.RID;
+                return $window.location.origin + "/id/" + catalog + tuple.data.RID + (version ? version : "");
             }
 
             // if resolverId is false or undefined OR any other values that are not allowed use the default
             // default is to show the fully qualified resolveable link for permalink
-            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID;
-        }
-
-        /**
-         * The following cases need to be handled for the resolverImplicitCatalog value:
-         *  - if null:                                      use current chaise path (include the version if none is present)
-         *  - if false:                                     /id/currCatalog/RID@version
-         *  - if undefined:                                 same as false
-         *  - if resolverImplicitCatalog == currCatalog:    /id/RID@version
-         *  - if resolverImplicitCatalog != currCatalog:    /id/currCatalog/RID@version
-         **/
-        function resolveVersionedPermalink(tuple, reference) {
-            var resolverId = chaiseConfig.resolverImplicitCatalog;
-            var currCatalog = reference.location.catalogId;
-            var snaptime = reference.table.schema.catalog.snaptime;
-            var version = reference.location.version;
-            var versionString = "@" + (version || snaptime);
-
-            // null or no RID
-            if (resolverId === null || !tuple.data || !tuple.data.RID) {
-                return $window.location.href.replace('#' + reference.location.catalog, '#' + currCatalog + versionString);
-            }
-
-            // if it's a number (isNaN tries to parse to integer before checking)
-            if (!isNaN(resolverId)) {
-                var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
-                return $window.location.origin + "/id/" + catalog + tuple.data.RID + versionString;
-            }
-
-            // if resolverId is false or undefined OR any other values that are not allowed use the default
-            // default is to shwo the fully qualified resolveable link for permalink
-            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID + versionString;
+            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID + (version ? version : "");
         }
 
         return {
@@ -839,8 +811,7 @@
             parseURLFragment: parseURLFragment,
             parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
             queryStringToJSON: queryStringToJSON,
-            resolveLivePermalink: resolveLivePermalink,
-            resolveVersionedPermalink: resolveVersionedPermalink,
+            resolvePermalink: resolvePermalink,
             setLocationChangeHandling: setLocationChangeHandling,
             setOrigin: setOrigin
         }

--- a/common/utils.js
+++ b/common/utils.js
@@ -767,20 +767,82 @@
             }
         }
 
+        /**
+         * The following cases need to be handled for the resolverImplicitCatalog value:
+         *  - if null:                                      use current chaise path (without the version if one is present)
+         *  - if false:                                     /id/currCatalog/RID
+         *  - if undefined:                                 same as false
+         *  - if resolverImplicitCatalog == currCatalog:    /id/RID
+         *  - if resolverImplicitCatalog != currCatalog:    /id/currCatalog/RID
+         **/
+        function resolveLivePermalink(tuple, reference) {
+            var resolverId = chaiseConfig.resolverImplicitCatalog;
+            var currCatalog = reference.location.catalogId;
+
+            // null or no RID
+            if (resolverId === null || !tuple.data || !tuple.data.RID) {
+                // location.catalog will be in the form of `<id>` or `<id>@<version>`
+                return $window.location.href.replace('#' + reference.location.catalog, '#' + currCatalog);
+            }
+
+            // if it's a number (isNaN tries to parse to integer before checking)
+            if (!isNaN(resolverId)) {
+                var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
+                return $window.location.origin + "/id/" + catalog + tuple.data.RID;
+            }
+
+            // if resolverId is false or undefined OR any other values that are not allowed use the default
+            // default is to show the fully qualified resolveable link for permalink
+            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID;
+        }
+
+        /**
+         * The following cases need to be handled for the resolverImplicitCatalog value:
+         *  - if null:                                      use current chaise path (include the version if none is present)
+         *  - if false:                                     /id/currCatalog/RID@version
+         *  - if undefined:                                 same as false
+         *  - if resolverImplicitCatalog == currCatalog:    /id/RID@version
+         *  - if resolverImplicitCatalog != currCatalog:    /id/currCatalog/RID@version
+         **/
+        function resolveVersionedPermalink(tuple, reference) {
+            var resolverId = chaiseConfig.resolverImplicitCatalog;
+            var currCatalog = reference.location.catalogId;
+            var snaptime = reference.table.schema.catalog.snaptime;
+            var version = reference.location.version;
+            var versionString = "@" + (version || snaptime);
+
+            // null or no RID
+            if (resolverId === null || !tuple.data || !tuple.data.RID) {
+                return $window.location.href.replace('#' + reference.location.catalog, '#' + currCatalog + versionString);
+            }
+
+            // if it's a number (isNaN tries to parse to integer before checking)
+            if (!isNaN(resolverId)) {
+                var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
+                return $window.location.origin + "/id/" + catalog + tuple.data.RID + versionString;
+            }
+
+            // if resolverId is false or undefined OR any other values that are not allowed use the default
+            // default is to shwo the fully qualified resolveable link for permalink
+            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID + versionString;
+        }
+
         return {
-            queryStringToJSON: queryStringToJSON,
-            appTagToURL: appTagToURL,
-            chaiseURItoErmrestURI: chaiseURItoErmrestURI,
-            fixedEncodeURIComponent: fixedEncodeURIComponent,
-            parseURLFragment: parseURLFragment,
-            setOrigin: setOrigin,
-            parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
-            setLocationChangeHandling: setLocationChangeHandling,
-            isBrowserIE: isBrowserIE,
-            getQueryParams: getQueryParams,
             appNamefromUrlPathname: appNamefromUrlPathname,
+            appTagToURL: appTagToURL,
+            chaiseDeploymentPath: chaiseDeploymentPath,
+            chaiseURItoErmrestURI: chaiseURItoErmrestURI,
             createRedirectLinkFromPath: createRedirectLinkFromPath,
-            chaiseDeploymentPath: chaiseDeploymentPath
+            fixedEncodeURIComponent: fixedEncodeURIComponent,
+            getQueryParams: getQueryParams,
+            isBrowserIE: isBrowserIE,
+            parseURLFragment: parseURLFragment,
+            parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
+            queryStringToJSON: queryStringToJSON,
+            resolveLivePermalink: resolveLivePermalink,
+            resolveVersionedPermalink: resolveVersionedPermalink,
+            setLocationChangeHandling: setLocationChangeHandling,
+            setOrigin: setOrigin
         }
     }])
 

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -3,8 +3,8 @@
 
     angular.module('chaise.record')
 
-    .controller('RecordController', ['AlertsService', 'DataUtils', 'ErrorService', 'logActions', 'MathUtils', 'messageMap', 'modalBox', 'modalUtils', 'recordAppUtils', 'recordCreate', 'UiUtils', 'UriUtils', '$cookies', '$document', '$log', '$rootScope', '$scope', '$timeout', '$window',
-        function RecordController(AlertsService, DataUtils, ErrorService, logActions, MathUtils, messageMap, modalBox, modalUtils, recordAppUtils, recordCreate, UiUtils, UriUtils, $cookies, $document, $log, $rootScope, $scope, $timeout, $window) {
+    .controller('RecordController', ['AlertsService', 'DataUtils', 'ERMrest', 'ErrorService', 'logActions', 'MathUtils', 'messageMap', 'modalBox', 'modalUtils', 'recordAppUtils', 'recordCreate', 'UiUtils', 'UriUtils', '$cookies', '$document', '$log', '$rootScope', '$scope', '$timeout', '$window',
+        function RecordController(AlertsService, DataUtils, ERMrest, ErrorService, logActions, MathUtils, messageMap, modalBox, modalUtils, recordAppUtils, recordCreate, UiUtils, UriUtils, $cookies, $document, $log, $rootScope, $scope, $timeout, $window) {
         var vm = this;
 
         var mainContainerEl = angular.element(document.getElementsByClassName('main-container')[0]);
@@ -119,73 +119,24 @@
             });
         };
 
-        /**
-         * The following cases need to be handled for the resolverImplicitCatalog value:
-         *  - if null:                                      use current chaise path
-         *  - if false:                                     /id/currCatalog/RID
-         *  - if undefined:                                 same as false
-         *  - if resolverImplicitCatalog == currCatalog:    /id/RID
-         *  - if resolverImplicitCatalog != currCatalog:    /id/currCatalog/RID
-         **/
-        function resolveLivePermalink(tuple) {
-            var resolverId = chaiseConfig.resolverImplicitCatalog;
-            var currCatalog = $rootScope.reference.location.catalogId;
-
-            // null or no RID
-            if (resolverId === null || !tuple.data || !tuple.data.RID) {
-                // location.catalog will be in the form of `<id>` or `<id>@<version>`
-                return $window.location.href.replace('#'+$rootScope.reference.location.catalog, '#'+$rootScope.reference.location.catalogId);
-            }
-
-            // if it's a number (isNaN tries to parse to integer before checking)
-            if (!isNaN(resolverId)) {
-                var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
-                return $window.location.origin + "/id/" + catalog + tuple.data.RID;
-            }
-
-            // if resolverId is false or undefined OR any other values that are not allowed use the default
-            // default is to show the fully qualified resolveable link for permalink
-            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID;
-        }
-
-        // NOTE: the current assumption is that url is versioned
-        function resolveVersionedPermalink(tuple) {
-            var resolverId = chaiseConfig.resolverImplicitCatalog;
-            var currCatalog = $rootScope.reference.location.catalogId;
-            var snaptime = $rootScope.reference.table.schema.catalog.snaptime;
-
-            // null or no RID
-            if (resolverId === null || !tuple.data || !tuple.data.RID) {
-                return $window.location.href.replace('#'+$rootScope.reference.location.catalog, '#'+$rootScope.reference.location.catalog+'@'+snaptime);
-            }
-
-            // if it's a number (isNaN tries to parse to integer before checking)
-            if (!isNaN(resolverId)) {
-                var catalog = (resolverId != currCatalog) ? currCatalog + "/" : "";
-                return $window.location.origin + "/id/" + catalog + tuple.data.RID + '@' + ($rootScope.reference.location.version || snaptime);
-            }
-
-            // if resolverId is false or undefined OR any other values that are not allowed use the default
-            // default is to shwo the fully qualified resolveable link for permalink
-            return $window.location.origin + "/id/" + currCatalog + "/" + tuple.data.RID + '@' + ($rootScope.reference.location.version || snaptime);
-        }
-
         vm.sharePopup = function() {
             var tuple = $rootScope.tuple;
+            var ref = $rootScope.reference;
+            var refTable = ref.table;
 
             var params = {
                 citation: tuple.citation,
-                displayname: $rootScope.reference.table.name+'_'+tuple.uniqueId
+                displayname: refTable.name+'_'+tuple.uniqueId
             }
 
-            params.permalink = resolveLivePermalink(tuple);
-            params.versionLink = resolveVersionedPermalink(tuple);
-            params.versionDateRelative = UiUtils.humanizeTimestamp($rootScope.reference.location.versionAsMillis($rootScope.reference.table.schema.catalog.snaptime));
-            params.versionDate = UiUtils.versionDate($rootScope.reference.location.versionAsMillis($rootScope.reference.table.schema.catalog.snaptime));
+            params.permalink = UriUtils.resolveLivePermalink(tuple, ref);
+            params.versionLink = UriUtils.resolveVersionedPermalink(tuple, ref);
+            params.versionDateRelative = UiUtils.humanizeTimestamp(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
+            params.versionDate = UiUtils.versionDate(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
 
-            $rootScope.reference.table.schema.catalog.currentSnaptime().then(function (snaptime) {
+            refTable.schema.catalog.currentSnaptime().then(function (snaptime) {
                 // if current fetched snpatime doesn't match old snaptime, show a warning
-                params.showVersionWarning = (snaptime !== $rootScope.reference.table.schema.catalog.snaptime);
+                params.showVersionWarning = (snaptime !== refTable.schema.catalog.snaptime);
             }).finally(function() {
                 modalUtils.showModal({
                     templateUrl: UriUtils.chaiseDeploymentPath() + "common/templates/shareCitation.modal.html",

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -129,8 +129,9 @@
                 displayname: refTable.name+'_'+tuple.uniqueId
             }
 
-            params.permalink = UriUtils.resolveLivePermalink(tuple, ref);
-            params.versionLink = UriUtils.resolveVersionedPermalink(tuple, ref);
+            var versionString = "@" + (ref.location.version || refTable.schema.catalog.snaptime);
+            params.permalink = UriUtils.resolvePermalink(tuple, ref);
+            params.versionLink = UriUtils.resolvePermalink(tuple, ref, versionString);
             params.versionDateRelative = UiUtils.humanizeTimestamp(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
             params.versionDate = UiUtils.versionDate(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
 


### PR DESCRIPTION
Changes for this feature have been completed. When the user navigates to a record page, regardless of it being versioned or not, the share dialog will have both a live link and a versioned link. The headings for these links have been changed too.

Other smaller features include:
 - If you load the record page to a live page then open the share dialog, a check is made to see if you are actually looking at the live content
   - a notification will be shown if you are viewing out of date content
 - Functions moved to a utility factory for re-ruse
 - other changes made in corresponding [ermrestJS PR](https://github.com/informatics-isi-edu/ermrestjs/pull/767)