### PR TITLE
Logging support for viewer app

### DIFF
--- a/common/ellipsis.js
+++ b/common/ellipsis.js
@@ -121,7 +121,9 @@
 
                     // view link
                     if (scope.config.viewable) {
-                        scope.viewLink = tupleReference.contextualize.detailed.appLink;
+                        var viewLink = tupleReference.contextualize.detailed.appLink;
+                        var qCharacter = viewLink.indexOf("?") !== -1 ? "&" : "?";
+                        scope.viewLink = viewLink + qCharacter + "paction=view";
                     }
 
                     // if tupleReference is not defined

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -322,8 +322,6 @@
                 columnModel: '=',
                 model: "=",
                 mode: "@",
-                parentLogStack: "=?",
-                parentLogStackPath: "=?",
                 inputContainer: "=?",
                 formContainer: "=?",
                 isRequired: "=?", // we cannot derive this from the columnModel (for select-all none of the inputs are required)
@@ -361,6 +359,8 @@
                 vm.hasParentModel = false;
                 if (typeof vm.parentModel === "object" && typeof vm.parentReference === "object") {
                     vm.hasParentModel = true;
+                    vm.parentLogStack = vm.parentModel.logStack;
+                    vm.parentLogStackPath = vm.parentModel.parentLogStackPath;
                 }
 
                 vm.customErrorMessage = null;
@@ -469,7 +469,7 @@
                     // log attributes
                     // TODO should eventually be moved outside this function and directly under link
                     //      if we want to do more logs for other column types as well
-                    params.logStack = recordCreate.getColumnModelLogStack(vm.columnModel, vm.parentLogStack);
+                    params.logStack = recordCreate.getColumnModelLogStack(vm.columnModel, vm.parentModel);
                     params.logStackPath = logService.getStackPath(vm.parentLogStackPath, logService.logStackPaths.FOREIGN_KEY_POPUP);
 
                     modalUtils.showModal({

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -296,7 +296,7 @@
             }
         }
     }])
-    
+
     /**
      * This directive can be used to display an appropriate input element based on the given columnModel in a form.
      * Based on the passed values, it can be used in two different modes:
@@ -305,7 +305,7 @@
      * The mode is determined by the directive itself based on the given attributes.
      * If you pass parentModel and parentReference, it will assume that you want the form mode, otherwise it will be in standalone mode.
      * The only noticable difference is just how the scope.model value works (especially in the case of foreignkey inputs).
-     * In standalone mode, 
+     * In standalone mode,
      *  - the initial value of scope.model for foreignkeys is ignored.
      *  - the value of scope.model for foreignkeys is a "tuple" (instead of rowname).
      *  - since we don't have access to the parentModel, there must be a translation layer to properly set the value of foreignkey columns.
@@ -322,6 +322,8 @@
                 columnModel: '=',
                 model: "=",
                 mode: "@",
+                parentLogStack: "=?",
+                parentLogStackPath: "=?",
                 inputContainer: "=?",
                 formContainer: "=?",
                 isRequired: "=?", // we cannot derive this from the columnModel (for select-all none of the inputs are required)
@@ -465,8 +467,10 @@
                     }
 
                     // log attributes
-                    params.logStack = vm.columnModel.logStack;
-                    params.logStackPath = logService.getStackPath("", logService.logStackPaths.FOREIGN_KEY_POPUP);
+                    // TODO should eventually be moved outside this function and directly under link
+                    //      if we want to do more logs for other column types as well
+                    params.logStack = recordCreate.getColumnModelLogStack(vm.columnModel, vm.parentLogStack);
+                    params.logStackPath = logService.getStackPath(vm.parentLogStackPath, logService.logStackPaths.FOREIGN_KEY_POPUP);
 
                     modalUtils.showModal({
                         animation: false,

--- a/common/modal.js
+++ b/common/modal.js
@@ -69,7 +69,9 @@
          *  - hideCitation: hide the citation section
          *  - hideHeader: hides all the section headers.
          *  - extraInformation: An array of objects that will be displayed. Each element can be either
-         *    {value: "string", title: "string"} or {title: "string", value: "string", link: "string", ype: "link"}
+         *    {value: "string", title: "string"} or {title: "string", value: "string", link: "string", type: "link"}
+         *  - logStackPath: if you want to change the default log stack path of the app
+         *  - logStack: if you want to change the default log stack object of the app
          */
         function openSharePopup (tuple, reference, extraParams) {
             var defer = $q.defer();
@@ -85,10 +87,11 @@
             params.versionLink = UriUtils.resolvePermalink(tuple, reference, versionString);
             params.versionDateRelative = UiUtils.humanizeTimestamp(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
             params.versionDate = UiUtils.versionDate(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
-
+            
+            var stack = params.logStack ? params.logStack : logService.getStackObject();
             var snaptimeHeader = {
-                action: logService.getActionString(logService.logActions.SHARE_OPEN),
-                stack: logService.getStackObject(),
+                action: logService.getActionString(logService.logActions.SHARE_OPEN, params.logStackPath),
+                stack: stack,
                 catalog: reference.defaultLogInfo.catalog,
                 schema_table: reference.defaultLogInfo.schema_table
             }
@@ -351,7 +354,8 @@
 
             // log related attributes
             logStack:                  logStack,
-            logStackPath:               params.logStackPath ? params.logStackPath : null,
+            logStackPath:              params.logStackPath ? params.logStackPath : null,
+            logAppMode:                params.logAppMode ? params.logAppMode : null, 
 
             // used for the recordset height and sticky section logic
             // TODO different modals should pass different strings (ultimatly it should be the element and not selector)
@@ -474,7 +478,13 @@
      *   - {String} versionDateRelative - version decoded to it's datetime then presented as relative to today's date
      *   - {boolean} showVersionWarning - decides whether to show "out of date content" warning
      *   - {Object} citation - citation object returned from ERMrest.tuple.citation
-     *
+     *   - {String} title (optional) - will be displayed in the modal title
+     *   - {boolean} hideCitation (optional) - hide the citation section
+     *   - {boolean} hideHeader (optional) - hides all the section headers.
+     *   - {Object[]} extraInformation (optional) - An array of objects that will be displayed. Each element can be either
+     *                {value: "string", title: "string"} or {title: "string", value: "string", link: "string", type: "link"}
+     *   - {Object} logStackPath (optional) - if you want to change the default log stack path of the app
+     *   - {Object} logStack (optional) - if you want to change the default log stack object of the app 
      */
     .controller('ShareCitationController', ['logService', 'params', '$rootScope', '$uibModalInstance', '$window', function (logService, params, $rootScope, $uibModalInstance, $window) {
         var vm = this;
@@ -526,8 +536,8 @@
 
         vm.copyToClipboard = function (text, action) {
             logService.logClientAction({
-                action: logService.getActionString(action),
-                stack: logService.getStackObject()
+                action: logService.getActionString(action, params.logStackPath),
+                stack: params.logStack ? params.logStack : logService.getStackObject()
             }, params.reference.defaultLogInfo);
             // Create a dummy input to put the text string into it, select it, then copy it
             // this has to be done because of HTML security and not letting scripts just copy stuff to the clipboard
@@ -548,8 +558,8 @@
 
         vm.logCitationDownload = function (action) {
             logService.logClientAction({
-                action: logService.getActionString(action),
-                stack: logService.getStackObject()
+                action: logService.getActionString(action, params.logStackPath),
+                stack: params.logStack ? params.logStack : logService.getStackObject()
             }, params.reference.defaultLogInfo);
         }
 

--- a/common/styles/scss/_viewer-app.scss
+++ b/common/styles/scss/_viewer-app.scss
@@ -261,7 +261,7 @@
                 margin-bottom: 20px;
                 position: relative;
             }
-            
+
             .annotation-spinner {
                 #spinner {
                     top: 200px;
@@ -274,7 +274,7 @@
                 border: 1px solid #d9d9d9;
                 border-radius: 3px;
                 background: #f8f8f8;
-                
+
                 .form-spinner-overlay {
                     position: absolute;
                     top: 0;
@@ -285,7 +285,7 @@
                     opacity: 0.5;
                     z-index: 6; // higher than the clear button
                 }
-                
+
                 .form-spinner {
                     // make sure the text is visible in one line
                     #spinner {
@@ -435,6 +435,7 @@
                 position: absolute;
                 right: 5px;
                 top: 5px;
+                cursor: pointer;
             }
 
 
@@ -746,7 +747,7 @@
                     flex-direction: row;
                     align-items: center;
                 }
-                
+
                 // TODO it's called editBtn but used for all the annotation buttons
                 .editBtn{
                     text-decoration: none;
@@ -761,16 +762,16 @@
                     align-items: center;
                     border: none;
                     background: none;
-                    
+
                     // change chaise default color
                     .glyphicon-refresh {
                         color: $primary-color;
                     }
-                    
+
                     &:focus {
                         outline: none;
                     }
-                    
+
                     &:last-child{
                         margin-right: 8px;
                     }
@@ -794,13 +795,13 @@
                         background-color: transparent;
                         margin-top: 8px;
                         margin-right: 2px;
-                        
+
                         .annotation-color-item {
                             height: 100%;
                             float: left;
                         }
                     }
-                    
+
                     .anatomy {
                         flex : 1;
                         padding: 3px;
@@ -909,7 +910,7 @@
 
 // modify the chaise share citation that is displayed for annotations
 #viewer .chaise-share-citation {
-    
+
     li:not(#share-link) {
         h3.share-item-header {
             display: inline-block;
@@ -917,22 +918,22 @@
                 content: ":";
             }
         }
-        
+
         .share-item-value {
             padding-left: 0px;
         }
     }
-    
+
     h3.share-item-header {
         font-size: 1.1em;
         margin-top: 5px;
         margin-bottom: 0px;
     }
-    
+
     .share-item-value {
         padding-left: 10px;
     }
-    
+
     #share-link {
         padding-top: 10px;
     }

--- a/common/table.js
+++ b/common/table.js
@@ -438,8 +438,9 @@
             var hasCauses = Array.isArray(vm.reloadCauses) && vm.reloadCauses.length > 0;
             var act = hasCauses ? logService.logActions.RELOAD : logService.logActions.LOAD;
 
-            // fix the action for add pure and binary popup (the check could be based on getDisabledTuples as well)
-            if (vm.config.displayMode === recordsetDisplayModes.addPureBinaryPopup) {
+            // if getDisabledTuples exists, then this read will load everything (domain values) and the
+            // getDisabledTuples is the actual load/reload
+            if (vm.getDisabledTuples) {
                 act = hasCauses ? logService.logActions.RELOAD_DOMAIN : logService.logActions.LOAD_DOMAIN;
             }
 
@@ -951,7 +952,8 @@
             if (childStackPath) {
                 stackPath = logService.getStackPath(stackPath, childStackPath);
             }
-            return logService.getActionString(actionPath, stackPath);
+            var appMode = vm.logAppMode ? vm.logAppMode : null;
+            return logService.getActionString(actionPath, stackPath, appMode);
         }
 
         /**

--- a/common/table.js
+++ b/common/table.js
@@ -53,6 +53,7 @@
      *        config,       // set of config to disable or enable features
      *        logStack,     // (required) used to capture the stack related to this table.
      *        logStackPath, // (required) used to capture the stack-path related to this table.
+     *        logAppMode,  // (optional) if defined, will be used instead of the default app mode.
      *        logObject (optional) // used only on the first request of main entity read.
      *       }
      *      available config options:

--- a/common/utils.js
+++ b/common/utils.js
@@ -235,7 +235,7 @@
          * @desc
          * Converts a chaise URI to an ermrest resource URI object or string.
          * @returns {string|Object}
-         * if returnObject = true: an object that has 'ermrestURI', `ppid`, 'pcid', and `isQueryParameter`
+         * if returnObject = true: an object that has 'ermrestURI', `ppid`, 'pcid', `paction`, and `isQueryParameter`
          * otherwise it will return the ermrest uri string.
          * @throws {MalformedUriError} if table or catalog data are missing.
          */
@@ -2596,6 +2596,7 @@
          * Returns the appropriate stack object that should be used.
          * If childStackElement passed, it will append it to the existing logStack of the app.
          * @param {Object} childStackElement
+         * @param {Object=} logStack if passed, will be used instead of the default value of the app.
          */
         function getStackObject(childStackNode, logStack) {
             if (!logStack) {
@@ -2622,7 +2623,7 @@
         /**
          * Creates a new stack node given the type, table, and extra information.
          * @param {String} type - one of the logStackTypes
-         * @param {ERMrest.Table} table - the table object of this node
+         * @param {ERMrest.Table=} table - the table object of this node
          * @param {Object=} extraInfo - if you want to attach more info to this node.
          */
         function getStackNode(type, table, extraInfo) {

--- a/common/utils.js
+++ b/common/utils.js
@@ -258,7 +258,7 @@
             var ermrestUri = {},
                 queryParams = {},
                 queryParamsString = "",
-                catalogId, ppid, pcid;
+                catalogId, ppid, pcid, paction;
 
             // remove query params other than limit
             if (hash && hash.indexOf('?') !== -1) {
@@ -278,6 +278,9 @@
                     }
                     if (queries[i].indexOf("ppid=") === 0) {
                         ppid = queries[i].split("=")[1];
+                    }
+                    if (queries[i].indexOf("paction=") === 0) {
+                        paction = queries[i].split("=")[1];
                     }
                     var q_parts = queries[i].split("=");
                     queryParams[decodeURIComponent(q_parts[0])] = decodeURIComponent(q_parts[1]);
@@ -380,6 +383,7 @@
                     hash: originalHash,
                     ppid: ppid,
                     pcid: pcid,
+                    paction: paction,
                     queryParamsString: queryParamsString,
                     queryParams: queryParams,
                     isQueryParameter: isQueryParameter

--- a/common/utils.js
+++ b/common/utils.js
@@ -2342,6 +2342,9 @@
             RELOAD: clientPathActionSeparator + "reload",
             DELETE: clientPathActionSeparator + "delete",
             EXPORT: clientPathActionSeparator + "export",
+            SHARE_OPEN: "share" + clientPathActionSeparator + "open",
+            CREATE: clientPathActionSeparator + "create",
+            UPDATE: clientPathActionSeparator + "update",
 
             // - client:
             CANCEL: clientPathActionSeparator + "cancel",
@@ -2352,6 +2355,9 @@
             EDIT_INTEND: "edit" + clientPathActionSeparator + "intend",
             DELETE_INTEND: "delete" + clientPathActionSeparator + "intend",
             DELETE_CANCEL: "delete" + clientPathActionSeparator + "cancel",
+            SHARE_LIVE_LINK_COPY: "share" + separator + "live" + clientPathActionSeparator + "copy",
+            SHARE_VERSIONED_LINK_COPY: "share" + separator + "version" + clientPathActionSeparator + "copy",
+            CITE_BIBTEXT_DOWNLOAD: "cite" + separator + "bibtex" + clientPathActionSeparator + "download",
 
             // recordset app and table:
 
@@ -2394,7 +2400,6 @@
             // record app:
 
             // - server:
-            SHARE_OPEN: "share" + clientPathActionSeparator + "open",
             LOAD_DOMAIN: clientPathActionSeparator + "load-domain", // add pure and binary first request
             RELOAD_DOMAIN: clientPathActionSeparator + "reload-domain",
             LINK: clientPathActionSeparator + "link",
@@ -2414,19 +2419,12 @@
             TOC_SCROLL_TOP: "toc" + separator + "main" + clientPathActionSeparator + "scroll-to",
             TOC_SCROLL_RELATED: "toc" + separator + "section" + clientPathActionSeparator + "scroll-to",
 
-            SHARE_LIVE_LINK_COPY: "share" + separator + "live" + clientPathActionSeparator + "copy",
-            SHARE_VERSIONED_LINK_COPY: "share" + separator + "version" + clientPathActionSeparator + "copy",
-
-            CITE_BIBTEXT_DOWNLOAD: "cite" + separator + "bibtex" + clientPathActionSeparator + "download",
-
 
             // recordedit app:
 
             // - server:
             FOREIGN_KEY_PRESELECT: clientPathActionSeparator +  "preselect",
             FOREIGN_KEY_DEFAULT: clientPathActionSeparator + "default",
-            CREATE: clientPathActionSeparator + "create",
-            UPDATE: clientPathActionSeparator + "update",
 
             // - client:
             FORM_CLONE: clientPathActionSeparator + "clone",
@@ -2440,13 +2438,34 @@
 
 
             // viewer app:
+            // TODO viewer logs are a bit different, so for now I just used a prefix for them.
+            //      I should later evaluate this decision and see whether I should remove these prefixes
+            //      after that we should be able to merge some of the actions with the rest of the chaise
 
             // - server:
-            VIEWER_ANNOT_LOAD: "annotation" + clientPathActionSeparator + "read",
-            VIEWER_ANNOT_COMMENT_LOAD: "annotation_comment" + clientPathActionSeparator + "read",
-            VIEWER_COMMENT_LOAD: "commnet" + clientPathActionSeparator + "read",
-            VIEWER_ANATOMY_LOAD: "anatomy" + clientPathActionSeparator + "read",
+            VIEWER_ANNOT_LOAD: clientPathActionSeparator + "load",
+            VIEWER_ANNOT_FETCH: clientPathActionSeparator + "fetch",
 
+            // - client:
+            VIEWER_ANNOT_PANEL_SHOW: "toolbar/panel" + clientPathActionSeparator + "show",
+            VIEWER_ANNOT_PANEL_HIDE: "toolbar/panel" + clientPathActionSeparator + "hide",
+            VIEWER_CHANNEL_SHOW: "toolbar/channel" + clientPathActionSeparator + "show",
+            VIEWER_CHANNEL_HIDE: "toolbar/channel" + clientPathActionSeparator + "hide",
+            VIEWER_SCREENSHOT: "toolbar" + clientPathActionSeparator + "screenshot",
+            VIEWER_ZOOM_RESET: "toolbar" + clientPathActionSeparator + "zoom-reset",
+            VIEWER_ZOOM_IN: "toolbar" + clientPathActionSeparator + "zoom-in",
+            VIEWER_ZOOM_OUT: "toolbar" + clientPathActionSeparator + "zoom-out",
+            // VIEWER_ZOOM_IN_MOUSE: "mouse" + clientPathActionSeparator + "zoom-in",
+            // VIEWER_ZOOM_OUT_MOUSE: "mouse" + clientPathActionSeparator + "zoom-out",
+
+            VIEWER_ANNOT_DISPLAY_ALL: clientPathActionSeparator + "display-all",
+            VIEWER_ANNOT_DISPLAY_NONE: clientPathActionSeparator + "display-none",
+            VIEWER_ANNOT_SHOW: clientPathActionSeparator + "show",
+            VIEWER_ANNOT_HIDE: clientPathActionSeparator + "hide",
+            VIEWER_ANNOT_HIGHLIGHT: clientPathActionSeparator + "highlight",
+
+            VIEWER_ANNOT_DRAW_MODE_SHOW: "draw-mode" + clientPathActionSeparator + "show",
+            VIEWER_ANNOT_DRAW_MODE_HIDE: "draw-mode" + clientPathActionSeparator + "hide",
 
             // - authen:
             LOGOUT_NAVBAR: "navbar/account" + clientPathActionSeparator + "logout",
@@ -2477,7 +2496,10 @@
             FOREIGN_KEY: "fk",
             COLUMN: "col",
             PSEUDO_COLUMN: "pcol",
-            FACET: "facet"
+            FACET: "facet",
+
+            // used in viewer app:
+            ANNOTATION: "annotation"
         });
 
         var logStackPaths = Object.freeze({
@@ -2495,7 +2517,11 @@
             // these two have been added to the tables that recordedit is showing
             //(but not used in logs technically since we're not showing any controls he)
             RESULT_SUCCESFUL_SET: "result-successful-set",
-            RESULT_FAILED_SET: "result-failed-set"
+            RESULT_FAILED_SET: "result-failed-set",
+
+            // used in viewer app:
+            ANNOTATION_ENTITY: "annotation-entity",
+            ANNOTATION_SET: "annotation-set"
         });
 
         var appModes = Object.freeze({
@@ -2570,11 +2596,14 @@
          * If childStackElement passed, it will append it to the existing logStack of the app.
          * @param {Object} childStackElement
          */
-        function getStackObject(childStackNode) {
-            if (childStackNode) {
-                return $rootScope.logStack.concat(childStackNode);
+        function getStackObject(childStackNode, logStack) {
+            if (!logStack) {
+                logStack = $rootScope.logStack;
             }
-            return $rootScope.logStack;
+            if (childStackNode) {
+                return logStack.concat(childStackNode);
+            }
+            return logStack;
         }
 
         /**
@@ -2596,10 +2625,10 @@
          * @param {Object=} extraInfo - if you want to attach more info to this node.
          */
         function getStackNode(type, table, extraInfo) {
-            var obj = {
-                type: type,
-                s_t: table.schema.name + ":" + table.name
-            };
+            var obj = {type: type};
+            if (table) {
+                obj.s_t = table.schema.name + ":" + table.name;
+            }
             if (typeof extraInfo === "object" && extraInfo !== null) {
                 for (var k in extraInfo) {
                     if (!extraInfo.hasOwnProperty(k)) continue;

--- a/common/utils.js
+++ b/common/utils.js
@@ -2458,6 +2458,7 @@
             // VIEWER_ZOOM_IN_MOUSE: "mouse" + clientPathActionSeparator + "zoom-in",
             // VIEWER_ZOOM_OUT_MOUSE: "mouse" + clientPathActionSeparator + "zoom-out",
 
+            VIEWER_ANNOT_LINE_THICKNESS: "line-thickness" + clientPathActionSeparator + "adjust",
             VIEWER_ANNOT_DISPLAY_ALL: clientPathActionSeparator + "display-all",
             VIEWER_ANNOT_DISPLAY_NONE: clientPathActionSeparator + "display-none",
             VIEWER_ANNOT_SHOW: clientPathActionSeparator + "show",

--- a/docs/user-docs/logging.md
+++ b/docs/user-docs/logging.md
@@ -92,6 +92,9 @@ Depending on the request, we might log extra attributes that we are gong to list
 
   If the user clicked on a link in the navbar, the `PCID` will properly denote what app the user came from that had the navbar present. A static page that uses the navbar app, will set the `PCID` as `navbar`. Otherwise the appname will be appended (i.e.   `navbar/<appname>`). This is true for the [deriva-webapps](https://github.com/informatics-isi-edu/deriva-webapps/wiki/Logging-in-WebApps#pcid-list) as well.
 
+- `paction`: The action in the parent page that fired the current request. Acceptable values are:
+  - `view`: Available on the first read of the main entity in record page. Indicates that user clicked on "view" button in tabular displays.
+
 - `stack`: This attribute can be found on almost all the requests. It will capture the path that user took to get to the performed action. For example, if the logged request is for when a user interacts with a add pure and binary picker, using this stack you can figure out which main table and related (or inline table) user is interacting with. `stack` is an array of objects that each node can have the following attributes:
   - Required attributes:
     - `s_t`: The end table of this node in the format of `schema:table`.

--- a/docs/user-docs/logging.md
+++ b/docs/user-docs/logging.md
@@ -85,6 +85,7 @@ Depending on the request, we might log extra attributes that we are gong to list
   - `record`
   - `recordset`
   - `recordedit`
+  - `viewer`
   - `navbar`
   - `navbar/record`
   - `navbar/recordset`
@@ -98,8 +99,9 @@ Depending on the request, we might log extra attributes that we are gong to list
 - `stack`: This attribute can be found on almost all the requests. It will capture the path that user took to get to the performed action. For example, if the logged request is for when a user interacts with a add pure and binary picker, using this stack you can figure out which main table and related (or inline table) user is interacting with. `stack` is an array of objects that each node can have the following attributes:
   - Required attributes:
     - `s_t`: The end table of this node in the format of `schema:table`.
+      - As an exception, in viewer app, if an image annotation is derived from file (not database), this value will not be available on the stack object.
 
-    - `type`: The type of the node request. It can be any of: `entity` (row based), `set` (rowset based), `col` (column), `pcol` (pseudo-column), `fk` (foreign key), `related`, `related-inline`, `related-link-picker`, `fk-picker`, `facet-popup`.
+    - `type`: The type of the node request. It can be any of: `entity` (row based), `set` (rowset based), `col` (column), `pcol` (pseudo-column), `fk` (foreign key), `related` (inline or related table), `annotation` (image annotation in viewer app).
 
   - Optional attributes:
     - `filters`: The facet object using the [compressed syntax](#facet-compressed-syntax).
@@ -130,7 +132,7 @@ Depending on the request, we might log extra attributes that we are gong to list
         - `facet-search-box`: Facet search box changed.
         - `facet-plot-relayout`: Users interact with plot and we need to get new info for it.
         - `facet-retry`: Users click on retry for a facet that timed out.
-        - `page-limit`: Change page limit.
+        - `page-limit`: Change displayed number of rows per page.
         - `page-next`: Go to next page,
         - `page-prev`: Go to previous page.
         - `related-create`: New rows have been created for a related table.
@@ -151,9 +153,13 @@ Depending on the request, we might log extra attributes that we are gong to list
 
     - `num_updated`: The number of rows that have been asked to be updated in that request.
 
-    - `updated_keys`: Available only on "update" request, it will return the key columns and their submitted values. It's an object that and the `cols` attribute returns an array of key column names, while `vals` returns an array of values that corresponds to the given `cols` array (So it's an array of arrays).
+    - `updated_keys`: Available only on "update" request, will return the key columns and submitted values. It's an object that and the `cols` attribute returns an array of key column names, while `vals` returns an array of values that corresponds to the given `cols` array (So it's an array of arrays).
 
     - `template`: Used only for the "export" request and will return an object with `displayname` and `type` attributes to give more information about the used export template.
+
+    - `old_thickness`, `new_thickness`: Available only on "line thickness adjustment" client log in viewer app. It will capture the old and new value after user interacted with the UI to change the line thickness.
+
+    - `file`: If the displayed image annotation in viewer app is derived from a while (and not database), `"file": 1` will be added to the stack (`s_t` will not be available.)
 
     - `cqp` (chaise query parameter): When a user uses a link that includes the `?` instead of the `#`. These urls are only used to help with google indexing and should be used only for navigating users from search engines to chaise apps.
 
@@ -169,11 +175,16 @@ As it is mentioned in the previous section, `action` is one of the required attr
 
 Where,
 
-- `app-mode` (optional) is used when for apps that have different modes. Currently only recordedit is using app-mode and the possible values are:
-  - `edit`: Edit mode of the app.
-  - `create-copy`: When users end up in this app by clicking on "copy" button in record app.
-  - `create-preselect`: When users end up in this app by clicking on "Add" button of related entities (In this case, we're preselecting the foreignkey relationship between related entity and the main).
-  - `create`: Create mode of the app that is not the other more specific versions.
+- `app-mode` (optional) is used when for apps that have different modes. The following are apps that are using this and the possible values:
+  - recordedit:
+    - `edit`: Edit mode of the app.
+    - `create-copy`: When users end up in this app by clicking on "copy" button in record app.
+    - `create-preselect`: When users end up in this app by clicking on "Add" button of related entities (In this case, we're preselecting the foreignkey relationship between related entity and the main).
+    - `create`: Create mode of the app that is not the other more specific versions.
+  - viewer:
+    - `edit`: When users are editing an annotation.
+    - `create`: When users are creating an annotation.
+    - `create-preselect`: When users click on "edit" button of an annotation that was imported from a file. In this case, technically they are going to create a new annotation record in the database and the annotated term is preselected.
 
 - `stack-path` (optional) is available only when `stack` is used and summarizes the `stack`. To distinguish between each stack nodes in this string, we're using `/`. The values used for each node are:
   - `entity`: Based on `entity` stack node `type`.
@@ -186,6 +197,8 @@ Where,
   - `facet-picker`: Used for facet picker.
   - `fk`: Based on `fk` stack node `type`.
   - `fk-picker`: Used for foreign key picker.
+  - `annotation-set`: Annotation list displayed on the viewer app.
+  - `annotation-entity`: Each individual annotation displayed in annotation list of viewer app.
 
   Based on this, `entity/related-inline` is a possible `stack-path`.
 
@@ -367,6 +380,15 @@ The following url patterns are what's unique about each of these requests and yo
 
 In recordset app, or any of the other places that use the recordset view, e.g, modal pickers, chaise will communicate with server as soon as user interacts with the page as long as we have enough flow-control slots to send the request. So there might be some requests that we generate while the user is interacting with the page that will be discarded. To find the actual request that the user sees on the page, you can use `start_ms`, and `end_ms`. All these reload requests will have these two attributes. If you join all the reload request by `start_ms`, you can find all the requests that we sent when the user started interacting at `start_ms`. So the request with the longest `end_ms` would give you the actual request that users will see on the page.
 
+#### Find number of clicks on the "view" button in recordset app
+
+Clicking on "view" button will navigate users to record page with a specific `paction` value. So you would need to find requests with the following values:
+
+- `cid=record`
+- `pcid=recordset`
+- `paction=view`
+
+If you're interested in doing this for each specific table, you can choose to do so by further filtering this with the value of `schema_table`.
 
 ## Change Log
 

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -74,6 +74,7 @@
         var ermrestUri = res.ermrestUri,
             pcid = res.pcid,
             ppid = res.ppid,
+            paction = res.paction,
             isQueryParameter = res.isQueryParameter;
 
         context.catalogID = res.catalogId;
@@ -104,6 +105,7 @@
                 var logObj = {};
                 if (pcid) logObj.pcid = pcid;
                 if (ppid) logObj.ppid = ppid;
+                if (paction) logObj.paction = paction;
                 if (isQueryParameter) logObj.cqp = 1;
 
 

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -269,7 +269,7 @@
             params.facetPanelOpen = false;
 
             var columnModel = vm.recordEditModel.columnModels[columnIndex];
-            params.logStack = columnModel.logStack;
+            params.logStack = recordCreate.getColumnModelLogStack(columnModel);
             params.logStackPath = logService.getStackPath("", logService.logStackPaths.FOREIGN_KEY_POPUP);
 
             modalUtils.showModal({
@@ -588,8 +588,8 @@
 
             var action = model.showSelectAll ? logService.logActions.SET_ALL_CLOSE : logService.logActions.SET_ALL_OPEN;
             logService.logClientAction({
-                action: logService.getActionString(action, model.logStackPath),
-                stack: model.logStack
+                action: recordCreate.getColumnModelLogAction(model, action),
+                stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
             if (selectAllOpen) {
@@ -653,8 +653,8 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: logService.getActionString(logService.logActions.SET_ALL_CANCEL, model.logStackPath),
-                stack: model.logStack
+                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_CANCEL),
+                stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
             model.showSelectAll = false;
@@ -752,8 +752,8 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: logService.getActionString(logService.logActions.SET_ALL_APPLY, model.logStackPath),
-                stack: model.logStack
+                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_APPLY),
+                stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
             setValueAllInputs(index, model.allInput);
@@ -764,8 +764,8 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: logService.getActionString(logService.logActions.SET_ALL_CLEAR, model.logStackPath),
-                stack: model.logStack
+                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_CLEAR),
+                stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
             var value = null;

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -588,7 +588,7 @@
 
             var action = model.showSelectAll ? logService.logActions.SET_ALL_CLOSE : logService.logActions.SET_ALL_OPEN;
             logService.logClientAction({
-                action: recordCreate.getColumnModelLogAction(model, action),
+                action: recordCreate.getColumnModelLogAction(action, model),
                 stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
@@ -653,7 +653,7 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_CANCEL),
+                action: recordCreate.getColumnModelLogAction(logService.logActions.SET_ALL_CANCEL, model),
                 stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
@@ -752,7 +752,7 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_APPLY),
+                action: recordCreate.getColumnModelLogAction(logService.logActions.SET_ALL_APPLY, model),
                 stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 
@@ -764,7 +764,7 @@
 
             var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
             logService.logClientAction({
-                action: recordCreate.getColumnModelLogAction(model, logService.logActions.SET_ALL_CLEAR),
+                action: recordCreate.getColumnModelLogAction(logService.logActions.SET_ALL_CLEAR, model),
                 stack: recordCreate.getColumnModelLogStack(model)
             }, defaultLogInfo);
 

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -98,7 +98,9 @@
                         AnnotationsService.loadAnnotations($rootScope.annotationURLs);
                         break;
                     case 'annotationsLoaded':
-                        $rootScope.loadingAnnotations = false;
+                        $scope.$apply(function(){
+                            $rootScope.loadingAnnotations = false;
+                        });
                         break;
                     case 'annotationDrawn':
                         vm.newAnnotation.shape = data.content.shape;
@@ -146,10 +148,12 @@
                     case "saveGroupSVGContent":
                         $scope.$apply(function(){
                             vm.saveAnatomySVGFile(data);
-                        })
+                        });
                         break;
                     case 'disableAnnotationSidebar':
-                        $rootScope.disableAnnotationSidebar = (data === true);
+                        $scope.$apply(function(){
+                            $rootScope.disableAnnotationSidebar = (data.content === true);
+                        });
                         break;
                     case 'errorAnnotation':
                         AlertsService.addAlert("Couldn't parse the given annotation.", "warning");

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -421,6 +421,12 @@
                         row.reference.table,
                         row.reference.filterLogInfo
                     );
+                } else {
+                    obj.logStackNode = logService.getStackNode(
+                        logService.logStackTypes.ANNOTATION,
+                        null,
+                        {"file": 1}
+                    );
                 }
 
                 vm.annotationModels.push(obj);
@@ -534,8 +540,8 @@
                         logService.logActions.VIEWER_ANNOT_LINE_THICKNESS,
                         null,
                         {
-                            old_value: oldStrokeScale,
-                            new_value: vm.strokeScale
+                            old_thickness: oldStrokeScale,
+                            new_thickness: vm.strokeScale
                         }
                     );
                 }
@@ -1086,6 +1092,7 @@
             // TODO why pass vm??
             // TODO the last element is logObject, should be changed later...
             recordCreate.addRecords(isUpdate, null, formModel, false, formModel.reference, [originalTuple], {}, vm, function (formModel, result) {
+                formModel.submissionButtonDisabled = true;
 
                 var afterMutation = function (tuple) {
 
@@ -1117,6 +1124,7 @@
 
                     vm.updateDisplayNum();
                     vm.closeAnnotationForm();
+                    formModel.submissionButtonDisabled = false;
 
                     AlertsService.addAlert("Your data has been saved.", "success");
                 };

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -717,8 +717,8 @@
                     size: "sm",
                     resolve: {
                         params: {
-                            buttonAction: "Discard",
-                            message: "Are you sure you want to discard your changes?"
+                            buttonAction: "Ok",
+                            message: "Any unsaved change will be discarded. Do you want to continue?"
                         }
                     }
                 }, close, null, false);

--- a/viewer/annotations/annotations.js
+++ b/viewer/annotations/annotations.js
@@ -3,7 +3,7 @@
     'use strict';
 
     angular.module('chaise.viewer')
-    
+
     // TODO not used
     .value('annotations', [])
 
@@ -25,9 +25,12 @@
      *  - tuple
      */
     .value('annotationModels', [])
-    
+
     // NOTE: if we change the recordedit vm model object, we should update this one as well.
     .value('annotationCreateForm', {
+        logStack: null,
+        logStackPath: null,
+        submissionButtonDisabled: false, //used in recordCreate to signal whether we're sending data or not
         reference: null,
         columnModels: [],
         rows: [{}], // rows of data in the form, not the table from ERMrest
@@ -38,6 +41,9 @@
 
     // NOTE: if we change the recordedit vm model object, we should update this one as well.
     .value('annotationEditForm', {
+        logStack: null,
+        logStackPath: null,
+        submissionButtonDisabled: false, //used in recordCreate to signal whether we're sending data or not
         reference: null,
         columnModels: [],
         rows: [{}], // rows of data in the form, not the table from ERMrest

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -15,14 +15,14 @@
          * @param {String} action - the actions string
          * @param {Object=}
          */
-        function logAnnotationClientAction(action, item) {
+        function logAnnotationClientAction(action, item, extraInfo) {
             var commonLogInfo = null;
             if ($rootScope.annotationEditReference) {
                 commonLogInfo = $rootScope.annotationEditReference.defaultLogInfo;
             }
             logService.logClientAction({
                 action: getAnnotationLogAction(action, item),
-                stack: getAnnotationLogStack(item)
+                stack: getAnnotationLogStack(item, extraInfo)
             }, commonLogInfo);
         }
 

--- a/viewer/annotations/annotations.service.js
+++ b/viewer/annotations/annotations.service.js
@@ -3,10 +3,82 @@
 
     angular.module('chaise.viewer')
 
-    .factory('AnnotationsService', ['context', 'user', 'image', 'annotations', 'AlertsService', 'ERMrest', '$window', '$q', 'viewerConstant', function(context, user, image, annotations, AlertsService, ERMrest, $window, $q, viewerConstant) {
+    .factory('AnnotationsService', ['context', 'user', 'image', 'annotations', 'AlertsService', 'ERMrest', '$window', '$q', 'viewerConstant', '$rootScope', 'logService', function(context, user, image, annotations, AlertsService, ERMrest, $window, $q, viewerConstant, $rootScope, logService) {
         var origin = $window.location.origin;
         var iframe = $window.frames[0];
         var table = null;
+
+
+        /**
+         * Given the action and item, log the client action
+         * if item is not passed, it will create the log based on annotation list
+         * @param {String} action - the actions string
+         * @param {Object=}
+         */
+        function logAnnotationClientAction(action, item) {
+            var commonLogInfo = null;
+            if ($rootScope.annotationEditReference) {
+                commonLogInfo = $rootScope.annotationEditReference.defaultLogInfo;
+            }
+            logService.logClientAction({
+                action: getAnnotationLogAction(action, item),
+                stack: getAnnotationLogStack(item)
+            }, commonLogInfo);
+        }
+
+        /**
+         * Get the log stack path of an annotation (or the whole annotation list)
+         * if item is not passed, we will return the log stack path string that can be used for the whole annotation panel
+         * @param {string}
+         * @param {Object=}
+         */
+        function getAnnotationLogStackPath(item) {
+            var stackPath = $rootScope.logStackPath;
+            if (item) {
+                stackPath = logService.getStackPath(stackPath, logService.logStackPaths.ANNOTATION_ENTITY);
+            } else {
+                stackPath = logService.getStackPath(stackPath, logService.logStackPaths.ANNOTATION_SET);
+            }
+            return stackPath;
+        }
+
+
+        /**
+         * Get the log action string of an annotation (or the whole annotation list)
+         * if item is not passed, we will return the action string that can be used for the whole annotation panel
+         * @param {string}
+         * @param {Object=}
+         */
+        function getAnnotationLogAction(actionPath, item) {
+            return logService.getActionString(actionPath, getAnnotationLogStackPath(item));
+        }
+
+        /**
+         * Get the log stack of an annotation (or the whole annotation list)
+         * if item is not passed, we will return the stack that can be used for the whole annotation panel
+         * @param {Object=} item any of the annotationModels object
+         * @param {Object=} extraInfo - if we want to log extra information
+         */
+        function getAnnotationLogStack(item, extraInfo) {
+            var stackNode;
+            if (item) {
+                stackNode = item.logStackNode;
+            } else {
+                var table, fileInfo;
+                if ($rootScope.annotationEditReference) {
+                    table = $rootScope.annotationEditReference.table;
+                } else {
+                    fileInfo = {"file": 1}
+                }
+                stackNode = logService.getStackNode(logService.logStackTypes.ANNOTATION, table, fileInfo);
+            }
+
+            var obj = logService.getStackObject(stackNode);
+            if (extraInfo) {
+                return logService.addExtraInfoToStack(obj, extraInfo);
+            }
+            return obj;
+        }
 
         // function drawAnnotation() {
         //     iframe.postMessage({messageType: 'drawAnnotation'}, origin);
@@ -59,8 +131,11 @@
                 return defer.reject("given item didn't have proper tuple"), defer.promise;
             }
 
-            // TODO proper log object
-            item.tuple.reference.delete().then(function () {
+            var logObj = {
+                action: getAnnotationLogAction(logService.logActions.DELETE, item),
+                stack: getAnnotationLogStack(item)
+            };
+            item.tuple.reference.delete(logObj).then(function () {
                 defer.resolve();
             }).catch(function (err) {
                 defer.reject(err);
@@ -159,12 +234,16 @@
         function saveAnnotationRecord(data){
             iframe.postMessage({messageType: 'saveAnnotationRecord', content: data}, origin);
         }
-        
+
         function loadAnnotations(data) {
             iframe.postMessage({messageType: 'loadAnnotations', content: data}, origin);
         }
 
         return {
+            logAnnotationClientAction: logAnnotationClientAction,
+            getAnnotationLogStackPath: getAnnotationLogStackPath,
+            getAnnotationLogAction: getAnnotationLogAction,
+            getAnnotationLogStack: getAnnotationLogStack,
             drawAnnotation: drawAnnotation,
             createAnnotation: createAnnotation,
             cancelNewAnnotation: cancelNewAnnotation,

--- a/viewer/constant.js
+++ b/viewer/constant.js
@@ -2,7 +2,7 @@
     'use strict';
 
     angular.module('chaise.viewer')
-    
+
     /**
      * TODO eventually this should be moved to a more configurable location,
      * either a standalone js file like chaise-config, or as part of the chaise-config file.
@@ -14,9 +14,14 @@
             DEFAULT_Z_INDEX_COLUMN_NAME: "Default_Z" // the default value of the zindex in the form TODO
         },
         annotation: {
+            // how much should we wait for user action and then log
+            SEARCH_LOG_TIMEOUT: 500,
+            LINE_THICKNESS_LOG_TIMEOUT: 1000,
+
+
             // how many annotations at a time should we read from database
             PAGE_COUNT: 25,
-            
+
             // annotation table
             ANNOTATION_TABLE_NAME: "Image_Annotation",
             ANNOTATION_TABLE_SCHEMA_NAME: "Gene_Expression",

--- a/viewer/constant.js
+++ b/viewer/constant.js
@@ -15,7 +15,7 @@
         },
         annotation: {
             // how much should we wait for user action and then log
-            SEARCH_LOG_TIMEOUT: 500,
+            SEARCH_LOG_TIMEOUT: 2000,
             LINE_THICKNESS_LOG_TIMEOUT: 1000,
 
 

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -130,7 +130,7 @@
                                                           parent-model="anno.annotationEditForm" model="anno.annotationEditForm.rows[0][columnModel.column.name]"
                                                           column-index="columnIndex" mode="edit" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
                                                           on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired"  parent-log-stack="anno.annotationEditForm.logStack" parent-log-stack-path="anno.annotationEditForm.logStackPath"></input-switch>
+                                                          is-required="columnModel.isRequired"></input-switch>
                                         </div>
                                     </div>
                                 </div>
@@ -148,7 +148,7 @@
                                                           parent-model="anno.annotationCreateForm" model="anno.annotationCreateForm.rows[0][columnModel.column.name]"
                                                           column-index="columnIndex" mode="create" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
                                                           on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired" parent-log-stack="anno.annotationCreateForm.logStack" parent-log-stack-path="anno.annotationCreateForm.logStackPath"></input-switch>
+                                                          is-required="columnModel.isRequired"></input-switch>
                                         </div>
                                     </div>
                                 </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -23,7 +23,7 @@
                                 <h3 class="side-panel-heading">{{anno.editingAnatomy == null ? "Annotations" :  (anno.editingAnatomy.isNew ? "Create annotation" : "Edit annotation")}}</h3>
                             </div>
                             <div class="pull-right">
-                                <button ng-disabled="anno.annotationFormPendingResult" ng-show="anno.editingAnatomy !== null" class="chaise-btn chaise-btn-tertiary" ng-click="anno.closeAnnotationForm(true)">
+                                <button ng-disabled="anno.annotationEditForm.submissionButtonDisabled || anno.annotationCreateForm.submissionButtonDisabled" ng-show="anno.editingAnatomy !== null" class="chaise-btn chaise-btn-tertiary" ng-click="anno.closeAnnotationForm(true)">
                                     <span class="fas fa-arrow-left"></span>
                                     <span>Back</span>
                                 </button>
@@ -78,9 +78,9 @@
                                 </div>
                             </div>
                             <div class='annotation-form-container' ng-form="anno.annoForm" ng-if="anno.showPanel" ng-class="{'open' : anno.editingAnatomy !== null}">
-                                <div class="form-spinner-overlay" ng-if="anno.annotationFormPendingResult">
+                                <div class="form-spinner-overlay" ng-if="anno.annotationEditForm.submissionButtonDisabled || anno.annotationCreateForm.submissionButtonDisabled">
                                 </div>
-                                <loading-spinner class="form-spinner" ng-if="anno.annotationFormPendingResult" message="Saving the changes..."></loading-spinner>
+                                <loading-spinner class="form-spinner" ng-if="anno.annotationEditForm.submissionButtonDisabled || anno.annotationCreateForm.submissionButtonDisabled" message="Saving the changes..."></loading-spinner>
                                 <div class="annotationRow">
                                     <div class="flex-column entity-key">
                                         <div class="annotationRowValue" ng-show="!anno.editingAnatomy.isNew && !anno.editingAnatomy.isStoredInDB">
@@ -130,7 +130,7 @@
                                                           parent-model="anno.annotationEditForm" model="anno.annotationEditForm.rows[0][columnModel.column.name]"
                                                           column-index="columnIndex" mode="edit" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
                                                           on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired"></input-switch>
+                                                          is-required="columnModel.isRequired"  parent-log-stack="anno.annotationEditForm.logStack" parent-log-stack-path="anno.annotationEditForm.logStackPath"></input-switch>
                                         </div>
                                     </div>
                                 </div>
@@ -148,7 +148,7 @@
                                                           parent-model="anno.annotationCreateForm" model="anno.annotationCreateForm.rows[0][columnModel.column.name]"
                                                           column-index="columnIndex" mode="create" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
                                                           on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired"></input-switch>
+                                                          is-required="columnModel.isRequired" parent-log-stack="anno.annotationCreateForm.logStack" parent-log-stack-path="anno.annotationCreateForm.logStackPath"></input-switch>
                                         </div>
                                     </div>
                                 </div>
@@ -161,7 +161,7 @@
                                                 <span>Save</span>
                                             </button>
                                         </div>
-                                        <div class='annotationRowValue' ng-disabled="anno.annotationFormPendingResult || !canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
+                                        <div class='annotationRowValue' ng-disabled="!canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
                                             <button class="btn chaise-btn chaise-btn-danger" ng-click="anno.removeAnnotationEntry(anno.editingAnatomy)">
                                                 <span class="chaise-btn-icon far fa-trash-alt"></span>
                                                 <span>Delete</span>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -62,11 +62,11 @@
             <div class="bottom-panel-container" id="viewer-content">
                 <div class="side-panel-resizable" ng-class="{'open-panel': !hideAnnotationSidebar, 'close-panel': hideAnnotationSidebar}" resizable r-directions=["right"] r-flex="true" r-partners="osd.resizePartners">
                     <div class="side-panel-container">
-                        <div class='annotation-list-container facet-panel'>
+                        <div class='annotation-list-container'>
                             <div class='strokeScale'>
                                 <span class='name'>Line Thickness <span class='strokeValue'>{{ anno.strokeScale }}</span></span>
                                 <div class='slider'>
-                                    <input type="range" class='strokeSlider' min="1" max="6" step="0.05" ng-model="anno.strokeScale" ng-change="anno.changeStrokeScale()">
+                                    <input type="range" class='strokeSlider' min="1" max="6" step="0.05" ng-model="anno.strokeScale" ng-change="anno.changeStrokeScale()" ng-mousedown="anno.changeStrokeScaleStart()" ng-mouseup="anno.changeStrokeScaleStop()">
                                 </div>
                                 <div class='sliderTicks'>
                                     <span class='currentScale'>1</span>

--- a/viewer/osd/osd.controller.js
+++ b/viewer/osd/osd.controller.js
@@ -3,7 +3,7 @@
 
     angular.module('chaise.viewer')
 
-    .controller('OSDController', ['AlertsService', 'deviceDetector', 'context', 'image', '$window', '$rootScope','$scope', function OSDController(AlertsService, deviceDetector,context, image, $window, $rootScope, $scope) {
+    .controller('OSDController', ['AlertsService', 'deviceDetector', 'context', 'image', 'logService', '$window', '$rootScope','$scope', function OSDController(AlertsService, deviceDetector,context, image, logService, $window, $rootScope, $scope) {
         var vm = this;
         var iframe = $window.frames[0];
         var origin = $window.location.origin;
@@ -75,7 +75,7 @@
         });
 
         function downloadView() {
-            var filename = vm.image.entity.slide_id;
+            var filename = context.imageID;
             if (!filename) {
                 filename = 'image';
             }
@@ -86,18 +86,42 @@
 
             vm.waitingForScreenshot = true;
             iframe.postMessage(obj, origin);
+
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(logService.logActions.VIEWER_SCREENSHOT, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function zoomInView() {
             iframe.postMessage({messageType: 'zoomInView'}, origin);
+
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(logService.logActions.VIEWER_ZOOM_IN, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function zoomOutView() {
             iframe.postMessage({messageType: 'zoomOutView'}, origin);
+
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(logService.logActions.VIEWER_ZOOM_OUT, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function homeView() {
             iframe.postMessage({messageType: 'homeView'}, origin);
+
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(logService.logActions.VIEWER_ZOOM_RESET, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function toggleAnnotations() {
@@ -125,7 +149,15 @@
                 sidebarptr.css("display","none");
             }
             // iframe.postMessage({messageType: 'openAnnotations'}, origin);
+
+            var action = $rootScope.hideAnnotationSidebar ? logService.logActions.VIEWER_ANNOT_PANEL_SHOW : logService.logActions.VIEWER_ANNOT_PANEL_HIDE;
             $rootScope.hideAnnotationSidebar = !$rootScope.hideAnnotationSidebar;
+
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(action, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function covered() {
@@ -149,8 +181,18 @@
             //   if(covered())
                 //   sidebarptr.css("display","none");
             // }
+
+            var action = vm.filterChannelsAreHidden ? logService.logActions.VIEWER_CHANNEL_HIDE : logService.logActions.VIEWER_CHANNEL_SHOW;
+
             iframe.postMessage({messageType: 'filterChannels'}, origin);
             vm.filterChannelsAreHidden = !vm.filterChannelsAreHidden;
+
+            // log the click
+            // app mode will change by annotation controller, this one should be independent of that
+            logService.logClientAction({
+                action: logService.getActionString(action, null, ""),
+                stack: logService.getStackObject()
+            }, $rootScope.reference.defaultLogInfo);
         }
 
         function testSafari() {

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -149,7 +149,7 @@
         var config = ConfigUtils.getContextJSON();
         var annotConstant = viewerConstant.annotation;
         var imageConstant = viewerConstant.image;
-        
+
         // TODO are these needed?
         context.server = config.server;
         context.wid = config.contextHeaderParams.wid;
@@ -230,7 +230,7 @@
                     )
                 ];
                 $rootScope.logAppMode = null;
-                    
+
                 var logObj = {
                     action: logService.getActionString(logService.logActions.LOAD),
                     stack: logService.getStackObject()

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -149,7 +149,8 @@
         var config = ConfigUtils.getContextJSON();
         var annotConstant = viewerConstant.annotation;
         var imageConstant = viewerConstant.image;
-
+        
+        // TODO are these needed?
         context.server = config.server;
         context.wid = config.contextHeaderParams.wid;
         context.cid = config.contextHeaderParams.cid;
@@ -159,8 +160,8 @@
 
         var res = UriUtils.chaiseURItoErmrestURI($window.location, true);
         var ermrestUri = res.ermrestUri,
-            pcid = config.contextHeaderParams.cid,
-            ppid = config.contextHeaderParams.pid,
+            pcid = res.cid,
+            ppid = res.pid,
             isQueryParameter = res.isQueryParameter,
             queryParamsString = res.queryParamsString,
             queryParams = res.queryParams;
@@ -171,7 +172,7 @@
 
         FunctionUtils.registerErmrestCallbacks();
 
-        var session, annotationEditReference;
+        var session;
         var osdViewerQueryParams = queryParamsString, // what will be passed onto osd viewer
             hasAnnotationQueryParam = false, // if there are svgs in query param, we should just use it and shouldn't get it from db.
             hasImageQueryParam = false, // if there is an image in query, we should just use it and shouldn't use the image uri from db
@@ -218,10 +219,7 @@
                 // TODO is it needed?
                 $rootScope.session = session;
 
-                var logObj = {};
-                if (pcid) logObj.pcid = pcid;
-                if (ppid) logObj.ppid = ppid;
-                if (isQueryParameter) logObj.cqp = 1;
+                $rootScope.reference = imageReference;
 
                 $rootScope.logStackPath = logService.logStackPaths.ENTITY;
                 $rootScope.logStack = [
@@ -231,7 +229,15 @@
                         imageReference.filterLogInfo
                     )
                 ];
-
+                $rootScope.logAppMode = null;
+                    
+                var logObj = {
+                    action: logService.getActionString(logService.logActions.LOAD),
+                    stack: logService.getStackObject()
+                };
+                if (pcid) logObj.pcid = pcid;
+                if (ppid) logObj.ppid = ppid;
+                if (isQueryParameter) logObj.cqp = 1;
                 return imageReference.contextualize.detailed.read(1, logObj, true, true);
             })
             // read the main (image) reference

--- a/viewer/viewer.utils.js
+++ b/viewer/viewer.utils.js
@@ -4,9 +4,9 @@
     angular.module('chaise.viewer')
 
     .factory('viewerAppUtils', [
-        'annotationCreateForm', 'annotationEditForm', 'ConfigUtils', 'context', 'ERMrest', 'logService', 'recordCreate', 'UriUtils', 'viewerConstant', 
+        'annotationCreateForm', 'annotationEditForm', 'AnnotationsService', 'ConfigUtils', 'context', 'ERMrest', 'logService', 'recordCreate', 'UriUtils', 'viewerConstant', 
         '$q', '$rootScope', 
-        function (annotationCreateForm, annotationEditForm, ConfigUtils, context, ERMrest, logService, recordCreate, UriUtils, viewerConstant, 
+        function (annotationCreateForm, annotationEditForm, AnnotationsService, ConfigUtils, context, ERMrest, logService, recordCreate, UriUtils, viewerConstant, 
                   $q, $rootScope) {
         
         var annotConstant = viewerConstant.annotation;
@@ -118,8 +118,8 @@
         function _readAnnotations (ref) {
             var defer = $q.defer();
             var logObj = {
-                action: logService.getActionString(logService.logActions.VIEWER_ANNOT_LOAD),
-                stack: logService.getStackObject()
+                action: AnnotationsService.getAnnotationLogAction(logService.logActions.VIEWER_ANNOT_LOAD),
+                stack: AnnotationsService.getAnnotationLogStack()
             };
 
             ref.read(annotConstant.PAGE_COUNT, logObj, false, true).then(function (page){


### PR DESCRIPTION
This PR,

- Adds proper log support to the viewer app (#1910). For the complete list of actions please [refer to this google sheet](https://docs.google.com/spreadsheets/d/1cHhPR0AacvuH2o3QavWlJCIIyPajfn93fJzFnc7VA5M).
- Add extra log info to distinguish between view button and the rest links (#1917)
- Fix a bug in the viewer app which would cause users to be stuck in the edit form (Open edit form for an annotation, don't change anything and click on save.)
- Unhighlight annotations when switching to edit mode. 
- Removed the unnecessary usage of `slide_id` in the code.
- Fixed a small bug in the logic of disabling the "show/hide annotation" button. It wasn't properly checking the value that osd viewer is returning.