### PR TITLE
set up head in config.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -750,6 +750,10 @@ $(JS_CONFIG): chaise-config-sample.js
 install: $(HTML) dont_install_in_root gitversion
 	rsync -avz --exclude='.*' --exclude='$(MODULES)' --exclude='wiki-images' --exclude=/chaise-config.js . $(CHAISEDIR)
 
+.PHONY: install-w-config dont_install_in_root
+install-w-config: $(HTML) dont_install_in_root gitversion
+	rsync -avz --exclude='.*' --exclude='$(MODULES)' --exclude='wiki-images' . $(CHAISEDIR)
+
 .PHONY: gitversion
 gitversion:
 	sh ./git_version_info.sh

--- a/common/config.js
+++ b/common/config.js
@@ -54,12 +54,14 @@
                     if (response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
 
                     headInjector.addCanonicalTag();
+                    headInjector.setupHead();
                     $rootScope.$emit("configuration-done");
                 });
                 // no need to add a catch block here, errors has been includedso handleException has been configured to be the default handler
             } else {
                 // there's no catalog to fetch (may be an index page)
                 headInjector.addCanonicalTag();
+                headInjector.setupHead();
                 $rootScope.$emit("configuration-done");
             }
         });

--- a/common/config.js
+++ b/common/config.js
@@ -53,14 +53,12 @@
                     // we already setup the defaults and the configuration based on chaise-config.js
                     if (response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
 
-                    headInjector.addCanonicalTag();
                     headInjector.setupHead();
                     $rootScope.$emit("configuration-done");
                 });
                 // no need to add a catch block here, errors has been includedso handleException has been configured to be the default handler
             } else {
                 // there's no catalog to fetch (may be an index page)
-                headInjector.addCanonicalTag();
                 headInjector.setupHead();
                 $rootScope.$emit("configuration-done");
             }

--- a/common/utils.js
+++ b/common/utils.js
@@ -1845,6 +1845,7 @@
         }
 
         function setupHead() {
+            addCanonicalTag();
             addCustomCSS();
             addTitle();
             setWindowName();

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -70,7 +70,6 @@
         $rootScope.showSpinner = false; // this property is set from common modules for controlling the spinner at a global level that is out of the scope of the app
 
         UriUtils.setOrigin();
-        headInjector.setupHead();
 
         $rootScope.showEmptyRelatedTables = false;
         $rootScope.modifyRecord = chaiseConfig.editRecord === false ? false : true;

--- a/recordedit/mdHelp.app.js
+++ b/recordedit/mdHelp.app.js
@@ -34,7 +34,6 @@
 
     .run(['headInjector', 'UiUtils', 'UriUtils', function (headInjector, UiUtils, UriUtils) {
         UriUtils.setOrigin();
-        headInjector.setupHead();
         // This is to allow the dropdown button to open at the top/bottom depending on the space available
         UiUtils.setBootstrapDropdownButtonBehavior();
 

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -102,7 +102,6 @@
         $rootScope.showSpinner = false;
 
         UriUtils.setOrigin();
-        headInjector.setupHead();
 
         // This is to allow the dropdown button to open at the top/bottom depending on the space available
         UiUtils.setBootstrapDropdownButtonBehavior();

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -76,8 +76,6 @@
         try {
             var session;
 
-            headInjector.setupHead();
-
             UriUtils.setOrigin();
 
             var context = ConfigUtils.getContextJSON(),


### PR DESCRIPTION
Moved the code to run in the config block so all chaise apps will set these properties. This came up because the deriva webapps don't honor the `customCss` property in chaise config.

@RFSH  I made this change really quick, but didn't spend much time thinking about how this would affect the functions called inside of `setupHead`. Everything should be fine (they all modify the document object) except the download click behavior function. 

I'm not sure if that function needs to be called after the angular app starts, or if that registers the on click behavior for any existing and newly created anchor tags with that class.