### PR TITLE
remove trackby to rerender ellipsis on every data update

### DIFF
--- a/common/ellipsis.js
+++ b/common/ellipsis.js
@@ -281,25 +281,6 @@
                         }
                     });
                 }
-
-                // when the row data updates we have to:
-                //  - run the init function to make sure functions for action columns point to proper reference
-                //  - reset the overflow (truncation) logic
-                $rootScope.$on('reference-modified', function() {
-                    if (removeCellSensors) {
-                        removeCellSensors();
-                    }
-
-                    $timeout(function () {
-                        init();
-
-                        userClicked = false;
-                        if (initializeOverflowLogic) {
-                            initializeOverflowLogic();
-                        }
-                    });
-                });
-
             }
         };
     }])

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -359,14 +359,13 @@
              * Callback to get the list of disabled tuples.
              * This is only applicable in case of adding related entities.
              * @param  {Object} tableModel the table model
+             * @param {Object} page the new page object
              * @param  {Array} requestCauses array of string that indicates why the request is fired
              * @return {Promise} Promise is resolved with a list of disabled rows (array of tuple objects).
              */
-            params.getDisabledTuples = function (tableModel, requestCauses, reloadStartTime) {
+            params.getDisabledTuples = function (tableModel, page, requestCauses, reloadStartTime) {
                 var defer = $q.defer();
-                var page = tableModel.page, pageSize = tableModel.pageLimit;
-
-                var disabledRows = [], index, newStack = tableModel.logStack;
+                var disabledRows = [], index, newStack = tableModel.logStack, pageSize = tableModel.pageLimit;
 
                 var action = logService.logActions.LOAD;
                 if (Array.isArray(requestCauses) && requestCauses.length > 0) {
@@ -387,7 +386,7 @@
                         if (index > -1) disabledRows.push(page.tuples[index]);
                     });
 
-                    defer.resolve(disabledRows);
+                    defer.resolve({disabledRows: disabledRows, page: page});
                 }).catch(function (err) {
                     defer.reject(err);
                 });

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -42,7 +42,7 @@
 
         <!-- rows -->
         <tbody>
-            <tr class="chaise-table-row" ng-class="{'disabled-row': isDisabled(vm.page.tuples[$index])}" ng-repeat="row in vm.rowValues track by $index"
+            <tr class="chaise-table-row" ng-class="{'disabled-row': isDisabled(vm.page.tuples[$index])}" ng-repeat="row in vm.rowValues"
                 ellipsis tuple="vm.page.tuples[$index]" row-values="row" row-index="$index" table-model="vm" on-row-click-bind="onSelect"
                 selected="isSelected(vm.page.tuples[$index])" select-disabled="isDisabled(vm.page.tuples[$index])">
             </tr>

--- a/test/e2e/specs/all-features-confirmation/chaise-config.js
+++ b/test/e2e/specs/all-features-confirmation/chaise-config.js
@@ -7,7 +7,7 @@ var chaiseConfig = {
     confirmDelete: true,
     defaultCatalog: 1,
     maxRelatedTablesOpen: 6,
-    maxRecordsetRowHeight: false, // triggers (ignores) some logic in ellipsis.js. Tests view buttons having proper links
+    // maxRecordsetRowHeight: false, // triggers (ignores) some logic in ellipsis.js. Tests view buttons having proper links
     allowErrorDismissal : true,
     resolverImplicitCatalog: 2, // in parallel config mode, this config is used first with catalog Id
     SystemColumnsDisplayCompact: ['RCB', 'RMT'],

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -259,7 +259,7 @@ describe('View existing record,', function() {
         it("should show all of the related tables in the correct order.", function() {
 
             browser.wait(function() {
-                return chaisePage.recordPage.getRelatedTablesWithPanel().count().then(function(ct) {
+                return chaisePage.recordPage.getRelatedTablesWithPanelandHeading().count().then(function(ct) {
                     return (ct == testParams.no_related_data.tables_order.length);
                 });
             }, browser.params.defaultTimeout);

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -198,7 +198,7 @@ var testParams = {
         data: [
             [
                 "main one", // self_link_rowname
-                "current: main one(1234501, 1,234,501), id: 01, array: 1,234,521, 1,234,522, 1,234,523, 1,234,524, 1,234,525", // self_link_id
+                "current: main one(1234501, 1,234,501), id: 01, array: 1,234,521, 1,234,522, 1,234,523, 1,234,524, 1,234,525\n... more", // self_link_id
                 "1,234,501", //normal_col_int_col
                 "current cnt: 5 - 1,234,511, 1234511, cnt_i1: 5", //normal_col_int_col_2
                 "outbound1 one", //outbound_entity_o1
@@ -930,8 +930,10 @@ describe('View recordset,', function() {
 
                 return chaisePage.recordsetPage.getPageLimitDropdown().click();
             }).then(function() {
+                var dropdownOption = chaisePage.recordsetPage.getPageLimitSelector(fileParams.page_size);
+                browser.wait(EC.elementToBeClickable(dropdownOption), browser.params.defaultTimeout);
                 // increase the page limit
-                return chaisePage.recordsetPage.getPageLimitSelector(fileParams.page_size).click();
+                return dropdownOption.click();
             }).then(function() {
                 browser.wait(function() {
                     return chaisePage.recordsetPage.getRows().count().then(function(ct) {

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -1143,6 +1143,12 @@ describe('View recordset,', function() {
                     }).then(function () {
                         return chaisePage.recordPageReady();
                     }).then(function () {
+                        browser.wait(function () {
+                            return chaisePage.recordPage.getColumns().count().then(function(ct) {
+                                return ct == systemColumnsParams.detailedColumns.length;
+                            });
+                        });
+
                         return chaisePage.recordPage.getColumns();
                     }).then(function (columns) {
                         expect(columns.length).toBe(systemColumnsParams.detailedColumns.length);

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -198,7 +198,7 @@ var testParams = {
         data: [
             [
                 "main one", // self_link_rowname
-                "current: main one(1234501, 1,234,501), id: 01, array: 1,234,521, 1,234,522, 1,234,523, 1,234,524, 1,234,525\n... more", // self_link_id
+                "current: main one(1234501, 1,234,501), id: 01, array: 1,234,521, 1,234,522, 1,234,523, 1,234,524, 1,234,525", // self_link_id
                 "1,234,501", //normal_col_int_col
                 "current cnt: 5 - 1,234,511, 1234511, cnt_i1: 5", //normal_col_int_col_2
                 "outbound1 one", //outbound_entity_o1

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -204,7 +204,12 @@ describe ("Viewing exisiting record with related entities, ", function () {
             totalCount: 4,
             existingCount: 1,
             disabledRows: ["1"],
-            selectIndex: 2,
+            search: {
+                term: "television|Coffee",
+                afterSearchCount: 2,
+                afterSearchDisabledRows: ["1"]
+            },
+            selectIndex: 1, // after search
             rowValuesAfter: [
                 ["Television"],
                 ["Coffee Maker"]

--- a/test/e2e/specs/delete-prohibited/navbar/catalog-chaise-config.spec.js
+++ b/test/e2e/specs/delete-prohibited/navbar/catalog-chaise-config.spec.js
@@ -40,6 +40,7 @@ describe('Navbar ', function() {
     it('should hide the navbar bar if the hideNavbar query parameter is set to true', function () {
         browser.get(url + "?hideNavbar=true");
         browser.wait(EC.presenceOf(navbar), browser.params.defaultTimeout);
+        chaisePage.recordsetPageReady()
 
         expect(navbar.isDisplayed()).toBeFalsy();
     });

--- a/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
+++ b/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
@@ -33,6 +33,7 @@ describe('View existing record,', function() {
 
         it('should display a disabled delete record button', function() {
             var deleteBtn = chaisePage.recordPage.getDeleteRecordButton();
+            chaisePage.waitForElement(deleteBtn);
             expect(deleteBtn.isPresent()).toBeTruthy("The delete button does not show on the page.");
             expect(deleteBtn.getAttribute("disabled")).toBeTruthy("The delete button was not disabled.");
         });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -813,24 +813,25 @@ var recordsetPage = function() {
         return el.getAttribute('uib-tooltip');
     };
 
-    this.getMainSearchBox = function() {
-        return element(by.className("recordset-main-search"));
+    this.getMainSearchBox = function(el) {
+        var locator = by.className("recordset-main-search");
+        return el ? el.element(locator) : element(locator);
     };
 
-    this.getMainSearchPlaceholder = function () {
-        return this.getMainSearchBox().element(by.className("chaise-input-placeholder"))
+    this.getMainSearchPlaceholder = function (el) {
+        return this.getMainSearchBox(el).element(by.className("chaise-input-placeholder"))
     }
 
-    this.getMainSearchInput = function() {
-        return this.getMainSearchBox().element(by.className("main-search-input"));
+    this.getMainSearchInput = function(el) {
+        return this.getMainSearchBox(el).element(by.className("main-search-input"));
     };
 
-    this.getSearchSubmitButton = function() {
-        return this.getMainSearchBox().element(by.className("chaise-search-btn"));
+    this.getSearchSubmitButton = function(el) {
+        return this.getMainSearchBox(el).element(by.className("chaise-search-btn"));
     };
 
-    this.getSearchClearButton = function() {
-        return this.getMainSearchBox().element(by.className("remove-search-btn"));
+    this.getSearchClearButton = function(el) {
+        return this.getMainSearchBox(el).element(by.className("remove-search-btn"));
     };
 
     this.getAddRecordLink = function(el) {
@@ -1143,8 +1144,21 @@ var recordsetPage = function() {
     this.getSelectAllBtn = function () {
         return element(by.id("table-select-all-rows"));
     };
-
 };
+
+var SearchPopup = function () {
+    this.getAddPureBinaryPopup = function () {
+        return element(by.className("add-pure-and-binary-popup"));
+    };
+
+    this.getFacetPopup = function () {
+        return element(by.className("faceting-show-details-popup"));
+    };
+
+    this.getForeignKeyPopup = function () {
+        return element(by.className("foreignkey-popup"));
+    };
+}
 
 var errorModal = function () {
     var self = this;
@@ -1170,6 +1184,7 @@ function chaisePage() {
     this.recordPage = new recordPage();
     this.recordsetPage = new recordsetPage();
     this.errorModal = new errorModal();
+    this.searchPopup = new SearchPopup();
     this.clickButton = function(button) {
         return browser.executeScript("$(arguments[0]).click();", button);
     };


### PR DESCRIPTION
### How to reproduce the bug:
- Go to a record page that has a pure and binary table.
- Click on "add" button to open the modal.
- Select a facet, so the number of rows that will be displayed after is less than the current number of rows.
- Chaise will throw a terminal error

(Sorry in advance for the following wall of text. I tried to explain it with as much detail as possible.)

### Some background about Chaise:

#### `vm.page` vs `vm.rowValues`:

When the data changes, we're first setting the value of `vm.page`, and then later in the promise chain, we will populate the values of `vm.rowValues`.
- `vm.rowValues` is what's displayed in each row of a recordset table.
- `vm.page` is used the `tuple` object that is used in ellipsis directive.

So what's displayed on the page won't change until we have populated the `vm.rowValues`. In the case of a normal recordset page, the logic to populate these two will be done in the same digest cycle and therefore, there's no issue. But in the case of pure and binary, since what we're displaying is a result of two separate queries (one for showing the rows and the other one for disabling some of them), AngularJS will do this in two different digest cycles. 

#### ellipsis directive:
This directive is used to represent a row of data in the recordset table. We're passing `tuple` and `rowValues` to this directive, among other parameters. `tuple` is coming from the `vm.page.tuples` and `rowValues` is each element in the array of `vm.rowValues` (`vm.rowValues` is technically an array of arrays). When ellipsis directive loads, we're using `tuple` to generate the view, edit, and delete links. When the data changes, AngularJS is using the same ellipsis template to show the new rows without actually recomputing the ellipsis. So we have to manually recompute ellipsis logic to generate appropriate action links manually.

### Why this is happening:
On each digest cycle, Angularjs will recompute the templates that need to be updated. As I mentioned, it takes two digest cycles to show the results in add pure and binary modal. So after the first digest cycle since the value of `vm.page` has been changed, the ellipsis directive will use the new value of `vm.tuple`. So At this point, the `tuple` and `rowValues` that the ellipsis directive has are not in sync. But we're firing an event in the same digest cycle to signal ellipsis to update itself. At this point, since `rowValue` has not been updated yet, for the ellipsis rows that are supposed to be hidden (because the returned result has fewer rows), we will update the ellipsis code. But since we updated the `tuple` in this digest cycle, its value is undefined and therefore the terminal error is displayed.


### How I fixed it in this PR:
We were using `reference-modified` to rerender the ellipsis logic manually. This event, in some cases as it was explained above, was called in the middle of two digest cycles.

At first, I changed this logic to the old method that we had, which is watching for the `rowValues` in ellipsis.  This solved the issue, but I realized by removing `track by` I can ensure AngularJS will run the link function for us, and then we don't need to run the ellipsis manually. AngularJS will always run the ellipsis directive based on correct values of `tuple` and `rowValues` after each data update and solves the issue.

Although by doing this, the DOM will keep destroying and creating new table rows each time the data changes. But during my manual testing, I didn't see any noticeable performance issues with this. We could add "track by" the `tuple.uniqueId` value, but I think we still want to recompute the ellipsis because the data might have changed, and therefore the truncation logic might need to be changed.

I created the PR so I can write the explanation somewhere and so we can do more manual testing.

### What's missing from this PR:
e2e testing!

P.S. I think some test cases are broken because of the chaise-config change that recently was done in some specs. I fixed one simple case in recordset presentation, but there are some more that are still broken (I tested with master so I'm sure the changes here didn't cause them). I'll look into them tomorrow.