### PR TITLE
Log info added to navbar links

### DIFF
--- a/common/navbar.js
+++ b/common/navbar.js
@@ -84,12 +84,17 @@
                         // append "/" if not present
                         if (path[path.length-1] !== "/") path += "/";
                     }
+                    path = $window.location.host + path;
+
+                    // parses the url into a location object
+                    var eleUrl = document.createElement('a');
+                    eleUrl.href = url;
 
                     var isChaise = false;
                     for (var i=0; i<appNames.length; i++) {
                         var name = appNames[i];
                         // path/appName exists in our url
-                        if (url.indexOf(path + name) !== -1) isChaise = true;
+                        if (eleUrl.href.indexOf(path + name) !== -1) isChaise = true;
                     }
 
                     return isChaise;

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -59,7 +59,24 @@
             var parentNewTab = obj.newTab;
             // template the url
             // TODO: This is done here to prevent writing a recursive function (again) in `setConfigJSON()`
-            if (obj.url && isCatalogDefined(catalogId)) obj.url = ERMrest.renderHandlebarsTemplate(obj.url, null, {id: catalogId});
+            if (obj.url && isCatalogDefined(catalogId)) {
+                obj.url = ERMrest.renderHandlebarsTemplate(obj.url, null, {id: catalogId});
+                // only append pcid/ppid if link is to the same origin
+                // same origin urls will be relative, check for http instead(?)
+                // if http, make sure not same origin
+                if (obj.url.indexOf("http") == -1 || obj.url.indexOf($window.location.origin) != -1) {
+                    var paramChar = "";
+                    if (obj.url.lastIndexOf("?") !== -1) {
+                        // already a `?` in the url
+                        paramChar += '&';
+                    } else {
+                        paramChar += '?';
+                    }
+                    // pcid should always be navbar
+                    // ppid should be the pid for the current page
+                    obj.url += paramChar + "pcid=navbar&ppid=" + $window.dcctx.pid;
+                }
+            }
             // If current node has children, set each child's newTab to its own existing newTab or parent's newTab
             if (Array.isArray(obj.children)) {
                 obj.children.forEach(function (child) {

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -38,6 +38,19 @@
         return val != undefined && val != null;
     }
 
+    function addLogParams(url, dcctx) {
+        // if `?` already in the url, use &
+        var paramChar = url.lastIndexOf("?") !== -1 ? "&" : "?";
+
+        var pcid = "navbar";
+        // if not navbar app, append appname
+        if (dcctx.cid !== "navbar") {
+            pcid += "/" + dcctx.cid;
+        }
+        // ppid should be the pid for the current page
+        return url + paramChar + "pcid=" + pcid + "&ppid=" + dcctx.pid;
+    }
+
     'use strict';
     angular.module('chaise.navbar', [
         'chaise.login',
@@ -62,28 +75,30 @@
             if (obj.url && isCatalogDefined(catalogId)) {
                 obj.url = ERMrest.renderHandlebarsTemplate(obj.url, null, {id: catalogId});
 
-                function isChaiseUrl (url) {
-                    function isChaiseApp (url) {
-                        return (url.indexOf("record") != -1 || url.indexOf("recordset") != -1 || url.indexOf("recordedit") != -1);
+                // same origin urls may be relative
+                function isChaiseApp (url) {
+                    var appNames = ["record", "recordset", "recordedit", "search", "login"];
+                    var path = "chaise/";
+                    if (chaiseConfig && typeof chaiseConfig.chaiseBasePath === "string") {
+                        var path = chaiseConfig.chaiseBasePath;
+                        // append "/" if not present
+                        if (path[path.length-1] !== "/") path += "/";
                     }
-                    // first check for same origin (easiest to know if a chaise url)
-                    // check for chaise app if not
-                    return (url.indexOf($window.location.origin) != -1 || isChaiseApp(url));
+
+                    var isChaise = false;
+                    for (var i=0; i<appNames.length; i++) {
+                        var name = appNames[i];
+                        // path/appName exists in our url
+                        if (url.indexOf(path + name) !== -1) isChaise = true;
+                    }
+
+                    return isChaise;
                 }
 
                 // only append pcid/ppid if link is to a chaise url
-                // same origin urls may be relative
-                if (isChaiseUrl(obj.url)) {
-                    var paramChar = "";
-                    if (obj.url.lastIndexOf("?") !== -1) {
-                        // already a `?` in the url
-                        paramChar += '&';
-                    } else {
-                        paramChar += '?';
-                    }
-                    // pcid should always be navbar
-                    // ppid should be the pid for the current page
-                    obj.url += paramChar + "pcid=navbar&ppid=" + ConfigUtils.getContextJSON().pid;
+                if (isChaiseApp(obj.url)) {
+                    var dcctx = ConfigUtils.getContextJSON();
+                    obj.url = addLogParams(obj.url, dcctx);
                 }
             }
             // If current node has children, set each child's newTab to its own existing newTab or parent's newTab
@@ -117,7 +132,7 @@
                     }
 
                     scope.toLive = function () {
-                        $window.location = $window.location.href.replace(catalogId, catalogId.split("@")[0])
+                        $window.location = addLogParams($window.location.href.replace(catalogId, catalogId.split("@")[0]), dcctx);
                     }
                 }
             }

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -61,10 +61,19 @@
             // TODO: This is done here to prevent writing a recursive function (again) in `setConfigJSON()`
             if (obj.url && isCatalogDefined(catalogId)) {
                 obj.url = ERMrest.renderHandlebarsTemplate(obj.url, null, {id: catalogId});
-                // only append pcid/ppid if link is to the same origin
-                // same origin urls will be relative, check for http instead(?)
-                // if http, make sure not same origin
-                if (obj.url.indexOf("http") == -1 || obj.url.indexOf($window.location.origin) != -1) {
+
+                function isChaiseUrl (url) {
+                    function isChaiseApp (url) {
+                        return (url.indexOf("record") != -1 || url.indexOf("recordset") != -1 || url.indexOf("recordedit") != -1);
+                    }
+                    // first check for same origin (easiest to know if a chaise url)
+                    // check for chaise app if not
+                    return (url.indexOf($window.location.origin) != -1 || isChaiseApp(url));
+                }
+
+                // only append pcid/ppid if link is to a chaise url
+                // same origin urls may be relative
+                if (isChaiseUrl(obj.url)) {
                     var paramChar = "";
                     if (obj.url.lastIndexOf("?") !== -1) {
                         // already a `?` in the url
@@ -74,7 +83,7 @@
                     }
                     // pcid should always be navbar
                     // ppid should be the pid for the current page
-                    obj.url += paramChar + "pcid=navbar&ppid=" + $window.dcctx.pid;
+                    obj.url += paramChar + "pcid=navbar&ppid=" + ConfigUtils.getContextJSON().pid;
                 }
             }
             // If current node has children, set each child's newTab to its own existing newTab or parent's newTab

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -75,33 +75,28 @@
             if (obj.url && isCatalogDefined(catalogId)) {
                 obj.url = ERMrest.renderHandlebarsTemplate(obj.url, null, {id: catalogId});
 
-                // same origin urls may be relative
-                function isChaiseApp (url) {
-                    var appNames = ["record", "recordset", "recordedit", "search", "login"];
-                    var path = "chaise/";
-                    if (chaiseConfig && typeof chaiseConfig.chaiseBasePath === "string") {
-                        var path = chaiseConfig.chaiseBasePath;
-                        // append "/" if not present
-                        if (path[path.length-1] !== "/") path += "/";
-                    }
-                    path = $window.location.host + path;
+                var appNames = ["record", "recordset", "recordedit", "search", "login"];
+                var path = "/chaise/";
+                if (chaiseConfig && typeof chaiseConfig.chaiseBasePath === "string") {
+                    var path = chaiseConfig.chaiseBasePath;
+                    // append "/" if not present
+                    if (path[path.length-1] !== "/") path += "/";
+                }
+                path = $window.location.host + path;
 
-                    // parses the url into a location object
-                    var eleUrl = document.createElement('a');
-                    eleUrl.href = url;
+                // parses the url into a location object
+                var eleUrl = document.createElement('a');
+                eleUrl.href = obj.url;
 
-                    var isChaise = false;
-                    for (var i=0; i<appNames.length; i++) {
-                        var name = appNames[i];
-                        // path/appName exists in our url
-                        if (eleUrl.href.indexOf(path + name) !== -1) isChaise = true;
-                    }
-
-                    return isChaise;
+                var isChaise = false;
+                for (var i=0; i<appNames.length; i++) {
+                    var name = appNames[i];
+                    // path/appName exists in our url
+                    if (eleUrl.href.indexOf(path + name) !== -1) isChaise = true;
                 }
 
                 // only append pcid/ppid if link is to a chaise url
-                if (isChaiseApp(obj.url)) {
+                if (isChaise) {
                     var dcctx = ConfigUtils.getContextJSON();
                     obj.url = addLogParams(obj.url, dcctx);
                 }


### PR DESCRIPTION
The navbar links will include the `pcid` and `ppid` if the link is to the same origin. The `ppid` will be set as `navbar` and the `ppid` will be the same as the one generated for the current page.

@RFSH  this can be reviewed, I'm not sure if I should add log info to the other navbar links/buttons (clicking the logo, clicking on the profile dropdown menu and it's subsequent options, or clicking the "return to live" button if looking at versioned data).