### PR TITLE
fix submit button in modal pickers

### DIFF
--- a/common/inputs.js
+++ b/common/inputs.js
@@ -400,6 +400,7 @@
                     modalUtils.showModal({
                         animation: false,
                         controller: "SearchPopupController",
+                        windowClass: "search-popup",
                         controllerAs: "ctrl",
                         resolve: {
                             params: params

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -357,6 +357,7 @@
             modalUtils.showModal({
                 animation: false,
                 controller: "SearchPopupController",
+                windowClass: "search-popup",
                 controllerAs: "ctrl",
                 resolve: {
                     params: params

--- a/common/styles/app.css
+++ b/common/styles/app.css
@@ -964,36 +964,6 @@ ul.show-list-style li {
   min-height: 40vh;
 }
 
-/* Sets the table's maximum height to 70% of the screen height and adds a border at the bottom */
-.modal-body .outer-table {
-    max-height: 70vh;
-    border: 1px solid lightgrey;
-}
-
-/* Sets the margin-bottom for the table inside modal to 0px*/
-.modal-body .outer-table .table {
-    margin-bottom: 0px;
-    overflow: scroll;
-}
-
-@media (max-width: 800px) {
-    .modal-body .outer-table {
-        max-height: 67vh;
-    }
-}
-
-@media (max-width: 600px) {
-    .modal-body .outer-table {
-        max-height: 60vh;
-    }
-}
-
-@media (max-width: 500px) {
-    .modal-body .outer-table {
-        max-height: 55vh;
-    }
-}
-
 .modal-body #spinner {
   width: 100%;
   text-align: center;
@@ -1212,7 +1182,13 @@ footer .container1 {
 .modal-dialog .profileValue{
     padding-left: 32px;
 }
- /********** faceting ************/
+
+ /********** selected rows chiclets ***********/
+ .selected-rows-filters > div {
+     padding: 0;
+ }
+
+ /********** filter and selected rows chiclets ************/
  .total-filters {
     margin-bottom: 10px;
     margin-left: 0px;
@@ -1650,6 +1626,11 @@ footer .container1 {
      border-color: #337ab7;
  }
 
+ .filter-label.label-default.label-inverted {
+     color: #333;
+     background-color: #f1f1f1;
+ }
+
  .filter-label {
      background-color: white;
      color: #333;
@@ -1818,9 +1799,14 @@ input[type=number]::-moz-placeholder {
 /************** search popup **************/
 #multi-select-submit-btn {
     position: absolute;
-    right: 10px;
-    top: 10px;
+    right: 50px;
+    top: 15px;
     z-index: 2;
+    padding: 3px 12px;
+}
+
+.search-popup .modal-header {
+  background-color: #f1f1f1;
 }
 
 .selected-rows {

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -14,7 +14,7 @@
                     <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                         <a class="remove-link" ng-click="removeAllPills($event)">
                             <span class="filter-label label label-primary">
-                                clear all
+                                Clear all selections
                             </span>
                         </a>
                         <div class="filter-label label label-default" ng-repeat="row in vm.selectedRows track by $index">

--- a/common/templates/recordsetSelectFaceting.html
+++ b/common/templates/recordsetSelectFaceting.html
@@ -6,11 +6,11 @@
             <div ng-if="vm.config.selectMode == 'multi-select' && !vm.config.hideSelectedRows" class="row total-filters selected-rows">
                 <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                     <a class="remove-link" ng-click="removeAllPills($event)" ng-disabled="vm.selectedRows.length < 1">
-                        <span class="filter-label label label-primary label-inverted" ng-if="vm.selectedRows.length < 1">
-                            No Item Selected
+                        <span class="filter-label label label-default label-inverted no-item-label" ng-if="vm.selectedRows.length < 1" style="cursor: default;">
+                            No item selected
                         </span>
-                        <span class="filter-label label label-primary label-inverted" ng-if="vm.selectedRows.length > 0">
-                            Clear All
+                        <span class="filter-label label label-primary" ng-if="vm.selectedRows.length > 0">
+                            Clear all selections
                         </span>
                     </a>
                     <div ng-if="vm.selectedRows.length > 0" class="filter-label label label-default" ng-repeat="row in vm.selectedRows track by $index" tooltip-enable="tooltipEnabled" uib-tooltip="{{row.displayname.value}}" tooltip-placement="bottom" chaise-enable-tooltip-width>

--- a/common/templates/searchPopup.modal.html
+++ b/common/templates/searchPopup.modal.html
@@ -4,12 +4,16 @@
         <span ng-if="::ctrl.tableModel.tableDisplayName.isHTML" ng-bind-html="::ctrl.tableModel.tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::ctrl.tableModel.tableComment ? ctrl.tableModel.tableComment : undefined}}"></span>
         <span ng-if="::!ctrl.tableModel.tableDisplayName.isHTML" ng-bind="::ctrl.tableModel.tableDisplayName.value" ng-attr-tooltip-placement="bottom" ng-attr-uib-tooltip="{{::ctrl.tableModel.tableComment ? ctrl.tableModel.tableComment : undefined}}"></span>
     </h2>
+    <span ng-if="ctrl.tableModel.config.selectMode=='multi-select'">
+        <button id="multi-select-submit-btn" ng-disabled="ctrl.tableModel.selectedRows.length < 1"
+                class="btn btn-primary btn-inverted pull-right" type="button" ng-click="ctrl.submit()"
+                tooltip-placement="bottom" uib-tooltip="{{ctrl.tableModel.selectedRows.length < 1 ? '' : 'submit selected items'}}" ng-disabled="ctrl.disableSubmit">
+            Submit
+        </button>
+    </span>
 </div>
 <div class="modal-body" style="overflow: auto;">
     <loading-spinner ng-show="!ctrl.tableModel.hasLoaded && !ctrl.tableModel.backgroundSearch"></loading-spinner>
-    <span ng-if="ctrl.tableModel.config.selectMode=='multi-select'" ng-hide="ctrl.tableModel.selectedRows.length < 1">
-        <button id="multi-select-submit-btn" class="btn btn-primary btn-inverted pull-right" type="button" ng-click="ctrl.submit()" ng-disabled="ctrl.disableSubmit">Submit</button>
-    </span>
     <div ng-switch="ctrl.mode">
         <!-- switch when 'selectFaceting' -->
         <recordset-select-faceting ng-switch-when="selectFaceting" vm="ctrl.tableModel" on-selected-rows-changed="ctrl.onSelectedRowsChanged" allow-create="false"></recordset-select-faceting>

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -304,6 +304,7 @@
             modalUtils.showModal({
                 animation: false,
                 controller: "SearchPopupController",
+                windowClass: "search-popup",
                 controllerAs: "ctrl",
                 resolve: {
                     params: params


### PR DESCRIPTION
This PR,

- Adds `search-popup` class to all the modal pickers that we have. This was causing inconsistency in UI of the different modal pickers that we have.
- Moves the "submit" button to be beside the "x" button in the header.
- Changes the background color of the modal pickers to be consistent with page headers.
- Removes the secondary scrollbar that we had for the recordset table in modal pickers, to make it consistent with the recordset page.
- Changes the button labels.

What should be done after this: Make sure the scrolling on modals works the same as recordset app (two scrollbars, one for main content and the other for facets).