### PR TITLE
fix aggregate column spinners

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -424,7 +424,18 @@
                     vm.aggregatesToInitialize = [];
                     if (vm.reference.activeList) {
                         vm.reference.activeList.aggregates.forEach(function (c, i) {
-                            vm.aggregatesToInitialize.push(i);
+                            if (vm.page.tuples.length > 0) {
+                                vm.aggregatesToInitialize.push(i);
+                            } else {
+                                // there are not matching rows, so there's no point in creating
+                                // aggregate requests.
+                                // make sure the spinner is hidden for the pending columns.
+                                c.objects.forEach(function (obj) {
+                                    if (obj.column) {
+                                        vm.columnModels[obj.index].isLoading = false;
+                                    }
+                                })
+                            }
                         });
                     }
 

--- a/common/table.js
+++ b/common/table.js
@@ -726,8 +726,8 @@
             vm.reference.columns.forEach(function (col) {
                 vm.columnModels.push({
                     column: col,
-                    isLoading: col.hasWaitFor || !col.isUnique,
-                    hasWaitFor: col.hasWaitFor || !col.isUnique
+                    isLoading: col.hasWaitFor === true || col.isUnique === false,
+                    hasWaitFor: col.hasWaitFor === true || col.isUnique === false
                 });
             });
 

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -281,6 +281,15 @@ describe('View recordset,', function() {
                     });
                 }).catch(chaisePage.catchTestError(done));
             });
+
+            it ("going to a page with no results, the loader for columns should hide.", function (done) {
+                browser.ignoreSynchronization=true;
+                browser.get(browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + activeListParams.schemaName + ":" + activeListParams.table_name + "/main_id=03");
+
+                chaisePage.waitForElement(element(by.id("divRecordSet")));
+                chaisePage.recordsetPage.waitForAggregates();
+                done();
+            })
         });
     }
 

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1341,8 +1341,12 @@ var recordsetPage = function() {
     };
 
     this.waitForAggregates = function (timeout) {
-        var locator = element.all(by.css('aggregate-col-loader'));
-        return browser.wait(protractor.ExpectedConditions.invisibilityOf(locator), timeout || browser.params.defaultTimeout);
+        var locator = element.all(by.css('.aggregate-col-loader'));
+        return browser.wait(function () {
+            return locator.isDisplayed().then(function (arr) {
+                return arr.includes(true) === false;
+            })
+        }, timeout || browser.params.defaultTimeout);
     };
 
     this.getWarningAlert = function () {


### PR DESCRIPTION
In this PR I made sure we're hiding aggregate column spinners when the data is null. 

Why this was happening:
In the current code, we are always sending requests for aggregate columns to ermrestjs, regardless of the returned value for main entity. The function to handle the value in chaise was assuming that the value will be an array, and would go over all the values and then would hide the spinner. But in case of null value for the main entity, the value is always an empty array and therefore the spinners would still keep spinning.

How I fixed it:
If the returned data for the main entity is null, we're not going to send extra requests for aggregate columns and we're hiding the spinner right away.

The change is very simple, but since the test is done locally, I wanted to announce the change so @jrchudy can confirm that the test case is passing for him too.