### PR TITLE
Boolean dropdowns can flow outside of container

### DIFF
--- a/common/inputs.js
+++ b/common/inputs.js
@@ -488,7 +488,7 @@
                     scope.model.value.time = null;
                 }
 
-                scope.inputContainer = document.querySelector('.input-container');
+                scope.inputContainerForDropdowns = document.querySelector('.input-container');
 
                 // used to increase the width of boolean dropdowns to the size of the input
                 scope.setDropdownWidth = function () {

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -492,10 +492,7 @@
 
                 scope.setDropdownWidth = function () {
                     var inputSelector = scope.columnIndex + '-boolean-input',
-                        dropdownSelector = scope.columnIndex + '-dropdown';
-
-                    var input = document.getElementById(inputSelector),
-                        dropdown = document.getElementById(dropdownSelector);
+                        input = document.getElementById(inputSelector);
 
                     scope.inputWidth = {
                         width: input.offsetWidth + 'px',

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -490,10 +490,12 @@
 
                 scope.inputContainer = document.querySelector('.input-container');
 
+                // used to increase the width of boolean dropdowns to the size of the input
                 scope.setDropdownWidth = function () {
                     var inputSelector = scope.columnIndex + '-boolean-input',
                         input = document.getElementById(inputSelector);
 
+                    // ng-style attached to dropdown for better repositioning
                     scope.inputWidth = {
                         width: input.offsetWidth + 'px',
                         "margin-top": '14px'

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -348,6 +348,7 @@
             templateUrl:  UriUtils.chaiseDeploymentPath() + 'common/templates/inputs/inputSwitch.html',
             scope: {
                 column: '=',
+                columnIndex: '=', // index in column models list
                 columnModel: '=',
                 model: '=?'
             },
@@ -485,6 +486,21 @@
                 // used for timestamp[tz] inputs only
                 scope.clearTime = function () {
                     scope.model.value.time = null;
+                }
+
+                scope.inputContainer = document.querySelector('.input-container');
+
+                scope.setDropdownWidth = function () {
+                    var inputSelector = scope.columnIndex + '-boolean-input',
+                        dropdownSelector = scope.columnIndex + '-dropdown';
+
+                    var input = document.getElementById(inputSelector),
+                        dropdown = document.getElementById(dropdownSelector);
+
+                    scope.inputWidth = {
+                        width: input.offsetWidth + 'px',
+                        "margin-top": '14px'
+                    };
                 }
             }
         }

--- a/common/styles/scss/_recordedit-app.scss
+++ b/common/styles/scss/_recordedit-app.scss
@@ -198,9 +198,7 @@
     }
 
     .adjust-boolean-dropdown {
-        margin-top: 0;
         border-top: 0;
-        width: 100%;
     }
 
     .select-all-text {

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -114,7 +114,7 @@
         </div>
         <!-- So that the boolean input can be validated -->
         <input type="hidden" ng-model="model.value" />
-        <ul id="{{columnIndex}}-dropdown" class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="inputWidth">
+        <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="inputWidth">
             <li ng-repeat="option in ::booleanValues" ng-click="model.value = option">
                 <a ng-bind-html="option" style="min-height: 20px;"></a>
             </li>

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -104,8 +104,8 @@
 
 
     <!-- boolean input -->
-    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="inputContainerForDropdowns">
-        <div id="{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle ng-click="setDropdownWidth()">
+    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="inputContainerForDropdowns" on-toggle="setDropdownWidth()">
+        <div id="{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle>
             <div contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="model.value"></div>
             <chaise-clear-input btn-class="boolean-remove" click-callback="::clearInput()" show="showBooleanRemove()"></chaise-clear-input>
             <button class="chaise-btn chaise-btn-primary" type="button">

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -104,7 +104,7 @@
 
 
     <!-- boolean input -->
-    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="inputContainer">
+    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="inputContainerForDropdowns">
         <div id="{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle ng-click="setDropdownWidth()">
             <div contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="model.value"></div>
             <chaise-clear-input btn-class="boolean-remove" click-callback="::clearInput()" show="showBooleanRemove()"></chaise-clear-input>

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -104,8 +104,8 @@
 
 
     <!-- boolean input -->
-    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown>
-        <div class="chaise-input-control has-feedback" uib-dropdown-toggle>
+    <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="inputContainer">
+        <div id="{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle ng-click="setDropdownWidth()">
             <div contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="model.value"></div>
             <chaise-clear-input btn-class="boolean-remove" click-callback="::clearInput()" show="showBooleanRemove()"></chaise-clear-input>
             <button class="chaise-btn chaise-btn-primary" type="button">
@@ -114,7 +114,7 @@
         </div>
         <!-- So that the boolean input can be validated -->
         <input type="hidden" ng-model="model.value" />
-        <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu">
+        <ul id="{{columnIndex}}-dropdown" class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="inputWidth">
             <li ng-repeat="option in ::booleanValues" ng-click="model.value = option">
                 <a ng-bind-html="option" style="min-height: 20px;"></a>
             </li>

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -581,12 +581,8 @@
             selectAllOpen = false;
         }
 
-        vm.setDropdownWidth = function (rowIndex, columnIndex) {
-            var inputSelector = rowIndex + '-' + columnIndex + '-boolean-input',
-                dropdownSelector = rowIndex + '-' + columnIndex + '-dropdown';
-
-            var input = document.getElementById(inputSelector),
-                dropdown = document.getElementById(dropdownSelector);
+        vm.setDropdownWidth = function () {
+            var input = document.querySelector('.re-boolean-input');
 
             vm.inputWidth = {
                 width: input.offsetWidth + 'px',
@@ -994,7 +990,10 @@
 
         // Listen to window resize event to change the width of div form-edit
         angular.element($window).bind('resize', function() {
-            onResize();
+            $timeout(function () {
+                onResize();
+                vm.setDropdownWidth();
+            }, 0)
         });
 
         var editMode = vm.editMode;

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -581,6 +581,19 @@
             selectAllOpen = false;
         }
 
+        vm.setDropdownWidth = function (rowIndex, columnIndex) {
+            var inputSelector = rowIndex + '-' + columnIndex + '-boolean-input',
+                dropdownSelector = rowIndex + '-' + columnIndex + '-dropdown';
+
+            var input = document.getElementById(inputSelector),
+                dropdown = document.getElementById(dropdownSelector);
+
+            vm.inputWidth = {
+                width: input.offsetWidth + 'px',
+                "margin-top": '14px'
+            };
+        }
+
         // toggles the state of the select all dialog
         vm.toggleSelectAll = function toggleSelectAll(index) {
             var model = vm.recordEditModel.columnModels[index];
@@ -915,7 +928,7 @@
         var $rootElement = angular.element(element).injector().get('$rootElement');
 
         // used for setting the width of table and
-        var inputContainerEl = document.querySelector('.input-container');
+        var inputContainerEl = vm.inputContainer = document.querySelector('.input-container');
         var tableEl = document.querySelector('#form-edit table');
 
         // used for adjusting the padding of main-container (because of scrollbar)

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -571,6 +571,18 @@
             return cm && cm.column && !cm.column.nullok && !cm.isDisabled;
         }
 
+        // when a boolean dropdown is opened, resize the dropdown menu to match the width of the input
+        vm.setDropdownWidth = function () {
+            // All boolean are visible and same size so it doesn't matter which is selected
+            var input = document.querySelector('.re-boolean-input');
+
+            // ng-style attached for better repositioning
+            vm.inputWidth = {
+                width: input.offsetWidth + 'px',
+                "margin-top": '14px'
+            };
+        }
+
 // **** Functions for set all input
         var selectAllOpen = false;
 
@@ -579,15 +591,6 @@
             model.showSelectAll = false;
             model.highlightRow = false;
             selectAllOpen = false;
-        }
-
-        vm.setDropdownWidth = function () {
-            var input = document.querySelector('.re-boolean-input');
-
-            vm.inputWidth = {
-                width: input.offsetWidth + 'px',
-                "margin-top": '14px'
-            };
         }
 
         // toggles the state of the select all dialog
@@ -992,6 +995,7 @@
         angular.element($window).bind('resize', function() {
             $timeout(function () {
                 onResize();
+                // resize dropdown menu if open while resizing
                 vm.setDropdownWidth();
             }, 0)
         });

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -200,8 +200,8 @@
                                                             </div>
 
                                                             <!-- boolean input -->
-                                                            <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="form.inputContainer">
-                                                                <div class="chaise-input-control re-boolean-input has-feedback" uib-dropdown-toggle ng-click="form.setDropdownWidth()">
+                                                            <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="form.inputContainer" on-toggle="form.setDropdownWidth()">
+                                                                <div class="chaise-input-control re-boolean-input has-feedback" uib-dropdown-toggle>
                                                                     <div id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-display" contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="form.recordEditModel.rows[rowIndex][column.name]"></div>
                                                                     <chaise-clear-input btn-class="boolean-remove" click-callback="form.clearInput(rowIndex, column.name)" show="form.showRemove(rowIndex, column.name, 'boolean')"></chaise-clear-input>
                                                                     <button ng-focus="::form.blurElement($event);" class="chaise-btn chaise-btn-primary" type="button">

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -200,8 +200,8 @@
                                                             </div>
 
                                                             <!-- boolean input -->
-                                                            <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown>
-                                                                <div class="chaise-input-control has-feedback" uib-dropdown-toggle>
+                                                            <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="form.inputContainer">
+                                                                <div id="{{rowIndex}}-{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle ng-click="form.setDropdownWidth(rowIndex, columnIndex)">
                                                                     <div id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-display" contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="form.recordEditModel.rows[rowIndex][column.name]"></div>
                                                                     <chaise-clear-input btn-class="boolean-remove" click-callback="form.clearInput(rowIndex, column.name)" show="form.showRemove(rowIndex, column.name, 'boolean')"></chaise-clear-input>
                                                                     <button ng-focus="::form.blurElement($event);" class="chaise-btn chaise-btn-primary" type="button">
@@ -210,7 +210,7 @@
                                                                 </div>
                                                                 <!-- So that the boolean input can be validated -->
                                                                 <input type="hidden" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" ng-required="::form.isRequired(columnIndex);" />
-                                                                <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu">
+                                                                <ul id="{{rowIndex}}-{{columnIndex}}-dropdown" class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="form.inputWidth">
                                                                     <li ng-repeat="option in ::form.booleanValues" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
                                                                         <a ng-bind-html="option" style="min-height: 20px;"></a>
                                                                     </li>
@@ -272,7 +272,7 @@
                                                         <td class="match-entity-value" colspan="{{form.recordEditModel.rows.length}}">
                                                             <!-- "The is a row of text" -->
                                                             <span class="select-all-text pull-left">Set value for all records: </span>
-                                                            <input-switch id="select-all-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" class="pull-left" column="column" column-model="form.recordEditModel.columnModels[columnIndex]" model="form.recordEditModel.columnModels[columnIndex].allInput" style="width: 250px; margin: 0px 5px;"></input-switch>
+                                                            <input-switch id="select-all-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" class="pull-left" column="column" column-model="form.recordEditModel.columnModels[columnIndex]" model="form.recordEditModel.columnModels[columnIndex].allInput" column-index="columnIndex" style="width: 250px; margin: 0px 5px;"></input-switch>
                                                             <span class="chaise-btn-group">
                                                                 <button id="select-all-apply-{{::form.makeSafeIdAttr(column.displayname.value)}}" class="chaise-btn chaise-btn-secondary pull-left" type="button" ng-disabled="form.disableApply(columnIndex)" ng-click="form.applySelectAll(columnIndex)" tooltip-placement="bottom" uib-tooltip="Click to apply the value to all records.">Apply All</button>
                                                                 <button id="select-all-clear-{{::form.makeSafeIdAttr(column.displayname.value)}}" class="chaise-btn chaise-btn-secondary pull-left" type="button" ng-click="form.clearSelectAll(columnIndex)" tooltip-placement="bottom" uib-tooltip="Click to clear all values for all records.">Clear All</button>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -201,7 +201,7 @@
 
                                                             <!-- boolean input -->
                                                             <div ng-switch-when="boolean" class="chaise-boolean-dropdown" uib-dropdown dropdown-append-to="form.inputContainer">
-                                                                <div id="{{rowIndex}}-{{columnIndex}}-boolean-input" class="chaise-input-control has-feedback" uib-dropdown-toggle ng-click="form.setDropdownWidth(rowIndex, columnIndex)">
+                                                                <div class="chaise-input-control re-boolean-input has-feedback" uib-dropdown-toggle ng-click="form.setDropdownWidth()">
                                                                     <div id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-display" contenteditable="false" style="cursor: pointer" data-placeholder="Select a value" ng-bind-html="form.recordEditModel.rows[rowIndex][column.name]"></div>
                                                                     <chaise-clear-input btn-class="boolean-remove" click-callback="form.clearInput(rowIndex, column.name)" show="form.showRemove(rowIndex, column.name, 'boolean')"></chaise-clear-input>
                                                                     <button ng-focus="::form.blurElement($event);" class="chaise-btn chaise-btn-primary" type="button">
@@ -210,7 +210,7 @@
                                                                 </div>
                                                                 <!-- So that the boolean input can be validated -->
                                                                 <input type="hidden" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" ng-required="::form.isRequired(columnIndex);" />
-                                                                <ul id="{{rowIndex}}-{{columnIndex}}-dropdown" class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="form.inputWidth">
+                                                                <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="form.inputWidth">
                                                                     <li ng-repeat="option in ::form.booleanValues" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
                                                                         <a ng-bind-html="option" style="min-height: 20px;"></a>
                                                                     </li>


### PR DESCRIPTION
This PR fixed an issue that @ljpearlman found in `recordedit` with boolean dropdowns being clipped when they are the last input field.

I added `dropdown-append-to` for boolean inputs so they are attached to the input container outside of the table (which has `overlow: hidden;`). I added a click event to the dropdown toggle element to recalculate the width of the dropdown each time it's opened because the number of forms can change.

This can be tested here:
https://dev.rebuildingakidney.org/chaise/recordedit/#2/Common:Principal_Investigator