### PR TITLE
Viewer app improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,7 @@ recordedit/mdHelp.html: recordedit/mdHelp.html.in .make-mdhelp-includes
 VIEWER_ROOT=viewer
 
 VIEWER_JS_SOURCE=$(VIEWER_ROOT)/viewer.app.js \
+	$(VIEWER_ROOT)/viewer.utils.js \
 	$(VIEWER_ROOT)/constant.js \
 	$(VIEWER_ROOT)/common/providers/context.js \
 	$(VIEWER_ROOT)/common/providers/image.js \

--- a/common/modal.js
+++ b/common/modal.js
@@ -4,7 +4,7 @@
     angular.module('chaise.modal', ['chaise.utils'])
 
     //TODO
-    .factory('modalUtils', ["logService", "UiUtils", "UriUtils", "$log", "$uibModal", "$window", function (logService, UiUtils, UriUtils, $log, $uibModal, $window) {
+    .factory('modalUtils', ["logService", "UiUtils", "UriUtils", "$log", "$q", "$uibModal", "$window", function (logService, UiUtils, UriUtils, $log, $q, $uibModal, $window) {
 
         /**
          * Given the parameters that are used to generate a modal, returns the appropriate size.
@@ -62,7 +62,8 @@
         }
         
         /**
-         * Given a tuple and reference will open the share popup.
+         * Given a tuple and reference will open the share popup. It will return a promise
+         * that will be resolved when the modal is displayed.
          * You can also pass extra parameters if you want. The acceptable extra params are:
          *  - title: will be displayed in the modal title
          *  - hideCitation: hide the citation section
@@ -71,6 +72,8 @@
          *    {value: "string", title: "string"} or {title: "string", value: "string", link: "string", ype: "link"}
          */
         function openSharePopup (tuple, reference, extraParams) {
+            var defer = $q.defer();
+            
             var refTable = reference.table;
             var params = extraParams || {};
             
@@ -102,7 +105,11 @@
                         params: params
                     }
                 }, false, false, false); // not defining any extra callbacks
+                
+                defer.resolve();
             });
+            
+            return defer.promise;
         }
 
         return {

--- a/common/styles/scss/_viewer-app.scss
+++ b/common/styles/scss/_viewer-app.scss
@@ -642,7 +642,7 @@
                 display: flex;
                 flex-direction: row;
                 overflow: hidden;
-                background: #fff;
+                background: $white-color;
                 flex-shrink: 0;
                 min-height: 40px;
                 cursor: pointer;
@@ -657,20 +657,20 @@
 
                 &.current input.edit,
                 &.current .anatomy{
-                    color : #fff;
+                    color : $white-color;
                 }
 
                 &.current .anatomy a{
-                    color : #fff;
+                    color : $white-color;
                 }
 
 
-                &.current .editBtn{
-                    color: #fff;
+                &.current .editBtn, &.current .editBtn i{
+                    color: $white-color;
                 }
                 .editBtn.selected{
                     background: #3669ac;
-                    color: #ffffff;
+                    color: $white-color;
                     padding: 3px;
                 }
 
@@ -738,20 +738,31 @@
                     flex-direction: row;
                     align-items: center;
                 }
-
+                
+                // TODO it's called editBtn but used for all the annotation buttons
                 .editBtn{
                     text-decoration: none;
                     padding: 3px;
                     border-radius: 2px;
                     margin: 2px;
-                    color: #407cca;
+                    color: $primary-color;
                     cursor: pointer;
                     font-size: 12px;
                     display: flex;
                     justify-content: center;
                     align-items: center;
                     border: none;
-
+                    background: none;
+                    
+                    // change chaise default color
+                    .glyphicon-refresh {
+                        color: $primary-color;
+                    }
+                    
+                    &:focus {
+                        outline: none;
+                    }
+                    
                     &:last-child{
                         margin-right: 8px;
                     }
@@ -760,10 +771,9 @@
                         color: #0099cce0;
                     }
 
-                    &.disabled{
-                        background: none;
-                        color: #424242;
-                        cursor: default;
+                    &.disabled,&:disabled{
+                        color: $disabled-color;
+                        cursor: not-allowed;
                     }
                 }
 

--- a/common/styles/scss/_viewer-app.scss
+++ b/common/styles/scss/_viewer-app.scss
@@ -259,13 +259,21 @@
 
             .annotation-form-container, .annotation-list{
                 margin-bottom: 20px;
+                position: relative;
+            }
+            
+            .annotation-spinner {
+                #spinner {
+                    top: 200px;
+                    // width: 160px;
+                    // height: 90px;
+                }
             }
 
             .annotation-form-container{
                 border: 1px solid #d9d9d9;
                 border-radius: 3px;
                 background: #f8f8f8;
-                position: relative;
                 
                 .form-spinner-overlay {
                     position: absolute;

--- a/record/index.html.in
+++ b/record/index.html.in
@@ -38,8 +38,8 @@
                                 </button>
                                 <!-- download CSV included by default -->
                                 <export reference="reference" style="position:relative;" disabled="!displayReady"></export>
-                                <button ng-disabled="!displayReady || tuple == null" id="share" class="chaise-btn chaise-btn-primary" ng-click="ctrl.sharePopup()" uib-tooltip="Click here to show the share dialog." tooltip-placement="bottom">
-                                    <span class="chaise-btn-icon glyphicon glyphicon-share"></span>
+                                <button ng-disabled="!displayReady || tuple == null || ctrl.waitingForSharePopup" id="share" class="chaise-btn chaise-btn-primary" ng-click="ctrl.sharePopup()" uib-tooltip="Click here to show the share dialog." tooltip-placement="bottom">
+                                    <span class="chaise-btn-icon glyphicon" ng-class="{'glyphicon-refresh glyphicon-refresh-animate': ctrl.waitingForSharePopup, 'glyphicon-share': !ctrl.waitingForSharePopup}"></span>
                                     <span>Share and cite</span>
                                 </button>
                             </div>

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -104,7 +104,12 @@
 
         // this function assumes tuple and reference are attached to the $rootScope
         vm.sharePopup = function() {
-            modalUtils.openSharePopup($rootScope.tuple, $rootScope.reference);
+            vm.waitingForSharePopup = true;
+            modalUtils.openSharePopup($rootScope.tuple, $rootScope.reference).then(function () {
+                vm.waitingForSharePopup = false;
+            }).catch(function (err) {
+                // the promise won't be rejected
+            });
         };
 
         vm.toRecordSet = function(ref) {

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -93,6 +93,12 @@
                 var messageType = data.messageType;
                 // console.log("event received : ", event);
                 switch (messageType) {
+                    case 'osdInitialized':
+                        AnnotationsService.loadAnnotations($rootScope.annotationURLs);
+                        break;
+                    case 'annotationsLoaded':
+                        $rootScope.loadingAnnotations = false;
+                        break;
                     case 'annotationDrawn':
                         vm.newAnnotation.shape = data.content.shape;
                         $scope.$apply(function() {
@@ -126,7 +132,6 @@
                         })
                         break;
                     case "onChangeStrokeScale":
-                        // console.log(data)
                         $scope.$apply(function(){
                             vm.strokeScale = +data.content.strokeScale.toFixed(2);
                         });
@@ -143,12 +148,12 @@
                             vm.saveAnatomySVGFile(data);
                         })
                         break;
-                    // The following cases are already handled elsewhere or are
-                    // no longer needed but the case is repeated here to avoid
-                    // triggering the default case.
-                    case 'annotoriousReady': // handled in viewer.app.js.
-                    case 'onHighlighted':
-                    case 'onUnHighlighted':
+                    case 'disableAnnotationSidebar':
+                        $rootScope.disableAnnotationSidebar = (data === true);
+                        break;
+                    case 'errorAnnotation':
+                        AlertsService.addAlert("Couldn't parse the given annotation.", "warning");
+                        console.log("annotation error: ", data);
                         break;
                 }
             } else {

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -133,7 +133,6 @@
                         break;
                     case "updateAnnotationList":
                         $scope.$apply(function(){
-                            console.log("here");
                             _addAnnotationToList(data.content);
                             vm.updateDisplayNum();
                         })
@@ -773,8 +772,22 @@
                     }
                 ]
             };
+                
+            // to disable all the share buttons
+            vm.waitingForSharePopup = true;
             
-            modalUtils.openSharePopup(item.tuple, $rootScope.annotationEditReference, moreInfo);
+            // to show the loader
+            item.waitingForSharePopup = true;
+
+            modalUtils.openSharePopup(item.tuple, $rootScope.annotationEditReference, moreInfo).then(function () {
+                if (!item.isSelected) {
+                    highlightGroup(item, event);
+                }
+                vm.waitingForSharePopup = false;
+                item.waitingForSharePopup = false;
+            }).catch(function () {
+                //
+            });
 
             event.stopPropagation();
             event.preventDefault();

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -159,6 +159,10 @@
         function saveAnnotationRecord(data){
             iframe.postMessage({messageType: 'saveAnnotationRecord', content: data}, origin);
         }
+        
+        function loadAnnotations(data) {
+            iframe.postMessage({messageType: 'loadAnnotations', content: data}, origin);
+        }
 
         return {
             drawAnnotation: drawAnnotation,
@@ -177,7 +181,8 @@
             addNewTerm : addNewTerm,
             removeEntry : removeEntry,
             removeSVG : removeSVG,
-            saveAnnotationRecord : saveAnnotationRecord
+            saveAnnotationRecord : saveAnnotationRecord,
+            loadAnnotations: loadAnnotations
         };
 
     }]);

--- a/viewer/constant.js
+++ b/viewer/constant.js
@@ -14,6 +14,9 @@
             DEFAULT_Z_INDEX_COLUMN_NAME: "Default_Z" // the default value of the zindex in the form TODO
         },
         annotation: {
+            // how many annotations at a time should we read from database
+            PAGE_COUNT: 25,
+            
             // annotation table
             ANNOTATION_TABLE_NAME: "Image_Annotation",
             ANNOTATION_TABLE_SCHEMA_NAME: "Gene_Expression",

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -217,15 +217,15 @@
                                                     </a>
                                                 </span>
                                                 <span class='editRow'>
-                                                    <span class='editBtn' ng-click="anno.toggleDisplay(item, $event)" data-type='toggleDisplay' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{ item.isDisplay ? 'Hide annotation' : 'Show annotation'}}">
+                                                    <button class='editBtn' ng-click="anno.toggleDisplay(item, $event)" data-type='toggleDisplay' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{ item.isDisplay ? 'Hide annotation' : 'Show annotation'}}">
                                                         <i ng-class="item.isDisplay ? 'glyphicon glyphicon-eye-open' : 'glyphicon glyphicon-eye-close'"></i>
-                                                    </span>
-                                                    <span ng-show="canUpdate" class="editBtn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
+                                                    </button>
+                                                    <button ng-show="canUpdate" class="editBtn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
                                                         <i class="glyphicon glyphicon-pencil"></i>
-                                                    </span>
-                                                    <span ng-if="item.tuple" class="editBtn" tooltip-placement="bottom" uib-tooltip="Share Annotation" ng-click="anno.shareAnnotation(item, $index, $event)">
-                                                        <span class="chaise-btn-icon glyphicon glyphicon-share"></span>
-                                                    </span>
+                                                    </button>
+                                                    <button ng-if="item.tuple" class="editBtn" tooltip-placement="bottom" uib-tooltip="Share Annotation" ng-click="anno.shareAnnotation(item, $index, $event)" ng-disabled="anno.waitingForSharePopup">
+                                                        <i class="chaise-btn-icon glyphicon" ng-class="{'glyphicon-refresh glyphicon-refresh-animate': item.waitingForSharePopup, 'glyphicon-share': !item.waitingForSharePopup}"></i>
+                                                    </button>
                                                 </span>
                                             </div>
                                         </span>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -41,12 +41,6 @@
                             <button ng-click="osd.filterChannels();" class="btn chaise-btn chaise-btn-primary" ng-class="{'pick':osd.filterChannelsAreHidden}" type="button" role="button" uib-tooltip="channel filtering" id="filter-btn">
                                 <span class="glyphicon glyphicon-tasks"></span> {{osd.filterChannelsAreHidden ? "Hide" : "Show" }} Channels
                             </button>
-                            <!-- <button ng-click="osd.openAnnotations();" class="btn chaise-btn chaise-btn-primary" type="button" ng-class="{'pick':!hideAnnotationSidebar}" role="button" title="edit annotations" id="edit-btn">
-                                <span class="glyphicon glyphicon-edit"></span> Annotations
-                            </button> -->
-                            <!-- <button ng-click="osd.toggleAnnotations();" class="btn chaise-btn chaise-btn-primary" ng-class="{'pick': osd.annotationsAreHidden}" type="button" role="button" title="hide or show annotations" id="hide-btn">
-                                <span class="glyphicon glyphicon-eye-close"></span> Hide
-                            </button> -->
                             <button ng-click="osd.zoomInView();" class="btn chaise-btn chaise-btn-primary" type="button" role="button" uib-tooltip="zoom in" id="zoomin-btn">
                                 <span class="glyphicon glyphicon-zoom-in"></span> Zoom In
                             </button>
@@ -56,8 +50,10 @@
                             <button ng-click="osd.homeView();" class="btn chaise-btn chaise-btn-primary" type="button" role="button" uib-tooltip="reset" id="gohome-btn">
                                 <span class="glyphicon glyphicon-home"></span> Reset
                             </button>
-                            <button ng-click="osd.downloadView();" class="btn chaise-btn chaise-btn-primary" type="button" role="button" uib-tooltip="take snapshot" id="download-btn">
-                                <span class="glyphicon glyphicon-camera"></span> Take a Screenshot </button>
+                            <button ng-click="osd.downloadView();" class="btn chaise-btn chaise-btn-primary" type="button" role="button" uib-tooltip="take snapshot" id="download-btn" ng-disabled="osd.waitingForScreenshot">
+                                <span class="chaise-btn-icon glyphicon" ng-class="{'glyphicon-refresh glyphicon-refresh-animate': osd.waitingForScreenshot, 'glyphicon-camera': !osd.waitingForScreenshot}"></span>
+                                <span>Take a Screenshot</span>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -175,6 +175,8 @@
                                 </div>
                             </div>
                             <div class='annotation-list' ng-show="anno.editingAnatomy == null">
+                                <!-- message="Loading annotations..." -->
+                                <loading-spinner class="annotation-spinner" ng-if="loadingAnnotations"></loading-spinner>
                                 <span class='row filter' data-type='overlayVisibility'>
                                     <span class='name'> Display : </span>
                                     <span ng-click="anno.changeAllAnnotationsVisibility();" ng-class="anno.isDisplayAll ?'displayAllBtn selected' : 'displayAllBtn'" data-type='all'>
@@ -201,7 +203,7 @@
                                     <button ng-show="canCreate" class='btn chaise-btn chaise-btn-primary newAnnoBtn' ng-click="anno.addNewTerm()" tooltip-placement="bottom" uib-tooltip="Create new annotation">New</button>
                                 </div>
                                 <span class='resultCount'>
-                                    <span>Displaying {{ anno.matchCount }} of {{ anno.totalCount }} Annotations</span>
+                                    <span>Displaying {{ anno.matchCount }} <span ng-if="!loadingAnnotations"> of {{ anno.totalCount }} </span>Annotations</span>
                                 </span>
                                 <div ng-if="osd.error != ''" class="annotation-error">
                                     {{osd.error}}

--- a/viewer/osd/osd.controller.js
+++ b/viewer/osd/osd.controller.js
@@ -50,28 +50,6 @@
                 var messageType = data.messageType;
 
                 switch (messageType) {
-                    case "disableAnnotationList":
-                        $scope.$apply(function(){
-                            // Note: This logic need to change
-                            // users should still be able to open annotation list if there's no annotation
-                            // the following two lines are commented for demo purpose
-                            // $rootScope.disableAnnotationSidebar = data.content;
-                            // TODO should be moved to annotation controller
-                            $rootScope.hideAnnotationSidebar = data.content;
-                            // var sidebarptr=$('#sidebar');
-                            // if(data.content) {
-                            //   sidebarptr.css("display","none");
-                            //   } else {
-                            //     sidebarptr.css("display","block");
-                            // }
-
-                        });
-                        break;
-                    case "errorAnnotation":
-                        $scope.$apply(function(){
-                            vm.error = "No data in svg found.";
-                        });
-                        break;
                     case "hideChannelList":
                         $scope.$apply(function(){
                           vm.filterChannelsAreHidden = !vm.filterChannelsAreHidden;

--- a/viewer/osd/osd.controller.js
+++ b/viewer/osd/osd.controller.js
@@ -55,7 +55,17 @@
                           vm.filterChannelsAreHidden = !vm.filterChannelsAreHidden;
                         });
                         break;
-
+                    case "downloadViewDone":
+                        $scope.$apply(function(){
+                          vm.waitingForScreenshot = false;
+                        });
+                        break;
+                    case "downloadViewError":
+                        $scope.$apply(function(){
+                          vm.waitingForScreenshot = false;
+                          AlertsService.addAlert("Couldn't process the screenshot.", "warning");
+                        });
+                        break;
                     default:
                         // other messages are handled by other controllers
                 }
@@ -73,6 +83,8 @@
                 messageType: 'downloadView',
                 content: filename
             }
+
+            vm.waitingForScreenshot = true;
             iframe.postMessage(obj, origin);
         }
 

--- a/viewer/viewer.utils.js
+++ b/viewer/viewer.utils.js
@@ -1,0 +1,160 @@
+(function() {
+    'use strict';
+
+    angular.module('chaise.viewer')
+
+    .factory('viewerAppUtils', [
+        'annotationCreateForm', 'annotationEditForm', 'ConfigUtils', 'context', 'ERMrest', 'logService', 'recordCreate', 'UriUtils', 'viewerConstant', 
+        '$q', '$rootScope', 
+        function (annotationCreateForm, annotationEditForm, ConfigUtils, context, ERMrest, logService, recordCreate, UriUtils, viewerConstant, 
+                  $q, $rootScope) {
+        
+        var annotConstant = viewerConstant.annotation;
+
+        /** TODO should we move this to osd viewer?
+         * if we cannot show any annotation on the image (osd doesn't support it), 
+         *  - disable the annotation list
+         *  - don't even send a request to database
+         */
+        function canOSDShowAnnotation(osdViewerQueryParams) {
+            var res = false;
+
+            if (!osdViewerQueryParams) {
+                return res;
+            }
+            osdViewerQueryParams.split('&').forEach(function (queryStr) {
+                var qpart = queryStr.split("=");
+                if (qpart.length != 2 || qpart[0] !== "url") return;
+                
+                if (qpart[1].indexOf("info.json") != -1) {
+                    res = true;
+                }
+            });
+            
+            return res;
+        }
+        
+        function readAllAnnotations () {
+            var defer = $q.defer();
+            
+            // TODO should be done in ermrestjs
+            var imageAnnotationURL = context.serviceURL + "/catalog/" + context.catalogID + "/entity/";
+            imageAnnotationURL += UriUtils.fixedEncodeURIComponent(annotConstant.ANNOTATION_TABLE_SCHEMA_NAME) + ":";
+            imageAnnotationURL += UriUtils.fixedEncodeURIComponent(annotConstant.ANNOTATION_TABLE_NAME) + "/";
+            imageAnnotationURL += UriUtils.fixedEncodeURIComponent(annotConstant.REFERENCE_IMAGE_COLUMN_NAME);
+            imageAnnotationURL += "=" + UriUtils.fixedEncodeURIComponent(context.imageID);
+
+            ERMrest.resolve(imageAnnotationURL, ConfigUtils.getContextHeaderParams()).then(function (ref) {
+            
+                if (!ref) {
+                    $rootScope.canCreate = false;
+                    $rootScope.canUpdate = false;
+                    $rootScope.canDelete = false;
+                    return false;
+                }
+                
+                // since we use this for populating edit form, we want this in edit context
+                ref = ref.contextualize.entryEdit;
+
+                // TODO we might be able to refactor this
+                // attach to the $rootScope so it can be used in annotations.controller
+                $rootScope.annotationEditReference = ref;
+
+                $rootScope.canCreate = ref.canCreate || false;
+                $rootScope.canUpdate = ref.canUpdate || false;
+                $rootScope.canDelete = ref.canDelete || false;
+
+                ref.session = $rootScope.session;
+
+                // TODO create and edit should be refactored to reuse the same code
+                // create the edit and create forms
+                var invisibleColumns = [
+                    annotConstant.OVERLAY_COLUMN_NAME,
+                    annotConstant.REFERENCE_IMAGE_VISIBLE_COLUMN_NAME,
+                    annotConstant.Z_INDEX_COLUMN_NAME,
+                    annotConstant.CHANNELS_COLUMN_NAME
+                ];
+                if ($rootScope.canCreate) {
+                    annotationCreateForm.reference = ref.contextualize.entryCreate;
+                    annotationCreateForm.reference.columns.forEach(function (column) {
+                        // remove the invisible (asset, image, z-index, channels) columns
+                        if (invisibleColumns.indexOf(column.name) !== -1) return;
+
+                        annotationCreateForm.columnModels.push(recordCreate.columnToColumnModel(column));
+                    });
+                }
+
+                if ($rootScope.canUpdate) {
+                    annotationEditForm.reference = ref;
+                    annotationEditForm.reference.columns.forEach(function (column) {
+                        // remove the invisible (asset, image, z-index, channels) columns
+                        if (invisibleColumns.indexOf(column.name) !== -1) return;
+
+                        annotationEditForm.columnModels.push(recordCreate.columnToColumnModel(column));
+                    });
+                }
+                
+                // TODO not used
+                $rootScope.showColumnSpinner = [{}];
+                
+                $rootScope.annotationTuples = [];
+                $rootScope.annotationURLs = [];
+
+                // using edit, because the tuples are used in edit context (for populating edit form)
+                return _readAnnotations(ref);
+            }).then(function (res) {
+                defer.resolve(res);
+            }).catch(function (err) {
+                defer.reject(err);
+            });
+
+            return defer.promise;
+        }
+        
+        /**
+         * read all the annotaitons on the image.
+         * depending on the number of annotations in db, it might send multiple requests
+         */ 
+        function _readAnnotations (ref) {
+            var defer = $q.defer();
+            var logObj = {
+                action: logService.getActionString(logService.logActions.VIEWER_ANNOT_LOAD),
+                stack: logService.getStackObject()
+            };
+
+            ref.read(annotConstant.PAGE_COUNT, logObj, false, true).then(function (page){
+                if (page && page.length > 0) {
+                    $rootScope.annotationTuples = $rootScope.annotationTuples.concat(page.tuples);
+                    
+                    page.tuples.forEach(function (tuple) {
+                        if(tuple.data && tuple.data[annotConstant.OVERLAY_COLUMN_NAME]){
+                            $rootScope.annotationURLs.push(tuple.data[annotConstant.OVERLAY_COLUMN_NAME]);
+                            
+                            $rootScope.hideAnnotationSidebar = false;
+                        }
+                    });
+                } else {
+                    return false;
+                }
+                
+                if (page.hasNext) {
+                    return _readAnnotations(page.next);
+                }
+                return true;
+            }).then(function (res) {
+                defer.resolve(res);
+            }).catch(function (err) {
+                defer.reject(err);
+            });
+            
+            return defer.promise;
+        }
+        
+        return {
+            readAllAnnotations: readAllAnnotations,
+            canOSDShowAnnotation: canOSDShowAnnotation
+        };
+        
+    }]);
+    
+})();


### PR DESCRIPTION
This PR will,

- Add a spinner to the share button to signal users that we're waiting for the popup (in both record and viewer app).
- Introduce a new method of passing annotations to osd viewer by using messages (instead of URL parameter).
- Fix the `Image_Annotation` read request to properly send multiple requests (instead of assuming there will be less than 200 rows).
- Display spinner for the screenshot button based on changes in [osd viewer#40](https://github.com/informatics-isi-edu/openseadragon-viewer/pull/40) PR.
- Change the color of buttons in the annotation sidebar to be aligned with the rest of the chaise buttons.
