### PR TITLE
Revert "Truncation one more time"

### DIFF
--- a/common/styles/scss/_recordset.scss
+++ b/common/styles/scss/_recordset.scss
@@ -254,19 +254,19 @@
         background: $table-striped-background-color;
     }
 
+    >thead>tr>th {
+        border-bottom: 1px solid $table-border-color;
+    }
+
     >thead>tr>th,
     >tbody>tr>th,
     >tfoot>tr>th,
     >thead>tr>td,
     >tbody>tr>td,
     >tfoot>tr>td {
-        border: none;
+        border-top: none;
         border-right: 1px solid $table-border-color;
         word-wrap: break-word;
-    }
-
-    >thead>tr:first-child {
-        border-bottom: 1px solid $table-border-color;
     }
 
     >tbody>tr>td {

--- a/common/templates/ellipsis.html
+++ b/common/templates/ellipsis.html
@@ -33,7 +33,6 @@
                 <span ng-if="val.value == null" ng-bind-html="defaultDisplayname.null"></span>
             </span>
         </div>
-        <!-- index+1 because rowValues pertain to columns in table starting at index 1 (action column is index 0) -->
         <div ng-if="overflow[$index+1]" style="display:inline;">
             ...
             <span style="display:inline-block; text-decoration: underline;cursor: pointer;" class="text-primary readmore" ng-click="readmore($index+1)">{{linkText}}</span>


### PR DESCRIPTION
The changes in #1883 have broken the "view details" links in recordset (and potentially other row-level buttons). Even when chaise is updating the row values (whether because of page, filter, or any other change), the "view details" links remain the same.

We should investigate this and create another PR. For now, I'm just reverting the change. 