### PR TITLE
Bug fixes

### DIFF
--- a/record/index.html.in
+++ b/record/index.html.in
@@ -58,7 +58,7 @@
                                                     <span class="chaise-btn-icon glyphicon glyphicon-plus"></span>
                                                     <span>Create</span>
                                                 </button>
-                                                <button id="copy-record" class="chaise-btn chaise-btn-primary" ng-click="::ctrl.copyRecord()" ng-disabled="::!ctrl.canEdit()" uib-tooltip="Click here to create a copy of this record." tooltip-placement="bottom">
+                                                <button id="copy-record" class="chaise-btn chaise-btn-primary" ng-click="::ctrl.copyRecord()" ng-disabled="::!ctrl.canCreate()" uib-tooltip="Click here to create a copy of this record." tooltip-placement="bottom">
                                                     <span class="chaise-btn-icon glyphicon glyphicon-copy"></span>
                                                     <span>Copy</span>
                                                 </button>

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -9,8 +9,8 @@
 
         var initialHref = $window.location.href;
         var mainContainerEl = angular.element(document.getElementsByClassName('main-container')[0]);
-        var addRecordRequests = {}; /// generated id: {displayMode: "", containerIndex: integer}
-        var editRecordRequests = {}; // generated id: {displayMode: "", containerIndex: integer, completed: boolean}
+        vm.addRecordRequests = {}; /// generated id: {displayMode: "", containerIndex: integer}
+        vm.editRecordRequests = {}; // generated id: {displayMode: "", containerIndex: integer, completed: boolean}
         var modalUpdate = false;
         vm.alerts = AlertsService.alerts;
         vm.makeSafeIdAttr = DataUtils.makeSafeIdAttr;

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -427,7 +427,7 @@
             // Generate a unique id for this request
             // append it to the URL
             var referrer_id = 'recordedit-' + MathUtils.getRandomInt(0, Number.MAX_SAFE_INTEGER);
-            addRecordRequests[referrer_id] = {
+            vm.addRecordRequests[referrer_id] = {
                 displayMode: tableModel.config.displayMode,
                 containerIndex: tableModel.config.containerIndex
             };
@@ -443,7 +443,7 @@
         };
 
         $scope.$on("edit-request", function(event, args) {
-            editRecordRequests[args.id] = {"displayMode": args.displayMode, "containerIndex": args.containerIndex, "finished": false};
+            vm.editRecordRequests[args.id] = {"displayMode": args.displayMode, "containerIndex": args.containerIndex, "finished": false};
         });
 
         $scope.$on('record-deleted', function (event, args) {
@@ -484,23 +484,23 @@
             }
 
             //find the completed edit requests
-            for (id in editRecordRequests) {
-                if (editRecordRequests[id].completed) {
-                    addToChangedContainers(editRecordRequests[id], [uc.RELATED_UPDATE, uc.RELATED_INLINE_UPDATE]);
-                    delete editRecordRequests[id];
+            for (id in vm.editRecordRequests) {
+                if (vm.editRecordRequests[id].completed) {
+                    addToChangedContainers(vm.editRecordRequests[id], [uc.RELATED_UPDATE, uc.RELATED_INLINE_UPDATE]);
+                    delete vm.editRecordRequests[id];
                 }
             }
 
             // find the completed create requests
-            for (id in addRecordRequests) {
+            for (id in vm.addRecordRequests) {
                 cookie = $cookies.getObject(id);
                 if (cookie) { // add request has been completed
                     console.log('Cookie found for the id=' + id);
-                    addToChangedContainers(addRecordRequests[id], [uc.RELATED_CREATE, uc.RELATED_INLINE_CREATE]);
+                    addToChangedContainers(vm.addRecordRequests[id], [uc.RELATED_CREATE, uc.RELATED_INLINE_CREATE]);
 
                     // remove cookie and request
                     $cookies.remove(id);
-                    delete addRecordRequests[id];
+                    delete vm.addRecordRequests[id];
                 } else {
                     console.log('Could not find cookie', cookie);
                 }
@@ -514,7 +514,7 @@
 
         // function called from form.controller.js to notify record that an entity was just updated
         window.updated = function(id) {
-            editRecordRequests[id].completed = true;
+            vm.editRecordRequests[id].completed = true;
         }
 
         // to make sure we're adding the watcher just once

--- a/test/e2e/specs/all-features/record/permissions-visibility.spec.js
+++ b/test/e2e/specs/all-features/record/permissions-visibility.spec.js
@@ -69,11 +69,13 @@ describe('When viewing Record app', function() {
         it('should display the share button', function() {
             var permalink = recordPage.getShareButton();
             expect(permalink.isDisplayed()).toBeTruthy();
+            expect(permalink.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Create button', function() {
             var button = recordPage.getCreateRecordButton();
             expect(button.isDisplayed()).toBeTruthy();
+            expect(button.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Edit button as disabled', function() {
@@ -82,10 +84,10 @@ describe('When viewing Record app', function() {
             expect(button.getAttribute("disabled")).toBeTruthy();
         });
 
-        it('should display the Copy button as disabled', function() {
+        it('should display the Copy button', function() {
             var button = recordPage.getCopyRecordButton();
-            expect(button.isPresent()).toBeTruthy();
-            expect(button.getAttribute("disabled")).toBeTruthy();
+            expect(button.isDisplayed()).toBeTruthy();
+            expect(button.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Delete button as disabled', function() {
@@ -160,16 +162,19 @@ describe('When viewing Record app', function() {
             // a user can edit, the user can also create.
             var button = recordPage.getCreateRecordButton();
             expect(button.isDisplayed()).toBeTruthy();
+            expect(button.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Edit button', function() {
             var button = recordPage.getEditRecordButton();
             expect(button.isDisplayed()).toBeTruthy();
+            expect(button.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Copy button', function() {
             var button = recordPage.getCopyRecordButton();
             expect(button.isDisplayed()).toBeTruthy();
+            expect(button.getAttribute("disabled")).toBeFalsy();
         });
 
         it('should display the Delete button as disabled', function() {


### PR DESCRIPTION
This PR will,

- Change the condition of copy button to use `canCreate`. It was wrongfully using `canEdit` instead.

- Modify the copy related test cases.

- attach `addRecordRequests` and `editRecordRequests` objects in record controller to the controller object. While I was testing this, sometimes their value would be empty. I suspect that is because of the garbage collector.  I’ve seen the same kind of behavior in ermrestjs and mainly in nodejs environment when I run the test cases. If I create an object that is not attached to the current module (so it’s global and technically attached to window/global object), sometimes its value would be undefined depending on when it’s called.  To solve this, attached these two objects to `vm` to make sure it won't be cleared out. I cannot be certain what I described was the case of this bug, but now working properly every time that I tested it.
 