### PR TITLE
fix hatrac completion bug

### DIFF
--- a/common/upload.js
+++ b/common/upload.js
@@ -281,6 +281,7 @@
                 vm.title = "Finalizing Upload";
                 var item = vm.jobCompletionQueue.shift();
                 if (!item) return;
+
                 item.hatracObj.completeUpload().then(
                     item.onCompleteUploadJob.bind(item),
                     onError);

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -107,7 +107,8 @@ var testParams = {
            name: "testfile1MB.txt",
            size: "1024000",
            displaySize: "1MB",
-           path: "testfile1MB.txt"
+           path: "testfile1MB.txt",
+           skipDeletion: true
        }, {
            name: "testfile500kb.png",
            size: "512000",
@@ -121,7 +122,7 @@ var testParams = {
            path: "testfile5MB.txt"
        }]
    }, {
-      comment: "uploading existing files in hatrac",
+      comment: "uploader when one file exists in hatrac and the other one is new",
       schema_name: "product-add",
       table_name: "file",
       table_displayname: "file",
@@ -136,7 +137,7 @@ var testParams = {
       inputs: [
           {"fileid": "1", "uri": 0, "timestamp_txt": currentTimestampTime}, // this is a new file
           {"fileid": "2", "uri": 1, "timestamp_txt": currentTimestampTime}, // the uploaded file for this already exists (uploaded in the previou step)
-          {"fileid": "3", "uri": 2, "timestamp_txt": currentTimestampTime} // this form won't be submitted
+          {"fileid": "3", "uri": 1, "timestamp_txt": currentTimestampTime} // this form won't be submitted
       ],
       formsAfterInput: 3,
       result_columns: [
@@ -144,8 +145,7 @@ var testParams = {
       ],
       results: [
           ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/b5dad28809685d9764dbd08fa23600bc:", "value": "testfile10MB_new.txt"}, "testfile10MB_new.txt", "10,240,000"],
-          // TODO we're not sending the version number back when the file exists (we're reusing the given url without any change)
-          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/2ada69fe3cdadcefddc5a83144bddbb4", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
       ],
       files : [{
           name: "testfile10MB_new.txt", // a new file with new md5
@@ -155,11 +155,45 @@ var testParams = {
       }, {
           name: "testfile500kb.png", // using the same file that has been already uploaded
           skipCreation: true,
+          skipDeletion: true,
           size: "512000",
           displaySize: "500KB",
           path: "testfile500kb.png"
+      }]
+   }, {
+      comment: "uploader when all the files already exist in hatrac",
+      schema_name: "product-add",
+      table_name: "file",
+      table_displayname: "file",
+      table_comment: "asset/object",
+      not_travis: !process.env.TRAVIS,
+      primary_keys: ["id"],
+      columns: [
+          { name: "fileid", title: "fileid", type: "int4", skipValidation: true },
+          { name: "uri", title: "uri", type: "text", isFile: true, comment: "asset/reference", skipValidation: true },
+          { name: "timestamp_txt", title: "timestamp_txt", type: "text", skipValidation: true},
+      ],
+      inputs: [
+          {"fileid": "1", "uri": 0, "timestamp_txt": currentTimestampTime}, // the uploaded file for this already exists (uploaded in the previou step)
+          {"fileid": "2", "uri": 1, "timestamp_txt": currentTimestampTime}, // the uploaded file for this already exists (uploaded in the previou step)
+          {"fileid": "3", "uri": 1, "timestamp_txt": currentTimestampTime} // this form won't be submitted
+      ],
+      formsAfterInput: 3,
+      result_columns: [
+          "fileid", "uri", "filename", "bytes"
+      ],
+      results: [
+          ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1,024,000"],
+          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+      ],
+      files : [{
+          name: "testfile1MB.txt", // using the same file that has been already uploaded
+          skipCreation: true,
+          size: "1024000",
+          displaySize: "1MB",
+          path: "testfile1MB.txt"
       }, {
-          name: "testfile500kb.png", // this form will be removed
+          name: "testfile500kb.png", // using the same file that has been already uploaded
           skipCreation: true,
           size: "512000",
           displaySize: "500KB",

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -40,14 +40,14 @@ var EC = protractor.ExpectedConditions;
  * @param  {Boolean} isEditMode  true if in editmode, used for testing the title.
  */
 exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
+    beforeAll(function () {
+        chaisePage.waitForElement(chaisePage.recordEditPage.getSubmitRecordButton());
+    });
 
     var visibleFields = [];
 
     if (isEditMode) {
         it("should have edit record title", function() {
-            var EC = protractor.ExpectedConditions;
-
-            browser.wait(EC.visibilityOf(chaisePage.recordEditPage.getEntityTitleElement()), browser.params.defaultTimeout);
             var title = chaisePage.recordEditPage.getEntityTitleElement();
             expect(title.getText()).toEqual("Edit " + tableParams.record_displayname + " Record", "Edit mode title is incorrect.");
         });
@@ -61,9 +61,6 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
     } else {
         it("should have create record title", function() {
-            var EC = protractor.ExpectedConditions;
-
-            browser.wait(EC.visibilityOf(chaisePage.recordEditPage.getEntityTitleElement()), browser.params.defaultTimeout);
             expect(chaisePage.recordEditPage.getEntityTitleElement().getText()).toBe("Create Record", "Create mode title is incorrect.");
         });
 
@@ -1218,6 +1215,8 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                         integerDataTypeFields.forEach(function(intInput) {
                             var c = intInput.column;
 
+                            if (c.skipValidation) return;
+
                             if (c.generated || c.immutable) return;
 
                             var prevValue = "";
@@ -1262,8 +1261,9 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
                     it("should validate int8(-9223372036854776000 < value < 9223372036854776000), int4(-2147483648 < value < 2147483647) and int2(-32768 < value < 32767) with range values", function() {
                         integerDataTypeFields.forEach(function(intInput) {
-
                             var c = intInput.column;
+
+                            if (c.skipValidation) return;
 
                             if (c.generated || c.immutable) return;
 
@@ -1664,6 +1664,7 @@ exports.testRecordAppValuesAfterSubmission = function(column_names, column_value
  */
 exports.createFiles = function(files) {
     files.forEach(function(f) {
+        if (f.skipCreation) return;
         var path = require('path').join(__dirname , "/../data_setup/uploaded_files/" + f.path);
         exec("perl -e 'print \"1\" x " + f.size + "' > " + path);
         console.log(path + " created");
@@ -1676,6 +1677,7 @@ exports.createFiles = function(files) {
  */
 exports.deleteFiles = function(files) {
     files.forEach(function(f) {
+        if (f.skipDeletion) return;
         var path = require('path').join(__dirname , "/../data_setup/uploaded_files/" + f.path);
         exec('rm ' + path);
         console.log(path + " deleted");


### PR DESCRIPTION
This PR will fix the recent issue that we found in hatrac. All the code in hatrac to check whether we should start the next step was relying on counters. I changed all of those to check the booleans that we are already keeping track of. 

I also changed the job completion step to be serialized. Previously we were firing all these request at the same time, but now they will be fired after the previous one is completed.

The other change is how we're handling the existing files in the server. Previously we were firing a complete upload request immediately and we would skip the job creation/upload steps. But still when we would get to the last step, we were firing duplicated callbacks in ermrestjs to complete the job again. Now they will be treated the same in chaise, and in ermrestjs if the file is already in the server and therefore marked as `jobDone`, I am just returning the `chunkUrl` instead of actually creating a job and uploading.

related ermrestjs issue: [ermrestjs#774](https://github.com/informatics-isi-edu/ermrestjs/pull/774)
