### PR TITLE
Change default user display name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,9 +124,10 @@ before_script:
   - sudo -H -u webauthn webauthn2-manage assign test1 admin
 
 script:
+  - make testfullfeatures
   - make testfullfeaturesconfirmation
   - make testdefaultconfig
-  - make testfullfeatures
+  # - make testfullfeatures
   - make testdeleteprohibited
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,10 +124,9 @@ before_script:
   - sudo -H -u webauthn webauthn2-manage assign test1 admin
 
 script:
-  - make testfullfeatures
   - make testfullfeaturesconfirmation
   - make testdefaultconfig
-  # - make testfullfeatures
+  - make testfullfeatures
   - make testdeleteprohibited
 
 after_failure:

--- a/common/login.js
+++ b/common/login.js
@@ -24,7 +24,8 @@
                             scope.user = null;
                         } else {
                             var user = $rootScope.session.client;
-                            scope.user = dcctx.user = user.display_name || user.full_name || user.email || user.id || user;
+                            scope.user = dcctx.user = user.full_name || user.display_name || user.email || user.id || user;
+                            if (user.full_name) scope.userTooltip = user.full_name + "\n" + user.display_name;
                         }
 
                     });

--- a/common/templates/login.html
+++ b/common/templates/login.html
@@ -8,7 +8,7 @@
     </li>
     <li uib-dropdown>
         <a href="#" class="dropdown-toggle" uib-dropdown-toggle ng-if="user !== null && !profileURL" ng-click="::logDropdownOpen()">
-            <span ng-bind="user"></span>
+            <span class="username-display" ng-bind="user" uib-tooltip="{{userTooltip}}" tooltip-placement="bottom-right"></span>
             <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -68,7 +68,8 @@ describe('Navbar ', function() {
     }
 
     it('should show the "Full Name" of the logged in user in the top right', function () {
-        expect(element(by.css('login .username-display')).getText()).toBe(browser.params.client.full_name, "user's displayed name is incorrect");
+        var name = (!process.env.TRAVIS ? browser.params.client.full_name : browser.params.client.display_name);
+        expect(element(by.css('login .username-display')).getText()).toBe(name, "user's displayed name is incorrect");
     });
 
 

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -68,7 +68,7 @@ describe('Navbar ', function() {
     }
 
     it('should show the "Full Name" of the logged in user in the top right', function () {
-        var name = (!process.env.TRAVIS ? browser.params.configuration.client.full_name : browser.params.configuration.client.display_name);
+        var name = (!process.env.TRAVIS ? browser.params.client.full_name : browser.params.client.display_name);
         expect(element(by.css('login .username-display')).getText()).toBe(name, "user's displayed name is incorrect");
     });
 

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -68,9 +68,7 @@ describe('Navbar ', function() {
     }
 
     it('should show the "Full Name" of the logged in user in the top right', function () {
-        var name = (!process.env.TRAVIS ? browser.params.client.full_name : browser.params.client.display_name);
-        console.log("in spec, params");
-        console.log(browser.params);
+        var name = (!process.env.TRAVIS ? browser.params.configuration.client.full_name : browser.params.configuration.client.display_name);
         expect(element(by.css('login .username-display')).getText()).toBe(name, "user's displayed name is incorrect");
     });
 

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -67,6 +67,10 @@ describe('Navbar ', function() {
         });
     }
 
+    it('should show the "Full Name" of the logged in user in the top right', function () {
+        expect(element(by.css('login .username-display')).getText()).toBe(browser.params.client.full_name, "user's displayed name is incorrect");
+    });
+
 
     it('should open the profile card on click of My Profile link', function(done) {
         var link = element(by.css('login .dropdown-toggle'));

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -69,6 +69,8 @@ describe('Navbar ', function() {
 
     it('should show the "Full Name" of the logged in user in the top right', function () {
         var name = (!process.env.TRAVIS ? browser.params.client.full_name : browser.params.client.display_name);
+        console.log("in spec, params");
+        console.log(browser.params);
         expect(element(by.css('login .username-display')).getText()).toBe(name, "user's displayed name is incorrect");
     });
 

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -87,9 +87,11 @@ exports.parameterize = function(config, configParams) {
 
                 // get the client information
                 var info = JSON.parse(body);
+                console.log(info.client);
 
                 if (testConfiguration.authCookie) {
                   process.env.AUTH_COOKIE = testConfiguration.authCookie;
+                  console.log("before ermLogin function call");
                   onErmrestLogin(defer, info);
                 } else defer.reject(error);
               } else {

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -135,6 +135,7 @@ exports.parameterize = function(config, configParams) {
 
     browser.params.configuration = testConfiguration, defer = Q.defer();
     browser.params.client = testConfiguration.client;
+    console.log("browser param configuration");
     console.log(browser.params.configuration);
 
     // Set catalogId in browser params for future reference to delete it if required

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -32,9 +32,10 @@ exports.parameterize = function(config, configParams) {
     config.capabilities['name'] = "chaise #" + process.env.TRAVIS_BUILD_NUMBER;
   }
 
-  var onErmrestLogin = function(defer) {
+  var onErmrestLogin = function(defer, sessionInfo) {
     testConfiguration.setup.url = process.env.ERMREST_URL;
     testConfiguration.setup.authCookie = testConfiguration.authCookie;
+    testConfiguration.client = sessionInfo.client;
 
     pImport.setup(testConfiguration).then(function(data) {
       process.env.CATALOGID = data.catalogId;
@@ -86,13 +87,10 @@ exports.parameterize = function(config, configParams) {
 
                 // get the client information
                 var info = JSON.parse(body);
-                testConfiguration.client = info.client;
-
-                console.log(testConfiguration);
 
                 if (testConfiguration.authCookie) {
                   process.env.AUTH_COOKIE = testConfiguration.authCookie;
-                  onErmrestLogin(defer);
+                  onErmrestLogin(defer, info);
                 } else defer.reject(error);
               } else {
                 console.dir(error);
@@ -111,9 +109,8 @@ exports.parameterize = function(config, configParams) {
             if (!error && response.statusCode == 200) {
                 // get the client information
                 var info = JSON.parse(body);
-                testConfiguration.client = info.client;
 
-                onErmrestLogin(defer);
+                onErmrestLogin(defer, info);
             } else {
                 throw new Error('Unable to retreive userinfo');
             }
@@ -134,9 +131,6 @@ exports.parameterize = function(config, configParams) {
     jasmine.getEnv().addReporter(new SpecReporter({displayStacktrace: 'all'}));
 
     browser.params.configuration = testConfiguration, defer = Q.defer();
-    browser.params.client = testConfiguration.client;
-    console.log("browser param configuration");
-    console.log(browser.params.configuration);
 
     // Set catalogId in browser params for future reference to delete it if required
     browser.params.catalogId = catalogId = process.env.CATALOGID;

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -35,6 +35,8 @@ exports.parameterize = function(config, configParams) {
   var onErmrestLogin = function(defer, sessionInfo) {
     testConfiguration.setup.url = process.env.ERMREST_URL;
     testConfiguration.setup.authCookie = testConfiguration.authCookie;
+    console.log("================sessioninfo onErmrstLogin================")
+    console.log(sessionInfo);
     testConfiguration.client = sessionInfo.client;
 
     pImport.setup(testConfiguration).then(function(data) {
@@ -127,6 +129,7 @@ exports.parameterize = function(config, configParams) {
 
   // This method will be called before starting to execute the test suite
   config.onPrepare = function() {
+    console.log(testConfiguration);
 
     var SpecReporter = require('jasmine-spec-reporter');
     // add jasmine spec reporter

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -86,6 +86,7 @@ exports.parameterize = function(config, configParams) {
 
                 // get the client information
                 var info = JSON.parse(body);
+                console.log(info);
                 testConfiguration.client = info.client;
 
                 if (testConfiguration.authCookie) {

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -86,8 +86,9 @@ exports.parameterize = function(config, configParams) {
 
                 // get the client information
                 var info = JSON.parse(body);
-                console.log(info);
                 testConfiguration.client = info.client;
+
+                console.log(testConfiguration);
 
                 if (testConfiguration.authCookie) {
                   process.env.AUTH_COOKIE = testConfiguration.authCookie;
@@ -134,6 +135,7 @@ exports.parameterize = function(config, configParams) {
 
     browser.params.configuration = testConfiguration, defer = Q.defer();
     browser.params.client = testConfiguration.client;
+    console.log(browser.params.configuration);
 
     // Set catalogId in browser params for future reference to delete it if required
     browser.params.catalogId = catalogId = process.env.CATALOGID;


### PR DESCRIPTION
Changed default display value of the displayed user information in top right corner. Previously this was displaying `display_name` by default which would show a string that looks like an email address. When `full_name` is not available, `display_name` is still used for the display value. 

A tooltip was also added when the user hover's over their user name. The tooltip will only be added if the user has a `full_name` defined so hovering over it shows more information (`full_name` and `display_name`)

Added a test for this in one of the navbar specs.