### PR TITLE
No internet no templates

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -307,9 +307,8 @@
 
             // if network is offline, use offline dialog workflow
             if (exception.online === false) {
-                console.log("In offline exception condition");
                 offlineErrorTemplate(exception);
-                return null;
+                return;
             }
             $rootScope.error = true;    // used to hide spinner in conjunction with a css property
 

--- a/common/errors.js
+++ b/common/errors.js
@@ -305,7 +305,12 @@
                 showLogin = false,
                 message, errorStatus;
 
-
+            // if network is offline, use offline dialog workflow
+            if (exception.online === false) {
+                console.log("In offline exception condition");
+                offlineErrorTemplate(exception);
+                return null;
+            }
             $rootScope.error = true;    // used to hide spinner in conjunction with a css property
 
             // don't throw an angular error if in search/viewer or one has already been thrown
@@ -436,5 +441,44 @@ window.onerror = function() {
     }
 
     logError(error);
-
 };
+
+var errorVisible = false;
+var offlineErrorTemplate = function (error) {
+    var errorVisible = document.getElementById('divErrorModal');
+    if (!document || !document.body || errorVisible) return;
+
+    var errName = error.constructor.name;
+    errName = (errName.toLowerCase() !== 'error') ? errName : "Terminal Error";
+
+    var html  = '<div modal-render="true" tabindex="-1" role="dialog" class="modal fade in" index="0" animate="animate" modal-animation="true" style="z-index: 1050; display: block;">'
+        + '<div class="modal-dialog" style="width:90% !important;">'
+            + '<div class="modal-content" uib-modal-transclude="">'
+                + '<div class="modal-header">'
+                    + '<button class="btn btn-default pull-right modal-close" type="button" onclick="document.getElementById(\'divErrorModal\').remove();">X</button>'
+                    + '<h2 class="modal-title ">Error: ' + errName + '</h2>'
+                + '</div>'
+                + '<div class="modal-body ">'
+                    + 'An unexpected error has occurred. Please check that you are still connected to your network. If you continue to face this issue, please contact the system administrator.'
+                    + '<br><br>'
+                    + 'Click OK to return to the Home Page.'
+                    + '<br>'
+                    + '<span class="terminalError"><br>'
+                        + '<pre  style="word-wrap: unset;">' + error.message + '<br><span style="padding-left:20px;">' + error.stack + '</span></pre>'
+                    + '</span>'
+                + '</div>'
+                + '<div class="modal-footer">'
+                    + '<button class="btn btn-danger" type="button" onclick="document.getElementById(\'divErrorModal\').remove();">OK</button>'
+                + '</div>'
+            + '</div>'
+        + '</div>'
+    + '</div>'
+    + '<div class="modal-backdrop fade in" style="z-index: 1040;"></div>';
+
+    var el = document.createElement('div');
+    el.id = "divErrorModal";
+    el.innerHTML = html;
+
+    document.body.appendChild(el);
+    errorVisible = true;
+}

--- a/common/modal.js
+++ b/common/modal.js
@@ -16,11 +16,6 @@
                 if (rejectCB) {
                     rejectCB(response);
                 } else if (typeof response !== "string") {
-                    // there is no internet connection, so templates couldn't be fetched
-                    // set a flag on the response (error) object
-                    if (response.message.includes("Error: [$compile:tpload]")) {
-                        response.online = $window.navigator.onLine;
-                    }
                     throw response;
                 }
             });

--- a/common/modal.js
+++ b/common/modal.js
@@ -4,7 +4,7 @@
     angular.module('chaise.modal', ['chaise.utils'])
 
     //TODO
-    .factory('modalUtils', ["$uibModal", "$log", function ($uibModal, $log) {
+    .factory('modalUtils', ["$log", "$uibModal", "$window", function ($log, $uibModal, $window) {
         function showModal(params, successCB, rejectCB, postRenderCB) {
             var modalInstance = $uibModal.open(params);
             if (postRenderCB) {
@@ -16,6 +16,11 @@
                 if (rejectCB) {
                     rejectCB(response);
                 } else if (typeof response !== "string") {
+                    // there is no internet connection, so templates couldn't be fetched
+                    // set a flag on the response (error) object
+                    if (response.message.includes("Error: [$compile:tpload]")) {
+                        response.online = $window.navigator.onLine;
+                    }
                     throw response;
                 }
             });

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -122,7 +122,10 @@
                         // happens with an error with code 0 (Timeout Error)
                         $log.warn(exception);
                         var message = exception.message || messageMap.errorMessageMissing;
-                        AlertsService.addAlert(message, 'error');
+                        // if online, we don't know how to handle the error
+                        if ($window.navigator.onLine) {
+                            AlertsService.addAlert(message, 'error');
+                        }
                     }
                 }, false, false);
             } else {

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -122,10 +122,9 @@
                         // happens with an error with code 0 (Timeout Error)
                         $log.warn(exception);
                         var message = exception.message || messageMap.errorMessageMissing;
+
                         // if online, we don't know how to handle the error
-                        if ($window.navigator.onLine) {
-                            AlertsService.addAlert(message, 'error');
-                        }
+                        if ($window.navigator.onLine) AlertsService.addAlert(message, 'error');
                     }
                 }, false, false);
             } else {

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -284,6 +284,7 @@ describe('View existing record,', function() {
     describe("For multiple records fetched for particular filters", function() {
 
         beforeAll(function() {
+            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name +  "/luxurious=true";
             browser.get(url);
             chaisePage.waitForElement(element(by.css('.modal-dialog ')));


### PR DESCRIPTION
Opening this PR so we can have a discussion about the changes. 

The error case described in issue #1711 occurs when the user is fetching a template but there is no network connection. In the `chaise` apps, this can only occur _after_ a page has loaded, so the user had a network connection at one point but then lost it. The only time that we try to "fetch" templates after a page has loaded, is when a user clicks on an action that opens a modal instance.

I made changes to `modalUtils` to handle all of these cases. I'm using the navigator object API, [described here](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine/Online_and_offline_events), to check the `onLine` property to determine what type of error case we are in. If the app is in an offline state, it will call into the added function that generates an HTML modal with JS instead of trying to fetch another template.

NOTE: I wasn't sure if there's a way to "pre-fetch" templates so they are always available (pre-fetch the error template instead so this isn't an issue with the error dialog). Something like a pseudo-cache.