### PR TITLE
Hiding iframe and video markdowns during print

### DIFF
--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -536,7 +536,7 @@
           visibility: visible !important;
         }
 
-        alerts {
+        .alert {
           display: none !important;
         }
 

--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -531,11 +531,12 @@
           display: none !important;
         }
 
+        //In print we hide YouTube and other videos. This class is then made visible to display the relevant info in print mode
         .video-info-in-print{
           visibility: visible !important;
         }
 
-        .alert-success{
+        alerts {
           display: none !important;
         }
 

--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -531,6 +531,10 @@
           display: none !important;
         }
 
+        .video-info-in-print{
+          visibility: visible !important;
+        }
+
         @page {
             size: auto;
             margin: 5% 3% 5% 3%;

--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -535,6 +535,10 @@
           visibility: visible !important;
         }
 
+        .alert-success{
+          display: none !important;
+        }
+
         @page {
             size: auto;
             margin: 5% 3% 5% 3%;

--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -536,7 +536,7 @@
           visibility: visible !important;
         }
 
-        .alert {
+        alerts {
           display: none !important;
         }
 


### PR DESCRIPTION
This PR includes the following fixes

- [x] Fixed the print for iframes with Treeview document to show the tree hierarchy during print.
- [x] Persisted scrolling during print
- [x] Parsing the URL to check if there is an embedded YouTube video. If yes, then add a class to apply the above discussed custom styles.
- [x] The same has been processed for the <video> markdown pattern as well.

- Applying the thumbnail to the YouTube video on print was complicated as the styles are applied via YouTube and we have limited access to it. Hence, the alternative was to display a note informing the user that the video is hidden during print and possibly provide the URL of the hidden video.
