### PR TITLE
skip login dialog for 401 on asset

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -23,6 +23,7 @@
         multipleDataErrorCode : "Multiple Records Found",
         multipleDataMessage : "There are more than 1 record found for the filters provided.",
         facetFilterMissing : "No filtering criteria was specified to identify a specific record.",
+        unauthorizedAssetRetrieval : "You must be an authorized user to download this asset.",
         systemAdminMessage : "An unexpected error has occurred. Try clearing your cache. If you continue to face this issue, please contact the system administrator."
     })
 
@@ -134,6 +135,23 @@
         InvalidInputError.prototype = Object.create(Error.prototype);
         InvalidInputError.prototype.constructor = InvalidInputError;
 
+        function UnauthorizedAssetAccess() {
+            /**
+            * @type {string}
+            * @desc   Error message status; acts as Title text for error dialog
+             */
+            this.status = errorNames.unauthorized;
+
+            /**
+            * @type {string}
+            * @desc   Error message
+             */
+            this.message = errorMessages.unauthorizedAssetRetrieval;
+        }
+
+        UnauthorizedAssetAccess.prototype = Object.create(Error.prototype);
+        UnauthorizedAssetAccess.prototype.constructor = UnauthorizedAssetAccess;
+
         /**
          * CustomError - throw custom error from Apps outside Chaise.
          *
@@ -189,6 +207,7 @@
             noRecordError:noRecordError,
             InvalidInputError: InvalidInputError,
             MalformedUriError: MalformedUriError,
+            UnauthorizedAssetAccess: UnauthorizedAssetAccess,
             CustomError: CustomError
         };
     }])
@@ -293,7 +312,7 @@
         var exceptionFlag = false;
 
         // TODO: implement hierarchies of exceptions in ermrestJS and use that hierarchy to conditionally check for certain exceptions
-        function handleException(exception, isDismissible, skipLoginDialog) {
+        function handleException(exception, isDismissible) {
             var chaiseConfig = ConfigUtils.getConfigJSON();
             $log.info(exception);
 
@@ -315,7 +334,7 @@
             if (exceptionFlag || window.location.pathname.indexOf('/search/') != -1 || window.location.pathname.indexOf('/viewer/') != -1) return;
 
             // If not authorized, ask user to sign in first
-            if (!skipLoginDialog && ERMrest && exception instanceof ERMrest.UnauthorizedError) {
+            if (ERMrest && exception instanceof ERMrest.UnauthorizedError) {
                 // Unauthorized (needs to login)
                 Session.loginInAModal(reloadCb);
                 return;

--- a/common/errors.js
+++ b/common/errors.js
@@ -23,7 +23,7 @@
         multipleDataErrorCode : "Multiple Records Found",
         multipleDataMessage : "There are more than 1 record found for the filters provided.",
         facetFilterMissing : "No filtering criteria was specified to identify a specific record.",
-        unauthorizedAssetRetrieval : "You must be an authorized user to download this asset.",
+        unauthorizedAssetRetrieval : "You must be logged in and authorized to download this asset.",
         systemAdminMessage : "An unexpected error has occurred. Try clearing your cache. If you continue to face this issue, please contact the system administrator."
     })
 
@@ -146,7 +146,7 @@
              * @type {string}
              * @desc   Error message status; acts as Title text for error dialog
              */
-            this.status = errorNames.unauthorized;
+            this.status = messageMap.unauthorizedErrorCode;
 
             /**
              * @type {string}
@@ -158,7 +158,7 @@
              * @type {string}
              * @desc Action message to display for click of the OK button
              */
-            this.errorData.clickActionMessage = messageMap.clickActionMessage.dismissDialog;
+            this.errorData.clickActionMessage = messageMap.clickActionMessage.loginOrDismissDialog;
 
             /**
              * @type {boolean}
@@ -377,7 +377,7 @@
             // There's no message
             if (message.trim().length < 1) message = errorMessages.systemAdminMessage;
 
-            if (!Session.getSessionValue()) {
+            if (!Session.getSessionValue() && !exception instanceof Errors.UnauthorizedAssetAccess) {
                 showLogin = true;
                 if (exception instanceof Errors.noRecordError) {
                     // if no logged in user, change the message

--- a/common/errors.js
+++ b/common/errors.js
@@ -293,7 +293,7 @@
         var exceptionFlag = false;
 
         // TODO: implement hierarchies of exceptions in ermrestJS and use that hierarchy to conditionally check for certain exceptions
-        function handleException(exception, isDismissible) {
+        function handleException(exception, isDismissible, skipLoginDialog) {
             var chaiseConfig = ConfigUtils.getConfigJSON();
             $log.info(exception);
 
@@ -315,7 +315,7 @@
             if (exceptionFlag || window.location.pathname.indexOf('/search/') != -1 || window.location.pathname.indexOf('/viewer/') != -1) return;
 
             // If not authorized, ask user to sign in first
-            if (ERMrest && exception instanceof ERMrest.UnauthorizedError) {
+            if (!skipLoginDialog && ERMrest && exception instanceof ERMrest.UnauthorizedError) {
                 // Unauthorized (needs to login)
                 Session.loginInAModal(reloadCb);
                 return;

--- a/common/errors.js
+++ b/common/errors.js
@@ -27,7 +27,7 @@
         systemAdminMessage : "An unexpected error has occurred. Try clearing your cache. If you continue to face this issue, please contact the system administrator."
     })
 
-    .factory('Errors', ['errorNames', 'errorMessages', function(errorNames, errorMessages) {
+    .factory('Errors', ['errorNames', 'errorMessages', 'messageMap', function(errorNames, errorMessages, messageMap) {
 
         // errorData object holds additional information viz. stacktrace, redirectUrl
         // Make sure to check cross-browser cmpatibility for stack attribute of Error Object
@@ -137,16 +137,34 @@
 
         function UnauthorizedAssetAccess() {
             /**
-            * @type {string}
-            * @desc   Error message status; acts as Title text for error dialog
+             * @type {object}
+             * @desc  custom object to store miscellaneous elements viz. stacktrace
+             */
+            this.errorData = {};
+
+            /**
+             * @type {string}
+             * @desc   Error message status; acts as Title text for error dialog
              */
             this.status = errorNames.unauthorized;
 
             /**
-            * @type {string}
-            * @desc   Error message
+             * @type {string}
+             * @desc   Error message
              */
             this.message = errorMessages.unauthorizedAssetRetrieval;
+
+            /**
+             * @type {string}
+             * @desc Action message to display for click of the OK button
+             */
+            this.errorData.clickActionMessage = messageMap.clickActionMessage.dismissDialog;
+
+            /**
+             * @type {boolean}
+             * @desc Set true to dismiss the error modal on clicking the OK button
+             */
+            this.clickOkToDismiss = true;
         }
 
         UnauthorizedAssetAccess.prototype = Object.create(Error.prototype);
@@ -350,7 +368,7 @@
             } else if (exception instanceof Errors.CustomError ) {
                 logError(exception);
                 redirectLink = exception.errorData.redirectUrl;
-            } else {
+            } else if (!exception instanceof Errors.UnauthorizedAssetAccess) {
                 logError(exception);
                 message = errorMessages.systemAdminMessage;
                 subMessage = exception.message;

--- a/common/modal.js
+++ b/common/modal.js
@@ -108,7 +108,7 @@
         // <p> tag is added to maintain the space between click action message and buttons
         // Also maintains consistency  in their placement irrespective of reload message
         // NOTE: $sce.trustAsHtml done in one place after setting everything
-        vm.clickActionMessage = $sce.trustAsHtml(vm.clickActionMessage + reloadMessage);
+        vm.clickActionMessage = vm.clickActionMessage + reloadMessage;
         vm.params.message = $sce.trustAsHtml(vm.params.message);
         vm.params.subMessage = $sce.trustAsHtml(vm.params.subMessage);
 

--- a/common/modal.js
+++ b/common/modal.js
@@ -42,7 +42,8 @@
             $uibModalInstance.dismiss('cancel');
         }
     }])
-    .controller('ErrorModalController', ['Errors', 'messageMap', 'params', 'Session', '$rootScope', '$sce', '$uibModalInstance', '$window', function ErrorModalController(Errors, messageMap, params, Session, $rootScope, $sce, $uibModalInstance, $window) {
+    .controller('ErrorModalController', ['ConfigUtils', 'Errors', 'messageMap', 'params', 'Session', '$rootScope', '$sce', '$uibModalInstance', '$window', function ErrorModalController(ConfigUtils, Errors, messageMap, params, Session, $rootScope, $sce, $uibModalInstance, $window) {
+        var cc = ConfigUtils.getConfigJSON();
         function isErmrestErrorNeedReplace (error) {
             switch (error.constructor) {
                 case ERMrest.InvalidFacetOperatorError:
@@ -75,6 +76,8 @@
         vm.displayDetails = false;
         vm.linkText = messageMap.showErrDetails;
         vm.showReloadBtn = false;
+        vm.showDownloadPolicy = (cc.assetDownloadPolicyURL && cc.assetDownloadPolicyURL.trim().length > 0 && typeof cc.assetDownloadPolicyURL == "string");
+        if (vm.showDownloadPolicy) vm.downloadPolicy = cc.assetDownloadPolicyURL;
         if (ERMrest && isRetryError(exception)) {
             // we are only showing the reload button for the 4 types of retriable errors while the page is loading.
             // we discussed that it doesn't make sense to "retry" other requests that may fail after the data has loaded.

--- a/common/modal.js
+++ b/common/modal.js
@@ -86,22 +86,22 @@
 
         // set the click action message
         if (exception instanceof Errors.multipleRecordError) {
-            vm.clickActionMessage =  messageMap.recordAvailabilityError.multipleRecords;
+            vm.clickActionMessage =  messageMap.clickActionMessage.multipleRecords;
         } else if (exception instanceof Errors.noRecordError) {
-            vm.clickActionMessage = messageMap.recordAvailabilityError.noRecordsFound;
-        } else if (exception instanceof Errors.CustomError && exception.errorData.clickActionMessage) {
+            vm.clickActionMessage = messageMap.clickActionMessage.noRecordsFound;
+        } else if ( (exception instanceof Errors.CustomError && exception.errorData.clickActionMessage) || exception instanceof Errors.UnauthorizedAssetAccess) {
             vm.clickActionMessage = exception.errorData.clickActionMessage;
         } else if (ERMrest && exception instanceof ERMrest.InvalidFilterOperatorError) {
-            vm.clickActionMessage = messageMap.recordAvailabilityError.noRecordsFound;
+            vm.clickActionMessage = messageMap.clickActionMessage.noRecordsFound;
         } else if (ERMrest && isErmrestErrorNeedReplace(exception)) {
-            vm.clickActionMessage = messageMap.actionMessageWReplace.clickActionMessage.replace('@errorStatus', vm.params.errorStatus);
+            vm.clickActionMessage = messageMap.clickActionMessage.messageWReplace.replace('@errorStatus', vm.params.errorStatus);
         } else {
-            vm.clickActionMessage = messageMap.recordAvailabilityError.pageRedirect + vm.params.pageName + '. ';
+            vm.clickActionMessage = messageMap.clickActionMessage.pageRedirect + vm.params.pageName + '. ';
 
             // TODO it might be more appropriate to move the following outside the if-else
             if (vm.params.appName == 'recordedit'){
                 vm.showReloadBtn = true;
-                reloadMessage = ' <p>' + messageMap.terminalError.reloadMessage +' </p>';
+                reloadMessage = ' <p>' + messageMap.clickActionMessage.reloadMessage +' </p>';
             }
         }
 

--- a/common/templates/errorDialog.modal.html
+++ b/common/templates/errorDialog.modal.html
@@ -5,11 +5,11 @@
 <div class="modal-body">
     <span ng-bind-html="ctrl.params.message"></span>
     <span ng-if="ctrl.params.showLogin"><a id="login-link" ng-click="ctrl.login()"> Please login</a> to continue.</span>
-    <span ng-if="ctrl.showDownloadPolicy">Download policy can be found <a id="download-policy-link" ng-href="{{ctrl.downloadPolicy}}">here</a>.</span>
+    <span ng-if="ctrl.showDownloadPolicy">The download instructions can be found <a id="download-policy-link" ng-href="{{ctrl.downloadPolicy}}">here</a>.</span>
 
     <br><br>
 
-    <span ng-bind-html="ctrl.clickActionMessage"></span>
+    <span compile="ctrl.clickActionMessage"></span>
     <a ng-show="ctrl.params.subMessage" ng-click="ctrl.showDetails()" id="toggle-error-details">
         <i class="pull-left glyphicon glyphicon-triangle-right" ng-class="{'glyphicon-triangle-bottom': ctrl.displayDetails, 'glyphicon-triangle-right': !ctrl.displayDetails}"></i>
         {{ctrl.linkText}}

--- a/common/templates/errorDialog.modal.html
+++ b/common/templates/errorDialog.modal.html
@@ -3,15 +3,17 @@
     <h2 class="modal-title">{{::ctrl.params.errorStatus}}</h2>
 </div>
 <div class="modal-body">
-  <span ng-bind-html="ctrl.params.message"></span>
-  <span ng-if="ctrl.params.showLogin"><a id="login-link" ng-click="ctrl.login()"> Please login</a> to continue.</span>
+    <span ng-bind-html="ctrl.params.message"></span>
+    <span ng-if="ctrl.params.showLogin"><a id="login-link" ng-click="ctrl.login()"> Please login</a> to continue.</span>
+    <span ng-if="ctrl.showDownloadPolicy">Download policy can be found <a id="download-policy-link" ng-href="{{ctrl.downloadPolicy}}">here</a>.</span>
 
     <br><br>
 
     <span ng-bind-html="ctrl.clickActionMessage"></span>
     <a ng-show="ctrl.params.subMessage" ng-click="ctrl.showDetails()" id="toggle-error-details">
-      <i class="pull-left glyphicon glyphicon-triangle-right" ng-class="{'glyphicon-triangle-bottom': ctrl.displayDetails, 'glyphicon-triangle-right': !ctrl.displayDetails}"></i>
-    {{ctrl.linkText}}</a>
+        <i class="pull-left glyphicon glyphicon-triangle-right" ng-class="{'glyphicon-triangle-bottom': ctrl.displayDetails, 'glyphicon-triangle-right': !ctrl.displayDetails}"></i>
+        {{ctrl.linkText}}
+    </a>
 
     <br>
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -86,7 +86,6 @@
         "actionMessageWReplace" : {
           clickActionMessage: "Click <b>OK</b> to reload this page without @errorStatus."
         },
-        "unauthenticatedAssetRetrieval" : "You must be authenticated to download this asset.",
         "errorMessageMissing": "An unexpected error has occurred. Please try again",
         "tableMissing": "No table specified in the form of 'schema-name:table-name' and no Default is set.",
         "maybeNeedLogin": "You may need to login to see the model or data.",
@@ -1704,7 +1703,7 @@
       }
      }])
 
-    .service('headInjector', ['ConfigUtils', 'ERMrest', 'ErrorService', 'MathUtils', 'messageMap', '$rootScope', '$window', function(ConfigUtils, ERMrest, ErrorService, MathUtils, messageMap, $rootScope, $window) {
+    .service('headInjector', ['ConfigUtils', 'ERMrest', 'Errors', 'ErrorService', 'MathUtils', '$rootScope', '$window', function(ConfigUtils, ERMrest, Errors, ErrorService, MathUtils, $rootScope, $window) {
         function addCustomCSS() {
             var chaiseConfig = ConfigUtils.getConfigJSON();
             if (chaiseConfig['customCSS'] !== undefined) {
@@ -1754,16 +1753,13 @@
                     // error/login modal was closed
                     if (typeof exception == 'string') return;
                     var ermrestError = ERMrest.responseToError(exception);
-                    var skipLoginDialog = false;
 
                     if (ermrestError instanceof ERMrest.UnauthorizedError) {
-                        ermrestError.status = messageMap.unauthorizedErrorCode;
-                        ermrestError.message  = messageMap.unauthenticatedAssetRetrieval;
-                        skipLoginDialog = true;
+                        ermrestError = new Errors.UnauthorizedAssetAccess();
                     }
 
                     // If an error occurs while a user is trying to download the file, allow them to dismiss the dialog
-                    ErrorService.handleException(ermrestError, true, skipLoginDialog);
+                    ErrorService.handleException(ermrestError, true);
                 }).finally(function () {
                     // remove the spinner
                     e.target.innerHTML = e.target.innerHTML.slice(0, e.target.innerHTML.indexOf(spinnerHTML));

--- a/common/utils.js
+++ b/common/utils.js
@@ -74,17 +74,14 @@
             title: "You need to be logged in to continue.",
             message: "To open the login window press"
         },
-        "recordAvailabilityError" : {
-          "multipleRecords": "Click <b>OK</b> to show all the matched records.",
-          "noRecordsFound": "Click <b>OK</b> to show the list of all records.",
-          "pageRedirect": "Click <b>OK</b> to go to the "
-        },
-        "terminalError" : {
-          "okBtnMessage": "Click <b>OK</b> to go to the Recordset.",
-          "reloadMessage": "Click <b>Reload</b> to start over."
-        },
-        "actionMessageWReplace" : {
-          clickActionMessage: "Click <b>OK</b> to reload this page without @errorStatus."
+        "clickActionMessage": {
+            "messageWReplace": "Click <b>OK</b> to reload this page without @errorStatus.",
+            "dismissDialog": "Click <b>OK</b> to dismiss this dialog.",
+            "multipleRecords": "Click <b>OK</b> to show all the matched records.",
+            "noRecordsFound": "Click <b>OK</b> to show the list of all records.",
+            "okBtnMessage": "Click <b>OK</b> to go to the Recordset.",
+            "reloadMessage": "Click <b>Reload</b> to start over.",
+            "pageRedirect": "Click <b>OK</b> to go to the "
         },
         "errorMessageMissing": "An unexpected error has occurred. Please try again",
         "tableMissing": "No table specified in the form of 'schema-name:table-name' and no Default is set.",

--- a/common/utils.js
+++ b/common/utils.js
@@ -76,7 +76,7 @@
         },
         "clickActionMessage": {
             "messageWReplace": "Click <b>OK</b> to reload this page without @errorStatus.",
-            "dismissDialog": "Click <b>OK</b> to dismiss this dialog.",
+            "loginOrDismissDialog": "Click <a ng-click='ctrl.login()'>Login</a> to log in to the system, or click <b>OK</b> to dismiss this dialog.",
             "multipleRecords": "Click <b>OK</b> to show all the matched records.",
             "noRecordsFound": "Click <b>OK</b> to show the list of all records.",
             "okBtnMessage": "Click <b>OK</b> to go to the Recordset.",


### PR DESCRIPTION
This PR is an extension of issue #1461 . This changes the error behavior to show the error dialog instead of the login dialog. This is an extension PR #1785 .

The following is what it looks like when a 401 error is thrown while trying to download an asset:
![image](https://user-images.githubusercontent.com/2932600/59139789-6d8c3080-894a-11e9-8eb8-0b5240308a09.png)




@RFSH  The functionality changes in this PR can be reviewed. I still need to make sure with @hongsudt that the language is what we want.

Once this PR is ready to be merged, I will add the documentation for the new `chaiseConfig` property.