### PR TITLE
update config app + add documentation

### DIFF
--- a/common/config.js
+++ b/common/config.js
@@ -1,7 +1,29 @@
 (function() {
     'use strict';
 
-    angular.module('chaise.config', ['chaise.utils', 'ermrestjs'])
+    /**
+     * Module Dependencies:
+     *    |--ermrestJS
+     *    |
+     *    |--utils.js
+     *       |--errors.js - needed for utils
+     *       |  |--alerts.js
+     *       |  |  |--filters.js
+     *       |  |
+     *       |  |--authen.js
+     *       |  |  |--storage.js
+     *       |  |
+     *       |  |--modal.js
+     *       |
+     *       |--inputs.js
+     *          |--validators.js
+     */
+    angular.module('chaise.config', [
+        'chaise.utils',
+        'ermrestjs',
+        'ngCookies',
+        'ui.bootstrap'
+    ])
 
     .run(['appName', 'ConfigUtils', 'ERMrest', 'headInjector', 'MathUtils', 'UriUtils', '$rootScope', '$window', function(appName, ConfigUtils, ERMrest, headInjector, MathUtils, UriUtils, $rootScope, $window) {
         headInjector.setWindowName();

--- a/docs/dev-docs/config-app.md
+++ b/docs/dev-docs/config-app.md
@@ -1,0 +1,64 @@
+# Configuration App
+
+> If the new Chaise app does not rely on any of the chaise-config attributes (or is using any of the chaise/common components), you do not need a separate config app.
+
+Since chaise-config can be configured through annotation, we had to make a http request to get its value from the catalog annotation. This means that the chaise-config will be available during the runtime and after an asynchronous call. Because of this we had to delay the loading of Chaise apps and introduce an extra app which its whole purpose is populating the necessary configuration variables.
+
+The following is how you should define the configuration app:
+
+- Create a new app that uses the `chaise.config` module.
+- Define the constant `appName` attribute that `chasie.config` will use.
+- In the run-block of this configuration app, bootstrap your app after the configuration is done.
+
+```javascript
+
+// define the configure-appname app which is using the chaise.config
+angular.module('chaise.configure-<APP_NAME>', ['chaise.config'])
+
+// this constant is used for `cid` (e.g. recordset)
+.constant('appName', '<APP_NAME>')
+
+.run(['$rootScope', function ($rootScope) {
+    $rootScope.$on("configuration-done", function () {
+        angular.element(document).ready(function(){
+            // attach the actual app to the given element.
+            angular.bootstrap(document.getElementById("<APP_NAME>"), ["chaise.<APP_NAME>"]);
+        });
+    });
+}]);
+```
+
+
+This will delay your app until the configuration is completely done. To make sure that this works, your HTML structure should be like the following:
+
+```html
+<html lang="en" id="<APP_NAME>">
+    <body>
+        <div class="configure-container" ng-app="chaise.configure-<APP>">
+            <loading-spinner></loading-spinner>
+        </div>
+        <div class="app-container" ng-controller="<APP_CONTROLLER> as ctrl">
+        </div>
+    </body>
+</html>    
+```
+
+With these css rules
+
+```css
+html .app-container {
+    display: none;
+}
+
+html.ng-scope .app-container {
+    display: block;
+}
+
+html.ng-scope .configure-container {
+    display: none;
+}
+```
+
+This will,
+  - Ensure that the `chaise.configure-<APP>` is the first app that will be loaded.
+  - Hide the main content and show a loading spinner while getting the catalog annotation.

--- a/lib/login/login.app.js
+++ b/lib/login/login.app.js
@@ -2,32 +2,7 @@ function loadModule() {
     (function () {
         'use strict';
 
-        /**
-         * Module Dependencies:
-         *   config.js
-         *    |--ermrestJS
-         *    |
-         *    |--utils.js
-         *       |--errors.js - needed for utils
-         *       |  |--alerts.js
-         *       |  |  |--filters.js
-         *       |  |
-         *       |  |--authen.js
-         *       |  |  |--storage.js
-         *       |  |
-         *       |  |--modal.js
-         *       |
-         *       |--inputs.js
-         *          |--validators.js
-         */
-        angular.module('chaise.configure-login', [
-            'chaise.config',
-            'chaise.utils',
-            'ermrestjs',
-            'ngCookies',
-            'ngAnimate',
-            'ui.bootstrap'
-        ])
+        angular.module('chaise.configure-login', ['chaise.config'])
 
         .constant('appName', 'login')
 

--- a/lib/navbar/navbar.app.js
+++ b/lib/navbar/navbar.app.js
@@ -2,32 +2,7 @@ function loadModule() {
     (function () {
         'use strict';
 
-        /**
-         * Module Dependencies:
-         *   config.js
-         *    |--ermrestJS
-         *    |
-         *    |--utils.js
-         *       |--errors.js - needed for utils
-         *       |  |--alerts.js
-         *       |  |  |--filters.js
-         *       |  |
-         *       |  |--authen.js
-         *       |  |  |--storage.js
-         *       |  |
-         *       |  |--modal.js
-         *       |
-         *       |--inputs.js
-         *          |--validators.js
-         */
-        angular.module('chaise.configure-navbar', [
-            'chaise.config',
-            'chaise.utils',
-            'ermrestjs',
-            'ngCookies',
-            'ngAnimate',
-            'ui.bootstrap'
-        ])
+        angular.module('chaise.configure-navbar', ['chaise.config'])
 
         .constant('appName', 'navbar')
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -1,33 +1,8 @@
 (function() {
     'use strict';
-/* Configuration of the Record App */
 
-    /**
-     * Module Dependencies:
-     *   config.js
-     *    |--ermrestJS
-     *    |
-     *    |--utils.js
-     *       |--errors.js - needed for utils
-     *       |  |--alerts.js
-     *       |  |  |--filters.js
-     *       |  |
-     *       |  |--authen.js
-     *       |  |  |--storage.js
-     *       |  |
-     *       |  |--modal.js
-     *       |
-     *       |--inputs.js
-     *          |--validators.js
-     */
-    angular.module('chaise.configure-record', [
-        'chaise.config',
-        'chaise.utils',
-        'ermrestjs',
-        'ngCookies',
-        'ngAnimate',
-        'ui.bootstrap'
-    ])
+/* Configuration of the Record App */
+    angular.module('chaise.configure-record', ['chaise.config'])
 
     .constant('appName', 'record')
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -1,32 +1,8 @@
 (function() {
     'use strict';
-/* Configuration of the Recordedit App */
 
-    /**
-     * Module Dependencies:
-     *   config.js
-     *    |--ermrestJS
-     *    |
-     *    |--utils.js
-     *       |--errors.js - needed for utils
-     *       |  |--alerts.js
-     *       |  |  |--filters.js
-     *       |  |
-     *       |  |--authen.js
-     *       |  |  |--storage.js
-     *       |  |
-     *       |  |--modal.js
-     *       |
-     *       |--inputs.js
-     *          |--validators.js
-     */
-    angular.module('chaise.configure-recordedit', [
-        'chaise.config',
-        'chaise.utils',
-        'ermrestjs',
-        'ngCookies',
-        'ui.bootstrap'
-    ])
+/* Configuration of the Recordedit App */
+    angular.module('chaise.configure-recordedit', ['chaise.config'])
 
     .constant('appName', 'recordedit')
 

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -1,33 +1,8 @@
 (function() {
     'use strict';
-/* Configuration of the Recordset App */
 
-    /**
-     * Module Dependencies:
-     *   config.js
-     *    |--ermrestJS
-     *    |
-     *    |--utils.js
-     *       |--errors.js - needed for utils
-     *       |  |--alerts.js
-     *       |  |  |--filters.js
-     *       |  |
-     *       |  |--authen.js
-     *       |  |  |--storage.js
-     *       |  |
-     *       |  |--modal.js
-     *       |
-     *       |--inputs.js
-     *          |--validators.js
-     */
-    angular.module('chaise.configure-recordset', [
-        'chaise.config',
-        'chaise.utils',
-        'ermrestjs',
-        'ngCookies',
-        'ngAnimate',
-        'ui.bootstrap'
-    ])
+/* Configuration of the Recordset App */
+    angular.module('chaise.configure-recordset', ['chaise.config'])
 
     .constant('appName', 'recordset')
 

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -1,31 +1,7 @@
 (function() {
     'use strict';
 
-    /**
-     * Module Dependencies:
-     *   config.js
-     *    |--ermrestJS
-     *    |
-     *    |--utils.js
-     *       |--errors.js - needed for utils
-     *       |  |--alerts.js
-     *       |  |  |--filters.js
-     *       |  |
-     *       |  |--authen.js
-     *       |  |  |--storage.js
-     *       |  |
-     *       |  |--modal.js
-     *       |
-     *       |--inputs.js
-     *          |--validators.js
-     */
-    angular.module('chaise.configure-viewer', [
-        'chaise.config',
-        'chaise.utils',
-        'ermrestjs',
-        'ngCookies',
-        'ui.bootstrap'
-    ])
+    angular.module('chaise.configure-viewer', ['chaise.config'])
 
     .constant('appName', 'viewer')
 


### PR DESCRIPTION
This PR will update the way we're including configuration app to make it more flexible. I moved all the dependencies to `config.js` and configuration app will only need to include `config.js`. This way if we decided to change any of the dependencies, we won't need to update other apps.

Also I couldn't find why we would need `ngAnimate` for config app. It wasn't included in recordedit any ways, so I just removed it and it works fine.

I also added a new doc to explain how other deriva-webapps should follow the same structure.