### PR TITLE
fix race condition in afterReadAggregate

### DIFF
--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -57,7 +57,7 @@
         </tbody>
     </table>
 </div>
-<span id="push-rows-loading" ng-show="vm.pushRowsSpinner">Loading...</span>
+<span id="push-rows-loading" ng-show="vm.pushMoreRowsPending">Loading...</span>
 
 
 <div class="chaise-table-pagination" ng-if="vm.initialized">

--- a/common/templates/tableHeader.html
+++ b/common/templates/tableHeader.html
@@ -5,7 +5,7 @@
         <span ng-if="vm.page.tuples.length > 0 && !vm.page.hasNext && vm.page.hasPrevious">last</span>
         <span ng-if="vm.page.tuples.length > 0 && !vm.page.hasNext && !vm.page.hasPrevious">all</span>
         <span ng-if="vm.rowValues.length > 0" uib-dropdown>
-            <button class="page-size-dropdown chaise-btn chaise-btn-secondary dropdown-toggle" type="button" uib-dropdown-toggle ng-click="::logPageSizeEvent()" ng-disabled="!vm.hasLoaded || !vm.initialized">
+            <button class="page-size-dropdown chaise-btn chaise-btn-secondary dropdown-toggle" type="button" uib-dropdown-toggle ng-click="::logPageSizeEvent()" ng-disabled="!vm.hasLoaded || !vm.initialized || vm.pushMoreRowsPending">
                 <span>{{vm.page ? vm.rowValues.length : vm.pageLimit}}</span>
                 <span class="caret"></span>
             </button>
@@ -22,7 +22,7 @@
         <span>{{(vm.totalRowsCnt && !vm.tableError) ? "of " + (vm.totalRowsCnt > vm.rowValues.length ? vm.totalRowsCnt.toLocaleString() : vm.rowValues.length) : ''}}</span>
         <span>{{vm.reference.location.isConstrained && vm.config.displayMode !== recordsetDisplayModes.related ? "matching results" : "records" }}</span>
         <span ng-if="vm.countError" class="glyphicon glyphicon-alert" uib-tooltip="Request timeout: total count cannot be retrieved. Refresh the page later to try again." tooltip-placement="bottom"></span>
-        <span ng-show="vm.pushRowsSpinner || (vm.config.displayMode === recordsetDisplayModes.related && !vm.hasLoaded)" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
+        <span ng-show="vm.pushMoreRowsPending || (vm.config.displayMode === recordsetDisplayModes.related && !vm.hasLoaded)" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
     </div>
     <div class="col-xs-12 col-sm-6">
         <div class="pull-right">


### PR DESCRIPTION
After the main read in recordset table is done, we're generating requests for aggregate columns based on the active list. Also if we have to show more than 500 cells, we're going to gradually populate `rowValues` object. Now if we receive the response for aggregate columns before populating the object, it will result in a terminal error.

To fix this, I introduced a new object called `pendingRowValues`. The purpose of this object is hold onto the row values while we're waiting for the `rowValues` to be completely populated. I also added a new function that the "push more rows" will call to merge the two objects.