### PR TITLE
add new env variable for viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ WEB_URL_ROOT?=/
 WEB_INSTALL_ROOT?=/var/www/html/
 ERMRESTJS_REL_PATH?=ermrestjs/
 CHAISE_REL_PATH?=chaise/
+OSD_VIEWER_REL_PATH?=openseadragon-viewer/
 
 # version number added to all the assets
 BUILD_VERSION:=$(shell date +%Y%m%d%H%M%S)
@@ -21,6 +22,7 @@ CHAISEDIR:=$(WEB_INSTALL_ROOT)$(CHAISE_REL_PATH)
 #chaise and ermrsetjs paths
 CHAISE_BASE_PATH:=$(WEB_URL_ROOT)$(CHAISE_REL_PATH)
 ERMRESTJS_BASE_PATH:=$(WEB_URL_ROOT)$(ERMRESTJS_REL_PATH)
+OSD_VIEWER_BASE_PATH:=$(WEB_URL_ROOT)$(OSD_VIEWER_REL_PATH)
 
 # ERMrestjs dependencies
 ERMRESTJS_DEPS=ermrest.vendor.min.js \
@@ -289,6 +291,7 @@ $(DIST)/$(MAKEFILE_VAR): $(BUILD_VERSION)
 	@echo 'chaiseBuildVariables.buildVersion="$(BUILD_VERSION)";' >> $(DIST)/$(MAKEFILE_VAR)
 	@echo 'chaiseBuildVariables.chaiseBasePath="$(CHAISE_BASE_PATH)";' >> $(DIST)/$(MAKEFILE_VAR)
 	@echo 'chaiseBuildVariables.ermrestjsBasePath="$(ERMRESTJS_BASE_PATH)";' >> $(DIST)/$(MAKEFILE_VAR)
+	@echo 'chaiseBuildVariables.OSDViewerBasePath="$(OSD_VIEWER_BASE_PATH)";' >> $(DIST)/$(MAKEFILE_VAR)
 
 
 $(DIST)/chaise-dependencies.html: $(BUILD_VERSION)
@@ -631,6 +634,7 @@ print_variables:
 	$(info building and deploying to: $(CHAISEDIR))
 	$(info Chaise will be accessed using: $(CHAISE_BASE_PATH))
 	$(info ERMrestJS must already be installed and accesible using: $(ERMRESTJS_BASE_PATH))
+	$(info If using viewer, OSD viewer must already be installed and accesible using: $(OSD_VIEWER_BASE_PATH))
 	$(info =================)
 
 # Rules for help/usage

--- a/common/utils.js
+++ b/common/utils.js
@@ -835,6 +835,17 @@
         }
 
         /**
+         * Returns the path that openseadragon-viewer is installed
+         */
+        function OSDViewerDeploymentPath() {
+            if (typeof chaiseBuildVariables.OSDViewerBasePath === "string") {
+                return chaiseBuildVariables.OSDViewerBasePath;
+            } else {
+                return '/openseadragon-viewer/';
+            }
+        }
+
+        /**
          * Returns the chaise base url without the trailing slash
          * TODO we might want to find a better way instead of this.
          * @return {String}
@@ -1006,6 +1017,7 @@
             getQueryParams: getQueryParams,
             isBrowserIE: isBrowserIE,
             isSameOrigin: isSameOrigin,
+            OSDViewerDeploymentPath: OSDViewerDeploymentPath,
             parsedFilterToERMrestFilter: parsedFilterToERMrestFilter,
             parseURLFragment: parseURLFragment,
             queryStringToJSON: queryStringToJSON,

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -209,8 +209,10 @@
                 $rootScope.reference = reference.contextualize.entryCreate;
             }
 
-            $rootScope.reference.session = session;
-            $rootScope.session = session;
+            if (typeof session !== "undefined") {
+                $rootScope.reference.session = session;
+                $rootScope.session = session;
+            }
             // $rootScope.reference = reference;
 
             // log attribues
@@ -285,6 +287,8 @@
 
                     console.log('uri='+image.entity.uri + waterMark);
 
+                    var osdViewerPath =  origin + UriUtils.OSDViewerDeploymentPath() + "mview.html";
+
                     /* Note: the following has been done so that the viewer app supports both type of formats i.e tiff and czi.
                       It calls the new OpenSeadragon viewer app with parameters based on the file format. Need to change this, when we
                       will start getting svg files in the URL itself instead of making a call to ermrest.
@@ -292,10 +296,10 @@
                     */
                     var params = window.location.href.split("?");
                     if(window.location.href.indexOf("url") > -1){
-                      image.entity.uri = origin+"/openseadragon-viewer/index.html?" + params[1];
+                      image.entity.uri = osdViewerPath + "?" + params[1];
                     } else {
                       var old_params = image.entity.uri.split("?");
-                      image.entity.uri = origin+"/openseadragon-viewer/index.html?" + old_params[1];
+                      image.entity.uri = osdViewerPath + "?" + old_params[1];
                     }
 
                     // image.entity.uri = image.entity.uri + "&url=data/Q-296R_all_contours_cw_named.svg";


### PR DESCRIPTION
This PR will add `OSD_VIEWER_REL_PATH` to parameterize the osd-viewer location. Since it's using `mview.html` (as opposed to `index.html`), this should be merged with [this PR in osd-viewer](https://github.com/informatics-isi-edu/openseadragon-viewer/pull/21)