### PR TITLE
Remove custom page limit text

### DIFF
--- a/common/table.js
+++ b/common/table.js
@@ -1541,6 +1541,16 @@
                 scope.recordsetDisplayModes = recordsetDisplayModes;
 
                 scope.pageLimits = [10, 25, 50, 75, 100, 200];
+                var insertCustomPageLimit = scope.$watch('vm.readyToInitialize', function () {
+                    if (scope.vm.readyToInitialize == true && scope.pageLimits.indexOf(scope.vm.pageLimit) === -1) {
+                        scope.pageLimits.push(scope.vm.pageLimit);
+                        scope.pageLimits.sort(function(a, b) {
+                            return a - b;
+                        });
+                        insertCustomPageLimit();
+                    }
+                });
+
                 scope.setPageLimit = function(limit) {
                     scope.vm.pageLimit = limit;
 

--- a/common/templates/tableHeader.html
+++ b/common/templates/tableHeader.html
@@ -9,9 +9,6 @@
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-left">
-                    <li ng-if="pageLimits.indexOf(vm.pageLimit) === -1">
-                        <a class="page-size-limit-custom" href ng-click="setPageLimit(vm.pageLimit)">{{ vm.pageLimit }} (Custom)<span class="glyphicon glyphicon-ok pull-right"></span></a>
-                    </li>
                     <li ng-repeat="limit in pageLimits">
                         <a class="page-size-limit-{{limit}}" href ng-click="setPageLimit(limit)">{{ limit }}<span class="glyphicon pull-right" ng-class="vm.pageLimit === limit ? 'glyphicon-ok' : 'glyphicon-invisible'"></span></a>
                     </li>

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -345,9 +345,9 @@ describe('View recordset,', function() {
 
             it("should use annotated page size", function() {
                 var EC = protractor.ExpectedConditions;
-                var e = chaisePage.recordsetPage.getCustomPageSize();
+                var e = chaisePage.recordsetPage.getPageLimitSelector(15);
                 browser.wait(EC.presenceOf(e), browser.params.defaultTimeout);
-                expect(e.getAttribute("innerText")).toBe("15 (Custom)");
+                expect(e.getAttribute("innerText")).toBe("15");
             });
 
             it("should show correct table rows", function() {
@@ -488,7 +488,7 @@ describe('View recordset,', function() {
 
             it("apply different searches, ", function(done) {
                 var EC = protractor.ExpectedConditions;
-                var e = chaisePage.recordsetPage.getCustomPageSize();
+                var e = chaisePage.recordsetPage.getPageLimitSelector(15);
                 browser.wait(EC.presenceOf(e), browser.params.defaultTimeout);
 
                 var searchBox = chaisePage.recordsetPage.getMainSearchInput(),
@@ -875,7 +875,7 @@ describe('View recordset,', function() {
 
         it("should load the table with " + fileParams.custom_page_size + " rows of data based on the page size annotation.", function() {
             // Verify page count and on first page
-            var e = chaisePage.recordsetPage.getCustomPageSize();
+            var e = chaisePage.recordsetPage.getPageLimitSelector(fileParams.custom_page_size);
 
             browser.wait(EC.presenceOf(e), browser.params.defaultTimeout).then(function() {
                 browser.wait(function () {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -878,10 +878,6 @@ var recordsetPage = function() {
         return element(by.css(".page-size-dropdown"));
     };
 
-    this.getCustomPageSize = function() {
-        return element(by.css(".page-size-limit-custom"));
-    };
-
     this.getPageLimitSelector = function (limit) {
         return element(by.css(".page-size-limit-" + limit));
     };


### PR DESCRIPTION
Removed the text `(custom)` when a `?limit=X` query parameter is present in the url. The custom page size is now also sorted properly in the dropdown.