### PR TITLE
Use ermrestjs http service instead of $http

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -3,8 +3,8 @@
 
     angular.module('chaise.authen', ['chaise.utils', 'chaise.storage'])
 
-    .factory('Session', ['ConfigUtils', 'messageMap', 'modalUtils', 'StorageService', 'UriUtils', '$cookies', '$http', '$interval', '$log', '$q', '$rootScope', '$sce', '$uibModalStack', '$window',
-        function (ConfigUtils, messageMap, modalUtils, StorageService, UriUtils, $cookies, $http, $interval, $log, $q, $rootScope, $sce, $uibModalStack, $window) {
+    .factory('Session', ['ConfigUtils', 'messageMap', 'modalUtils', 'StorageService', 'UriUtils', '$cookies', '$interval', '$log', '$q', '$rootScope', '$sce', '$uibModalStack', '$window',
+        function (ConfigUtils, messageMap, modalUtils, StorageService, UriUtils, $cookies, $interval, $log, $q, $rootScope, $sce, $uibModalStack, $window) {
         // authn API no longer communicates through ermrest, removing the need to check for ermrest location
         var serviceURL = $window.location.origin;
 
@@ -173,7 +173,7 @@
                 }
             };
 
-            $http.get(url, config).then(function(response){
+            ConfigUtils.getHTTPService().get(url, config).then(function(response){
                 var data = response.data;
 
                 var login_url = "";
@@ -251,7 +251,7 @@
              * @param  {string=} context undefined or "401"
              */
             getSession: function(context) {
-                return $http.get(serviceURL + "/authn/session").then(function(response) {
+                return ConfigUtils.getHTTPService().get(serviceURL + "/authn/session").then(function(response) {
                     if (context === "401" && shouldReloadPageAfterLogin(response.data)) {
                         window.location.reload();
                         return response.data;
@@ -274,7 +274,7 @@
              * Meant for validating the server session and verify if it's still active or not
              */
             validateSession: function () {
-                return $http.get(serviceURL + "/authn/session").then(function(response) {
+                return ConfigUtils.getHTTPService().get(serviceURL + "/authn/session").then(function(response) {
                     _session = response.data;
                     return _session;
                 }).catch(function(err) {
@@ -337,7 +337,7 @@
 
                 url += '?logout_url=' + UriUtils.fixedEncodeURIComponent(logoutURL);
 
-                $http.delete(url).then(function(response) {
+                ConfigUtils.getHTTPService().delete(url).then(function(response) {
                     StorageService.deleteStorageNamespace(LOCAL_STORAGE_KEY);
                     $window.location = response.data.logout_url;
                 }, function(error) {

--- a/common/utils.js
+++ b/common/utils.js
@@ -1398,7 +1398,7 @@
         }
     }])
 
-    .factory("ConfigUtils", ['$rootScope', '$window', 'defaultChaiseConfig', function($rootScope, $window, defaultConfig) {
+    .factory("ConfigUtils", ['defaultChaiseConfig', '$http', '$rootScope', '$window', function(defaultConfig, $http, $rootScope, $window) {
 
         /**
          * Will return the dcctx object that has the following attributes:
@@ -1498,10 +1498,21 @@
             $window.dcctx.chaiseConfig = cc;
         }
 
+        /**
+         * Returns the http service that should be used in chaise
+         * NOTE: This has been added for backward compatibility.
+         * The window.dcctx.server should always be available if config app has been included
+         * @return {Object}
+         */
+        function getHTTPService() {
+            return getContextJSON().server ? getContextJSON().server.http : $http;
+        };
+
         return {
             getContextJSON: getContextJSON,
             getConfigJSON: getConfigJSON,
-            setConfigJSON: setConfigJSON
+            setConfigJSON: setConfigJSON,
+            getHTTPService: getHTTPService
         }
     }])
 


### PR DESCRIPTION
The following are the three different places in chaise we're directly generating http requests. 

- Search app: 
  It's relying on the old ermrestjs that resides in chaise. We cannot do anything about this.

- viewer app: 
  There's a `getGoauth` function that is being called upon 401/404 error response while getting the session. Since it's using the `authen.js` this shouldn't even happen and the `authen.js` should handle this case. I'm not sure why this code path even exists in viewer app. Most probably we can just remove this code path (While I was fixing the viewer app I saw this config block and added a TODO with more details on why I think we should just remove it).  We should discuss about this

- `authen.js`: 
  The login/logout requests. In this PR, I modified the $http in this file, to use the new `window.dcctx.server.http`.

P.S. Instead of directly using `window.dcctx.server.http`, I added a `getHTTPService` for backward compatibility. We could remove it if you think it's not necessary. 

#1741 