### PR TITLE
fix range picker bug related to clearing facets

### DIFF
--- a/common/faceting.js
+++ b/common/faceting.js
@@ -490,18 +490,28 @@
 
                     // some of the facets might have been cleared, this function will unselect those
                     scope.syncSelected = function () {
-                        if (scope.facetColumn.hasNotNullFilter) {
-                            scope.ranges[0].selected = scope.facetColumn.hasNotNullFilter;
-                        }
-
+                        var i;
                         var filterIndex = function (uniqueId) {
                             return scope.facetColumn.rangeFilters.findIndex(function (f) {
                                 return f.uniqueId == uniqueId;
                             });
                         }
 
-                        //scope.ranges[0] is the notnull filter
-                        for (var i = 1; i < scope.ranges.length; i++) {
+                        // see if there's a not-null choice
+                        if (!scope.facetColumn.hideNotNullChoice) {
+                            scope.ranges[0].selected = scope.facetColumn.hasNotNullFilter;
+
+                            // if not-null is unchecked, enable the other options
+                            if (!scope.facetColumn.hasNotNullFilter) {
+                                for (i = 1; i < scope.ranges.length; i++) {
+                                    scope.ranges[i].disabled = false;
+                                }
+                            }
+                        }
+
+
+                        //scope.ranges[0] could be the not-null filter.
+                        for (i = (scope.facetColumn.hideNotNullChoice ? 0 : 1); i < scope.ranges.length; i++) {
                             // if couldn't find the filter, then it should be unselected
                             if (filterIndex(scope.ranges[i].uniqueId) === -1) {
                                 scope.ranges[i].selected = false;

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -787,6 +787,13 @@ describe("Viewing Recordset with Faceting,", function() {
                                         return clearAll.click();
                                     }).then(function () {
                                         browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
+
+                                        // make sure all checkboxes are cleared
+                                        browser.wait(
+                                            EC.not(EC.visibilityOf(chaisePage.recordsetPage.getCheckedFacetOptions(idx))),
+                                            browser.params.defaultTimeout,
+                                            "clear-all didn't clear checkboxes"
+                                        );
                                         done();
                                     }).catch(chaisePage.catchTestError(done));
                                 });
@@ -989,6 +996,13 @@ describe("Viewing Recordset with Faceting,", function() {
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
 
+                                    // make sure all checkboxes are cleared
+                                    browser.wait(
+                                        EC.not(EC.visibilityOf(chaisePage.recordsetPage.getCheckedFacetOptions(idx))),
+                                        browser.params.defaultTimeout,
+                                        "clear-all didn't clear checkboxes"
+                                    );
+
                                     //clear the inputs
                                     return minDateClear.click();
                                 }).then(function () {
@@ -1059,6 +1073,13 @@ describe("Viewing Recordset with Faceting,", function() {
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
 
+                                    // make sure all checkboxes are cleared
+                                    browser.wait(
+                                        EC.not(EC.visibilityOf(chaisePage.recordsetPage.getCheckedFacetOptions(idx))),
+                                        browser.params.defaultTimeout,
+                                        "clear-all didn't clear checkboxes"
+                                    );
+
                                     //clear the min inputs
                                     return minDateClear.click();
                                 }).then(function () {
@@ -1100,6 +1121,13 @@ describe("Viewing Recordset with Faceting,", function() {
                                     return clearAll.click();
                                 }).then(function () {
                                     browser.wait(EC.not(EC.visibilityOf(clearAll)), browser.params.defaultTimeout);
+
+                                    // make sure all checkboxes are cleared
+                                    browser.wait(
+                                        EC.not(EC.visibilityOf(chaisePage.recordsetPage.getCheckedFacetOptions(idx))),
+                                        browser.params.defaultTimeout,
+                                        "clear-all didn't clear checkboxes"
+                                    );
 
                                     // close the facet
                                     return chaisePage.recordsetPage.getFacetById(idx).click();


### PR DESCRIPTION
The function that was responsible for syncing the checkboxes was not properly working. It had two flaws:

-  was assuming that the not-null choice is always available;
- and also wouldn't clear the not-null filter if it was selected. 

I modified the function to properly take care of the not-null and the rest of the options.