### PR TITLE
Sugest login in error

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -322,11 +322,9 @@
                 // change defaults
                 pageName = "Recordset";
                 redirectLink = exception.errorData.redirectUrl;
-                if (exception instanceof Errors.noRecordError && !Session.getSessionValue()) showLogin = true;
             } else if (ERMrest && exception instanceof ERMrest.ERMrestError ) {
                 if (DataUtils.isObjectAndKeyDefined(exception.errorData, 'gotoTableDisplayname')) pageName = exception.errorData.gotoTableDisplayname;
                 if (DataUtils.isObjectAndKeyDefined(exception.errorData, 'redirectUrl')) redirectLink = exception.errorData.redirectUrl;
-                if (exception instanceof ERMrest.NotFoundError && !Session.getSessionValue()) showLogin = true;
             } else if (exception instanceof Errors.CustomError ) {
                 logError(exception);
                 message = exception.message;
@@ -336,6 +334,8 @@
                 message = errorMessages.systemAdminMessage;
                 subMessage = exception.message;
             }
+
+            if (!Session.getSessionValue()) showLogin = true;
 
             errorPopup(exception, pageName, redirectLink, subMessage, stackTrace, isDismissible, showLogin, message, errorStatus);
 

--- a/common/modal.js
+++ b/common/modal.js
@@ -81,15 +81,6 @@
             vm.showReloadBtn = !$rootScope.displayReady;
         }
 
-        // in case of adding login button, we should add extra message
-        if (vm.params.showLogin) {
-            if (ERMrest && exception instanceof ERMrest.NotFoundError) {
-                vm.params.message = $sce.trustAsHtml(vm.params.message + messageMap.maybeNeedLogin);
-            } else if (exception instanceof Errors.noRecordError) {
-                vm.params.message = $sce.trustAsHtml(messageMap.noRecordForFilter + '<br>' + messageMap.maybeUnauthorizedMessage);
-            }
-        }
-
         // set the click action message
         if (exception instanceof Errors.multipleRecordError) {
             vm.clickActionMessage =  messageMap.recordAvailabilityError.multipleRecords;
@@ -113,7 +104,10 @@
 
         // <p> tag is added to maintain the space between click action message and buttons
         // Also maintains consistency  in their placement irrespective of reload message
+        // NOTE: $sce.trustAsHtml done in one place after setting everything
         vm.clickActionMessage = $sce.trustAsHtml(vm.clickActionMessage + reloadMessage);
+        vm.params.message = $sce.trustAsHtml(vm.params.message);
+        vm.params.subMessage = $sce.trustAsHtml(vm.params.subMessage);
 
         vm.clickOkToDismiss = exception.clickOkToDismiss;
         vm.showDetails = function() {


### PR DESCRIPTION
Refactored the error flow a little bit so it's more consistent.

I moved all `$sce.trustAsHtml` calls for error messages to one place. Moved all message manipulation to the `handleException` function. Always add the `maybeShowLogin` message when the user is not logged in unless it's the `noRecordError` case, in which we show a different message.

@RFSH you mentioned in the issue that we should differentiate between the following 2 errors cases in `ermrestJS`:
 - when the facet string is completely invalid (and therefore cannot be decoded) 
 - when the facet string is correct but the generated path is invalid (possibly because user isn't authorized for parts of that path

Should this change still be made or do you think that distinction is not as important if we are _always_ going to show the login link when the user has no session?