### PR TITLE
Dropdown headers

### DIFF
--- a/chaise-config-sample.js
+++ b/chaise-config-sample.js
@@ -73,9 +73,14 @@ var chaiseConfig = {
             //      }
             // },
             // {
-            //      // URLs support templating primarily for catalog substition
+            //     // URLs support templating primarily for catalog substition
             //     name: "Create",
             //     url: "/chaise/recordedit/#{{$catalog.snapshot}}/YOUR_SCHEMA:YOUR_TABLE"
+            // },
+            // {
+            //     // set header to true to create an unclickable bold menu option with class `chaise-dropdown-header`
+            //     name: "A header",
+            //     header: true
             // }
         ]
     },

--- a/common/styles/scss/_navbar.scss
+++ b/common/styles/scss/_navbar.scss
@@ -70,6 +70,11 @@ body > .container {
     color: $disabled-color;
 }
 
+.chaise-dropdown-header {
+    font-size: $font-size;
+    color: $primary-color;
+}
+
 .dropdown-submenu {
     position: relative;
 }

--- a/common/styles/scss/_navbar.scss
+++ b/common/styles/scss/_navbar.scss
@@ -70,9 +70,11 @@ body > .container {
     color: $disabled-color;
 }
 
+.dropdown-menu>li>a.chaise-dropdown-header,
 .chaise-dropdown-header {
     font-size: $font-size;
     color: $black-color;
+    font-weight: 600;
 }
 
 .dropdown-submenu {

--- a/common/styles/scss/_navbar.scss
+++ b/common/styles/scss/_navbar.scss
@@ -72,7 +72,7 @@ body > .container {
 
 .chaise-dropdown-header {
     font-size: $font-size;
-    color: $primary-color;
+    color: $black-color;
 }
 
 .dropdown-submenu {

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -17,7 +17,7 @@
         <div class="collapse navbar-collapse navbar-inverse" id="fb-navbar-main-collapse">
             <ul id="navbar-menu" class="nav navbar-nav">
                 <li ng-repeat="item in menu" class="dropdown" on-toggle="onToggle(open, item)" ng-if="canShow(item)" uib-dropdown>
-                    <a ng-if="!item.children || !canEnable" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+                    <a ng-if="!item.children || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
                     <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" uib-dropdown-toggle>{{item.name}} <span class="caret"></span></a>
                     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
                 </li>

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -17,8 +17,8 @@
         <div class="collapse navbar-collapse navbar-inverse" id="fb-navbar-main-collapse">
             <ul id="navbar-menu" class="nav navbar-nav">
                 <li ng-repeat="item in menu" class="dropdown" on-toggle="onToggle(open, item)" ng-if="canShow(item)" uib-dropdown>
-                    <a ng-if="!item.children || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
-                    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" uib-dropdown-toggle>{{item.name}} <span class="caret"></span></a>
+                    <a ng-if="!item.children && canShow(item) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+                    <a ng-if="item.children && canShow(item)" class="dropdown-toggle" uib-dropdown-toggle>{{item.name}} <span class="caret"></span></a>
                     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
                 </li>
             </ul>

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -17,8 +17,8 @@
         <div class="collapse navbar-collapse navbar-inverse" id="fb-navbar-main-collapse">
             <ul id="navbar-menu" class="nav navbar-nav">
                 <li ng-repeat="item in menu" class="dropdown" on-toggle="onToggle(open, item)" ng-if="canShow(item)" uib-dropdown>
-                    <a ng-if="!item.children && canShow(item) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
-                    <a ng-if="item.children && canShow(item)" class="dropdown-toggle" uib-dropdown-toggle>{{item.name}} <span class="caret"></span></a>
+                    <a ng-if="!item.children || !canEnable" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+                    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" uib-dropdown-toggle>{{item.name}} <span class="caret"></span></a>
                     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
                 </li>
             </ul>

--- a/common/templates/navbarMenu.html
+++ b/common/templates/navbarMenu.html
@@ -1,5 +1,5 @@
 <li ng-repeat="item in menu" ng-class="{'dropdown-submenu': item.children && canEnable(item)}" ng-if="canShow(item)">
-    <strong ng-if="item.header == true" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
+    <strong ng-if="canShow(item) && item.header == true" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
     <a ng-if="!item.children && canShow(item) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
     <a ng-if="item.children && canShow(item)" class="dropdown-toggle" ng-class="{'disable-link': !canEnable(item)}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>

--- a/common/templates/navbarMenu.html
+++ b/common/templates/navbarMenu.html
@@ -1,5 +1,6 @@
 <li ng-repeat="item in menu" ng-class="{'dropdown-submenu': item.children && canEnable(item)}" ng-if="canShow(item)">
-    <a ng-if="!item.children || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+    <strong ng-if="item.header" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
+    <a ng-if="(!item.children || !canEnable(item)) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
     <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" ng-class="{'disable-link': !canEnable(item)}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
 </li>

--- a/common/templates/navbarMenu.html
+++ b/common/templates/navbarMenu.html
@@ -1,6 +1,6 @@
 <li ng-repeat="item in menu" ng-class="{'dropdown-submenu': item.children && canEnable(item)}" ng-if="canShow(item)">
-    <strong ng-if="item.header" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
-    <a ng-if="(!item.children || !canEnable(item)) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
-    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" ng-class="{'disable-link': !canEnable(item)}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
+    <strong ng-if="item.header == true" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
+    <a ng-if="!item.children && canShow(item) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+    <a ng-if="item.children && canShow(item)" class="dropdown-toggle" ng-class="{'disable-link': !canEnable(item)}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
 </li>

--- a/common/templates/navbarMenu.html
+++ b/common/templates/navbarMenu.html
@@ -1,6 +1,8 @@
 <li ng-repeat="item in menu" ng-class="{'dropdown-submenu': item.children && canEnable(item)}" ng-if="canShow(item)">
-    <strong ng-if="canShow(item) && item.header == true" class="dropdown-header chaise-dropdown-header">{{item.name}}</strong>
-    <a ng-if="!item.children && canShow(item) && item.url" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
-    <a ng-if="item.children && canShow(item)" class="dropdown-toggle" ng-class="{'disable-link': !canEnable(item)}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
+    <span ng-if="item.header == true && !item.children && !item.url" class="dropdown-header chaise-dropdown-header">{{item.name}}</span>
+    <!-- the following case is for showing a url link or a disabled menu that has children -->
+    <a ng-if="(!item.children && item.url) || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item), 'chaise-dropdown-header': item.header == true}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+    <!-- the following case is for showing an enabled menu that has children -->
+    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" ng-class="{'chaise-dropdown-header': item.header == true}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
 </li>

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -4,6 +4,17 @@
 
 A Chaise deployment includes a sample config file ([chaise-config-sample.js](https://github.com/informatics-isi-edu/chaise/blob/master/chaise-config-sample.js)) at the root directory that you can edit and then rename to `chaise-config.js`.
 
+Each chaise config property below can be defined in each place that we allow for a chaise configuration with a few exceptions noted below. Chaise config uses a set order for determining which chaise configuration's properties will be used. The order that the properties will be checked and then applied are as follows:
+  1. Default values defined in [chaise configuration document](https://github.com/informatics-isi-edu/chaise/blob/master/docs/user-docs/chaise-config.md).
+  2. Any properties defined at the root of the object returned from [chaise-config.js](https://github.com/informatics-isi-edu/chaise/blob/master/chaise-config-sample.js).
+  3. Any matching `configRules` in the order they appear in the `configRules` array. Properties in the last matching rule will take precedence
+  4. Any properties defined at the root of the object returned from this annotation.
+  5. Step 3 from above, but with the `configRules` from this annotation.
+
+Notes: is that as the `configRules` are checked, properties set in step 2 will be overridden by properties defined in step 3 that have the same name. This allows the server wide configuration to be a base configuration for the chaise apps and allows for further configuration based on a combination of hostname and catalog id. This applies for step 4 and 5 as well when reading the values from the catalog annotation.
+
+If a property appears in the same configuration twice, the property defined later will be used.
+
 The below table explains the usage of the default parameters:
 
 | Parameter | Values | Default Value | chaise-config.js | URL | Remarks |
@@ -26,7 +37,7 @@ The below table explains the usage of the default parameters:
 | defaultTables | An object that specifies a catalog's the default schema and table | N/A | "defaultTables": {N: {"schema": S, "table": T}, ...} | N/A | Use this parameter to specify for each catalog `N`, which table `T` Chaise shows by default. |
 | signUpURL | A URL | N/A | "signUpURL":\<your_URL\> | N/A | Use this parameter to specify what the "Sign Up" link in the navbar should link to. If `signUpURL` is unspecified, the navbar will not display a "Sign Up" link. |
 | profileURL | A URL | N/A | "profileURL":\<your_URL\> | N/A | When a user is logged in, the navbar displays the user's username. Use this parameter to specify what the username in the navbar should link to (e.g. `https://app.globus.org/account` if your deployment uses Globus authentication). If `profileURL` is unspecified, the navbar will display the username as regular text. |
-| navbarMenu | An object | N/A | "navbarMenu":\{...\} | N/A | Use this parameter to customize the menu items displayed in the navbar at the top of all Chaise apps by supplying an object with your links and/or dropdown menus. Each option accepts an 'acls' object that has two attribute arrays ('show' and 'enable') used to define lists of globus groups or users that can see and click that link. The `url` property of each menu object allows for templating of the catalog id parameter using handlebars. Consult the _chaise-config.js_ file for more details about format. |
+| navbarMenu | An object | N/A | "navbarMenu":\{...\} | N/A | Use this parameter to customize the menu items displayed in the navbar at the top of all Chaise apps by supplying an object with your links and/or dropdown menus. Each option accepts an 'acls' object that has two attribute arrays ('show' and 'enable') used to define lists of globus groups or users that can see and click that link. The `url` property of each menu object allows for templating of the catalog id parameter using handlebars. The `header` property of each menu object will create an unclickable bold header with class `chaise-dropdown-header`. Consult the _chaise-config-sample.js_ file for more details about format. |
 | sidebarPosition | "left" <br> "right" | "right" | "sidebarPosition": \<value\> | N/A | Applies to the Search app only. If \<value\> is "left", the sidebar will be on the left and the main content will shift left correspondingly. If \<value\> is "right", the sidebar will be on the right. |
 | attributesSidebarHeading | String | "Choose Attributes" | "attributesSidebarHeading": \<value\> | N/A | Applies to Search app only. Use this parameter to customize the heading displayed in at the top of the Attributes sidebar (usually the first sidebar that appears when the Search app loads). |
 | userGroups | An object | N/A | "userGroups" : {"curators": <group id>, "annotators": <group id>, "curators": <group id>} | N/A | For Viewer app only. The Viewer app assigns an authenticated user one of three permission levels depending on the user's Globus memberships. The permission levels, from highest to lowest, are `curator`, `annotator`, `user`. The default Globus group IDs that determine who's a `curator`, `annotator`, or `user` are set by [RBK](https://github.com/informatics-isi-edu/rbk-project). To override these default group IDs for each permission level, you may specify your own via this `userGroups` setting.

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -46,6 +46,10 @@ var chaiseConfig = {
                 name: "RecordEdit",
                 children: [
                     {
+                        name: "For Mutating Data",
+                        header: true
+                    },
+                    {
                         name: "Add Records",
                         url: "/chaise/recordedit/#1/isa:dataset",
                         acls: {

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -37,6 +37,7 @@ var chaiseConfig = {
             },
             {
                 name: "Records",
+                url: "/chaise/search/#1/isa:dataset",
                 acls: {
                     show: ["https://auth.globus.org/9d596ac6-22b9-11e6-b519-22000aef184d"],
                     enable: []

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -57,7 +57,7 @@ describe('Navbar ', function() {
             var editMenu = menuDropdowns.get(3);
             // need to open menu so it renders and has a value
             editMenu.click().then(function () {
-                subMenuHeader = editMenu.all(by.css("strong.chaise-dropdown-header"));
+                subMenuHeader = editMenu.all(by.css("span.chaise-dropdown-header"));
                 expect(subMenuHeader.get(0).getText()).toBe("For Mutating Data", "Sub menu header is incorrect or not showing");
 
                 return editMenu.all(by.css("a.disable-link"));

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -34,9 +34,9 @@ describe('Navbar ', function() {
     it('for the menu, should generate the correct # of list items based on acls to show/hide specific options', function() {
         var nodesInDOM = menu.all(by.tagName('li'));
         // Count the number of nodes that are being shown (top level and submenus)
-        //   - Local: config has 12 but 1 is hidden by ACLs
-        //   - Travis: config has 12 but 7 are hidden based on ACLs
-        var counter = (!process.env.TRAVIS ? 11 : 5); // counted from chaise config doc rather than having code count
+        //   - Local: config has 13 but 1 is hidden by ACLs
+        //   - Travis: config has 13 but 7 are hidden based on ACLs
+        var counter = (!process.env.TRAVIS ? 12 : 6); // counted from chaise config doc rather than having code count
 
         nodesInDOM.count().then(function(count) {
             expect(count).toEqual(counter, "number of nodes present does not match what's defined in chaise-config");
@@ -44,7 +44,7 @@ describe('Navbar ', function() {
     });
 
     if (!process.env.TRAVIS) {
-        var menuDropdowns, subMenuOptions;
+        var menuDropdowns, disabledSubMenuOptions;
         it('should have a disabled "Records" link.', function () {
             menuDropdowns = element.all(by.css('#navbar-menu > li.dropdown'));
 
@@ -53,17 +53,25 @@ describe('Navbar ', function() {
             expect(menuDropdowns.get(2).element(by.css("a.disable-link")).getText()).toBe("Records", "text is incorrect, may include caret");
         });
 
-        it('should have a disabled "Edit Existing Record" submenu link (no children).', function () {
+        it('should have a header and a disabled "Edit Existing Record" submenu link (no children).', function () {
+            var editMenu = menuDropdowns.get(3);
             // need to open menu so it renders and has a value
-            menuDropdowns.get(3).click().then(function () {
-                subMenuOptions = menuDropdowns.get(3).all(by.css("a.disable-link"));
-                expect(subMenuOptions.get(0).getText()).toBe("Edit Existing Record", "the wrong link is disabled or none were selected");
+            editMenu.click().then(function () {
+                subMenuHeader = editMenu.all(by.css("strong.chaise-dropdown-header"));
+                expect(subMenuHeader.get(0).getText()).toBe("For Mutating Data", "Sub menu header is incorrect or not showing");
+
+                return editMenu.all(by.css("a.disable-link"));
+            }).then(function (options) {
+                disabledSubMenuOptions = options;
+
+                expect(options.length).toBe(4, "some options are not shown properly");
+                expect(disabledSubMenuOptions[0].getText()).toBe("Edit Existing Record", "the wrong link is disabled or none were selected");
             });
         });
 
         it('should have disabled "Edit Records" submenu link (has children)', function () {
             //menu should still be open from previous test case
-            expect(subMenuOptions.get(1).getText()).toBe("Edit Records", "the wrong link is disabled or caret is still visible");
+            expect(disabledSubMenuOptions[1].getText()).toBe("Edit Records", "the wrong link is disabled or caret is still visible");
         });
     }
 


### PR DESCRIPTION
This PR adds functionality to the navbar to include dropdown header options. The structure will look like the following in the chaise config property `navbarMenu`:
```
"children": [{
    "name": "A header",
    "header": true
}, ...
```

Other changes included:
 1. I found a failing test in one of the navbar specs where a menu option wasn't showing properly. ~~After looking at the code, I realized I implemented `canShow` and `canEnable` for the navbar menu options and sub menu options. I used `canEnable` for each of the `ng-if` conditions and never used `canShow`.~~
 2. Modified the condition for the case that we wanted a url link. If there is no url defined, the link won't show at all.
 3. Added more information to `chaise-config.md` pertaining to the order that chaise configurations are interpreted. Included a note about using the "last" defined value if multiple properties of the same name exist.