### PR TITLE
Refactor recordedit codes related to select all and uploader

### DIFF
--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -130,7 +130,7 @@
 
     <!-- File input -->
     <div ng-switch-when="file">
-        <upload reference="::$root.reference" column="::column" placeholder="getDisabledInputValue()" value="model.value" is-required="false"></upload>
+        <upload reference="::$root.reference" column="::column" placeholder="getDisabledInputValue()" value="model.value" is-required="false" is-disabled="columnModel.isDisabled"></upload>
     </div>
 
     <!--JSON input -->

--- a/common/upload.js
+++ b/common/upload.js
@@ -14,7 +14,7 @@
                     values: '=?',
                     value: '=',
                     reference: '=',
-                    isDisabled: "=?",
+                    isDisabled: "=",
                     placeholder: "=",
                     isRequired: "="
                 },
@@ -27,7 +27,6 @@
                     $timeout(function() {
                         scope.fileEl = angular.element(element[0].querySelector('input[type="file"]'));
                         scope.context = ConfigUtils.getContextJSON();
-                        scope.isDisabled = InputUtils.isDisabled(scope.column);
 
                         // Bind change event file input
                         scope.fileEl

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -133,11 +133,6 @@
                                 rowVal=JSON.parse(rowVal);
                                 break;
                             default:
-                                if (col.isAsset) {
-                                    if (!vm.readyToSubmit) {
-                                        rowVal = { url: "" };
-                                    }
-                                }
                                 break;
                         }
                     }

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -226,7 +226,8 @@
 
                                                             <!-- File input -->
                                                             <div ng-switch-when="file">
-                                                                <upload id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" reference="::reference"  column="::column" placeholder="::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name])" values="form.recordEditModel.rows[rowIndex]" value="form.recordEditModel.rows[rowIndex][column.name]" is-required="!column.nullok"></upload>
+                                                                <upload id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" reference="::reference"  column="::column" placeholder="::form.getDisabledInputValue(column, form.recordEditModel.rows[rowIndex][column.name])"
+                                                                values="form.recordEditModel.rows[rowIndex]" value="form.recordEditModel.rows[rowIndex][column.name]" is-required="::form.isRequired(columnIndex)" is-disabled="form.isDisabled(columnIndex)"></upload>
                                                             </div>
 
                                                             <!--JSON input -->

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -287,6 +287,8 @@
                                 // initialize row objects {column-name: value,...}
                                 recordEditModel.rows[j] = {};
                                 // needs to be initialized so foreign keys can be set
+                                // these are the values that we're sending to ermrestjs,
+                                // chaise should not use these values and we should just populate the values
                                 recordEditModel.submissionRows[j] = {};
 
                                 var tuple = page.tuples[j],


### PR DESCRIPTION
This PR was first introduced to fix the #1932 issue but since I was working on recordedit, I did some other refactoring as well. The changes are:

- Modified the select-all implementation regarding asset columns which fixed the #1932  issue. To make the implementation simpler, recordedit was using the simple disabled input for all the "select-all" forms, including assets. But this means that the `rows` value had to be a simple string and couldn't be the object that we store for assets. To solve this issue, recordedit was abusing `submissionRows` to hold the object. But this had an impact on other columns, and it was buggy. The code assumed that `sumbissionRows` is only populated after submit but that's not necessarily the case. For example, in the case of foreignkey pickers, we need `submissionRows` for the `domain_filter_pattern` support. Therefore we shouldn't have used `submissionRows` to hold these values. To fix this, I changed the input from a simple disabled to an actual upload directive that is disabled. A while ago we added disabled support to this directive, so I just had to make sure the boolean states are properly set. After this change, I could simply pass the rows to the upload directive and didn't need the `submissionRows` hack.

- `transformRowValues` function that we have is not what it was intended to be at first. So I updated the function JSDOC to explain its new implementation. We should not use this function on its own and it only should be used in `populateSubmissionRows`.  So I spend some time to try and merge these two functions, but it introduced some other bugs. I didn't want to debug it any further, so I just left comments about how I think we can improve this function later.

- `transformRowValues` is not modifying the asset columns anymore.

- While testing this, I found out that the `copyFormRow` is very slow and realized that it's copying all the row values blindly. It was copying `Upload` objects that we have as part of `hatracObj` attribute of asset values. It was copying all the reference and column attributes inside this object, which I have no idea how it was working because there are circular dependencies in reference and cannot simply be deep-copied. So I changed its implementation to copy or create new objects selectively. This improved performance a lot. From my testing, if your form had two assets, it would take around 10 seconds to copy the form. With the new code, it takes less than a second.