### PR TITLE
Error dialog on pure and binary add error

### DIFF
--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -2,8 +2,8 @@
     'use strict';
     angular.module('chaise.recordcreate', ['chaise.errors','chaise.utils'])
 
-    .factory("recordCreate", ['$cookies', '$log', '$q', '$rootScope', '$window', 'AlertsService', 'DataUtils', 'logActions', 'messageMap', 'modalBox', 'modalUtils', 'Session', 'UriUtils',
-        function($cookies, $log, $q, $rootScope, $window, AlertsService, DataUtils, logActions, messageMap, modalBox, modalUtils, Session, UriUtils) {
+    .factory("recordCreate", ['$cookies', '$log', '$q', '$rootScope', '$window', 'AlertsService', 'DataUtils', 'ErrorService', 'logActions', 'messageMap', 'modalBox', 'modalUtils', 'Session', 'UriUtils',
+        function($cookies, $log, $q, $rootScope, $window, AlertsService, DataUtils, ErrorService, logActions, messageMap, modalBox, modalUtils, Session, UriUtils) {
 
         var viewModel = {};
         var GV_recordEditModel = {},
@@ -245,7 +245,12 @@
                         // append link to end of alert.
                         if (exception instanceof ERMrest.DuplicateConflictError) {
                             exception.message += ' Click <a href="' + exception.duplicateReference.contextualize.detailed.appLink + '" target="_blank">here</a> to see the conflicting record that already exists.';
-                            AlertsService.addAlert(exception.message, 'error');
+                            if (isModalUpdate) {
+                                // pure and binary add on record page, we want a popup error
+                                ErrorService.handleException(exception, true);
+                            } else {
+                                AlertsService.addAlert(exception.message, 'error');
+                            }
                         } else {
                             AlertsService.addAlert(exception.message, (exception instanceof ERMrest.NoDataChangedError ? 'warning' : 'error') );
                         }

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -245,12 +245,11 @@
                         // append link to end of alert.
                         if (exception instanceof ERMrest.DuplicateConflictError) {
                             exception.message += ' Click <a href="' + exception.duplicateReference.contextualize.detailed.appLink + '" target="_blank">here</a> to see the conflicting record that already exists.';
-                            if (isModalUpdate) {
-                                // pure and binary add on record page, we want a popup error
-                                ErrorService.handleException(exception, true);
-                            } else {
-                                AlertsService.addAlert(exception.message, 'error');
-                            }
+                        }
+
+                        if (isModalUpdate) {
+                            // pure and binary add on record page, we want a popup error
+                            ErrorService.handleException(exception, true);
                         } else {
                             AlertsService.addAlert(exception.message, (exception instanceof ERMrest.NoDataChangedError ? 'warning' : 'error') );
                         }


### PR DESCRIPTION
The change for this was simple. If the `isModalUpdate` flag is true, we know we are in `record` app. This might not be the best way to test for this if `isModalUpdate` gets used in other app contexts later. I was thinking I could check the log action but don't want to tie log actions together with other functionality of our app.

I'm not sure if it's possible to test this error because of our disabled rows function.