### PR TITLE
navbar app improvements

### DIFF
--- a/common/config.js
+++ b/common/config.js
@@ -73,9 +73,9 @@
                 // the server object that can be used in other places
                 $window.dcctx.server = ERMrest.ermrestFactory.getServer(service, $window.dcctx.contextHeaderParams);
 
-                $window.dcctx.server.catalogs.get(catalogId).then(function (response) {
+                $window.dcctx.server.catalogs.get(catalogId, true).then(function (response) {
                     // we already setup the defaults and the configuration based on chaise-config.js
-                    if (response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
+                    if (response && response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
 
                     return headInjector.setupHead();
                 }).then(function () {

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -234,6 +234,9 @@
                 // navbar doesn't need to have functionality until the session returns, just like app.js blocks
                 var subFunctionId = Session.subscribeOnChange(function() {
 
+                    // signal the ancestors that navbar is now displayed
+                    $rootScope.$emit("navbar-done");
+
                     // Unsubscribe onchange event to avoid this function getting called again
                     Session.unsubscribeOnChange(subFunctionId);
 

--- a/common/styles/scss/app.scss
+++ b/common/styles/scss/app.scss
@@ -18,6 +18,15 @@
 @import "viewer-app";
 @import "switch-user-accounts";
 
+
+// if we want to hide the page and then show navbar and content together
+.wait-for-navbar {
+    visibility: hidden;
+}
+.wait-for-navbar-loader {
+    visibility: visible;
+}
+
 // configure app rules
 .chaise-body .app-container {
     display: none;

--- a/common/utils.js
+++ b/common/utils.js
@@ -2611,6 +2611,11 @@
             var defer = $q.defer();
             var chaiseConfig = ConfigUtils.getConfigJSON();
             if (chaiseConfig['customCSS'] !== undefined) {
+                // if the file is already injected
+                if (document.querySelector('link[href="' + chaiseConfig['customCSS'] + '"]')) {
+                    return defer.resolve(), defer.promise;
+                }
+
                 var customCSSElement = document.createElement("link");
                 customCSSElement.setAttribute("rel", "stylesheet");
                 customCSSElement.setAttribute("type", "text/css");

--- a/lib/login/login.app.js
+++ b/lib/login/login.app.js
@@ -97,16 +97,27 @@ const CSS_DEPS = [
 
 var head = document.getElementsByTagName('head')[0];
 function loadStylesheets(url) {
+    url = chaisePath + url;
+    // if the file is already injected
+    if (document.querySelector('link[href="' + url + '"]')) {
+        return;
+    }
     var link = document.createElement('link');
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = chaisePath + url;
+    link.href = url;
     head.appendChild(link);
 }
 function loadJSDeps(url, callback) {
+    url = chaisePath + url;
+    // if the file is already injected
+    if (document.querySelector('script[src="' + url + '"]')) {
+        callback();
+        return;
+    }
     var script = document.createElement('script');
     script.type = 'text/javascript';
-    script.src = chaisePath + url;
+    script.src = url;
     script.onload = callback;
     head.appendChild(script);
 }

--- a/lib/navbar/navbar-app.md
+++ b/lib/navbar/navbar-app.md
@@ -20,8 +20,8 @@ Note: Change these paths based on the location of the chaise folder relative to 
 3. If chaise is not installed on the parent directory of your deployment (chaise is installed in `example.com/path-to/chaise/`), make sure you have `chaiseBasePath` defined in your chaise-config file as `/path-to/chaise/`.
 
 ## Sample HTML Pages
-1. /chaise/lib/navbar/sample-navbar.html
-This is a simple html page with the navbar app at the top of the page. This includes the 3 dependencies required for the navbar app in the header and the <navbar> directive in the body in the header section.
+1. `/chaise/lib/navbar/sample-navbar.html`:
+    This is a simple html page with the navbar app at the top of the page. This includes the 3 dependencies required for the navbar app in the header and the <navbar> directive in the body in the header section.
 
 ## Note
 1. This app is only intended to work if the html page is present at the same level as the chaise project directory.
@@ -30,5 +30,18 @@ ermrestjs/*
 chaise/*
 sample-navbar.html
 ```
+
 2. The bootstrap and jQuery versions of the html page might be different from the ones used in Chaise. This might produce some inconsistent behavior in the html page.
+
 3. Some css classes from the app.css file in chaise, which is a dependency for the login app, might conflict with the css classes on the target html page
+
+4. Since navbar is going to take some time to load, if you want to make sure you're showing navbar and the rest of the page together, you can use the following class names:
+  - `wait-for-navbar`: This class should be used on an element that is wrapping the main content of your page.
+  - `wait-for-navbar-loader`: If you want to display a loader while the navbar is loading, make sure your loader is using this class name.
+  ```html
+  <div class="wait-for-navbar">
+    <div class="wait-for-navbar-loader">some loader</div>
+    <navbar></navbar>
+    <!-- your main content should be here -->
+  </div>
+  ```

--- a/lib/navbar/navbar.app.js
+++ b/lib/navbar/navbar.app.js
@@ -38,8 +38,8 @@ function loadModule() {
             }]);
         }])
 
-        .run(['AlertsService', 'messageMap', 'Session', 'ERMrest', 'UiUtils', 'UriUtils',
-        function (AlertsService, messageMap, Session, ERMrest, UiUtils, UriUtils) {
+        .run(['AlertsService', 'messageMap', '$rootScope', 'Session', 'ERMrest', 'UiUtils', 'UriUtils',
+        function (AlertsService, messageMap, $rootScope, Session, ERMrest, UiUtils, UriUtils) {
             try {
                 var subId = Session.subscribeOnChange(function () {
                     Session.unsubscribeOnChange(subId);
@@ -52,6 +52,20 @@ function loadModule() {
             } catch (exception) {
                 throw exception;
             }
+
+            // when navbar done, if the page was hidden and we were showing a loader,
+            // switch the modes.
+            $rootScope.$on("navbar-done", function () {
+                var bodyWait = document.querySelector(".wait-for-navbar");
+                if (bodyWait) {
+                    bodyWait.style.visibility = "visible";
+                }
+
+                var loader = document.querySelector(".wait-for-navbar-loader");
+                if (loader) {
+                    loader.style.visibility = "hidden";
+                }
+            });
         }]);
 
         /**
@@ -63,6 +77,15 @@ function loadModule() {
         });
     })();
 }
+
+
+// since we're dynamically loading css, this makes sure the rule
+// to hide the content and show the loader is applied from the beginning:
+var css = '.wait-for-navbar {visibility: hidden;} .wait-for-navbar-loader {visibility: visible;}',
+    style = document.createElement('style');
+document.head.appendChild(style);
+style.type = 'text/css';
+style.appendChild(document.createTextNode(css));
 
 var chaisePath = "/chaise/";
 if (typeof chaiseConfig != 'undefined' && typeof chaiseConfig === "object" && chaiseConfig['chaiseBasePath'] !== undefined) {
@@ -100,16 +123,28 @@ const CSS_DEPS = [
 
 var head = document.getElementsByTagName('head')[0];
 function loadStylesheets(url) {
+    url = chaisePath + url;
+    // if the file is already injected
+    if (document.querySelector('link[href="' + url + '"]')) {
+        return;
+    }
+
     var link = document.createElement('link');
     link.rel = 'stylesheet';
     link.type = 'text/css';
-    link.href = chaisePath + url;
+    link.href = url;
     head.appendChild(link);
 }
 function loadJSDeps(url, callback) {
+    url = chaisePath + url;
+    // if the file is already injected
+    if (document.querySelector('script[src="' + url + '"]')) {
+        callback();
+        return;
+    }
     var script = document.createElement('script');
     script.type = 'text/javascript';
-    script.src = chaisePath + url;
+    script.src = url;
     script.onload = callback;
     head.appendChild(script);
 }

--- a/lib/navbar/sample-navbar.html
+++ b/lib/navbar/sample-navbar.html
@@ -8,11 +8,7 @@
     <script src="/chaise/lib/navbar/navbar.app.js"></script>
   </head>
   <body>
-    <div class="wrap">
-      <header id="header">
-        <navbar></navbar>
-      </header>
-      <!-- your main content should be here -->
-    </div>
+    <navbar></navbar>
+    <!-- your main content should be here -->
   </body>
 </html>


### PR DESCRIPTION
This PR is part of #1936. The changes include:

- Modified the config app to use the new ermrestjs parameter to skip fetching of the schema object.
- Added css classes that can be used to hide the content of the page while navbar is loading.
- Added some checks to places that we're dynamically loading files so if we've already prefetched them (included in HTML file), we're not fetching them again.

This is part of the incremental changes that are required for #1936. Other changes will be added later as part of other PRs.