### PR TITLE
add app-wide class names

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -10,7 +10,7 @@
     <div class="configure-container" ng-app="chaise.configure-record">
         <loading-spinner></loading-spinner>
     </div>
-    <div class="app-container" ng-controller="RecordController as ctrl">
+    <div class="app-container r_s_{{ctrl.makeSafeIdAttr(reference.table.schema.name)}} r_t_{{ctrl.makeSafeIdAttr(reference.table.name)}}" ng-controller="RecordController as ctrl">
         <navbar></navbar>
         <div class="row">
             <div id="bookmark-container" class="col-xs-12 meta-icons">

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -23,7 +23,7 @@
     <div class="configure-container" ng-app="chaise.configure-recordedit">
         <loading-spinner></loading-spinner>
     </div>
-    <div class="app-container container-fluid">
+    <div class="app-container container-fluid re_s_{{idSafeSchemaName}} re_t_{{idSafeTableName}}">
         <navbar></navbar>
         <loading-spinner ng-show="!displayReady && !error"></loading-spinner>
         <div ng-if="reference && (reference.canCreate || reference.canUpdate)">

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -266,6 +266,8 @@
                                 $rootScope.tableComment = $rootScope.reference.table.comment;
                             }
                             $rootScope.tableDisplayName = $rootScope.reference.displayname;
+                            $rootScope.idSafeTableName = DataUtils.makeSafeIdAttr($rootScope.reference.table.name);
+                            $rootScope.idSafeSchemaName = DataUtils.makeSafeIdAttr($rootScope.reference.table.schema.name);
 
                             for (var j = 0; j < page.tuples.length; j++) {
                                 // initialize row objects {column-name: value,...}
@@ -388,6 +390,8 @@
                     if ($rootScope.reference.canCreate) {
                         $rootScope.tableDisplayName = $rootScope.reference.displayname;
                         $rootScope.tableComment = $rootScope.reference.table.comment;
+                        $rootScope.idSafeTableName = DataUtils.makeSafeIdAttr($rootScope.reference.table.name);
+                        $rootScope.idSafeSchemaName = DataUtils.makeSafeIdAttr($rootScope.reference.table.schema.name);
 
                         // get the prefilled values
                         var prefilledColumns = {}, prefilledFks = [];

--- a/recordset/index.html.in
+++ b/recordset/index.html.in
@@ -10,7 +10,7 @@
         <div class="configure-container" ng-app="chaise.configure-recordset">
             <loading-spinner></loading-spinner>
         </div>
-        <div class="app-container" ng-controller="recordsetController as ctrl">
+        <div class="app-container rs_s_{{makeSafeIdAttr(vm.schemaName)}} rs_t_{{makeSafeIdAttr(vm.tableName)}}" ng-controller="recordsetController as ctrl">
             <navbar></navbar>
             <div class="row">
                 <div id="bookmark-container" class="col-xs-12 meta-icons">

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -158,6 +158,8 @@
                         recordsetModel.pageLimit = 25;
                     }
                     recordsetModel.tableDisplayName = recordsetModel.reference.displayname;
+                    recordsetModel.tableName = recordsetModel.reference.table.name;
+                    recordsetModel.schemaName = recordsetModel.reference.table.schema.name;
 
                     recordsetModel.search = recordsetModel.reference.location.searchTerm;
 

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -11,6 +11,8 @@
         var chaiseConfig = ConfigUtils.getConfigJSON();
         $scope.vm = recordsetModel;
 
+        $scope.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
+
         recordsetModel.RECORDEDIT_MAX_ROWS = 200;
         ctrl.showExportButton = (chaiseConfig.showExportButton === true);
         $scope.navbarBrand = (chaiseConfig.navbarBrand !== undefined ?  chaiseConfig.navbarBrand : "");


### PR DESCRIPTION
This PR will add new classes to record, recordedit, and recordset that can be used for writing custom css in deployments.

The new classes are 

- `rs_s_<schemaName>` and `rs_t_<tableName>` for recordset.
- `r_s_<schemaName>` and `r_t_<tableName>` for record.
- `re_s_<schemaName>` and `re_t_<tableName>` for recordedit.

I added these classes because we wanted to change the recordset page of [this table in gudmap](https://dev.gudmap.org/~ashafaei/chaise/recordset/#2/Dashboard:Release_Status@sort(ID)). As you can see, using these new classes I'm only showing the table.

``` css
.rs_s_Dashboard.rs_t_Release_Status .faceting-resizable, 
.rs_s_Dashboard.rs_t_Release_Status faceting-collapse-btn,
.rs_s_Dashboard.rs_t_Release_Status #recordset-controls-container,
.rs_s_Dashboard.rs_t_Release_Status #facet-filters-container {
	display: none;
}
```


The following are different things that I think it needs reviewing:

1. Where should I attach these classes? I wanted somewhere top-level so you can change any part of the page. For example, you should be able to select the navbar element using these classes too. Therefore I've attached the classes to `app-container` element that is universal in chaise. 

2. The way I'm capturing the table name and schema name. I tried to follow the same pattern that we have for showing the `tableDisplayName` in the `bookmark-menu`. In record and recordset, we're attaching the controller to `app-container`. So I could simply call the `makeSafeIdAttr` in there. But in recordedit the setup is different. Because of that I'm calling the `makeSafeIdAttr` when I'm creating the table name and schema name variables. This part is a bit ugly and also different from the other apps. Do you have any better suggestions? Or is this good enough? Should I change the other apps to be the same as recordedit?

3. Do I need to add new test cases for this?