### PR TITLE
Fix a bug in recordedit where it would ignore falsy values

### DIFF
--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -909,7 +909,7 @@
                         var referenceColumn = foreignKeyColumns[k];
                         var foreignTableColumn = column.foreignKey.mapping.get(referenceColumn);
                         // check if value is set in submission data yet (searchPopup will set this value if foreignkey is picked)
-                        if (!submissionRow[referenceColumn.name]) {
+                        if (submissionRow[referenceColumn.name] == null) {
                             /**
                              * User didn't change the foreign key, copy the value over to the submission data with the proper column name
                              * In the case of edit, the originating value is set on $rootScope.tuples.data. Use that value if the user didn't touch it (value could be null, which is fine, just means it was unset)

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -12,7 +12,7 @@
     </div>
     <div class="app-container re_s_{{idSafeSchemaName}} re_t_{{idSafeTableName}}">
         <navbar></navbar>
-        <loading-spinner ng-show="!displayReady && !error"></loading-spinner>
+        <loading-spinner id="recordedit-main-spinner" ng-show="!displayReady && !error"></loading-spinner>
         <div class="recordedit-container" ng-if="reference && (reference.canCreate || reference.canUpdate)" ng-controller="FormController as form">
             <div class="form-container">
                 <div class="app-content-container" ng-hide="form.resultset">

--- a/test/e2e/data_setup/data/product/person.json
+++ b/test/e2e/data_setup/data/product/person.json
@@ -1,3 +1,3 @@
-[{"id": 1, "first_name": "John", "last_name": "Doe"},
- {"id": 2, "first_name": "Jane", "last_name": "Doe"},
- {"id": 3, "first_name": "Harold", "last_name": "Jones"}]
+[{"id": 1, "first_name": "John", "last_name": "Doe", "index": 0},
+ {"id": 2, "first_name": "Jane", "last_name": "Doe", "index": 0},
+ {"id": 3, "first_name": "Harold", "last_name": "Jones", "index": 0}]

--- a/test/e2e/data_setup/schema/recordedit/product-person.json
+++ b/test/e2e/data_setup/schema/recordedit/product-person.json
@@ -907,7 +907,7 @@
                 "typename": "int4"
             },
             "nullok": true,
-            "default": 0
+            "default": 1
         }
       ],
       "annotations": {

--- a/test/e2e/data_setup/schema/recordedit/product-person.json
+++ b/test/e2e/data_setup/schema/recordedit/product-person.json
@@ -45,6 +45,11 @@
               "table_name": "accommodation",
               "schema_name": "product-person",
               "column_name": "last_name"
+            },
+            {
+              "table_name": "accommodation",
+              "schema_name": "product-person",
+              "column_name": "index"
             }
           ],
           "annotations": {},
@@ -58,6 +63,11 @@
               "table_name": "person",
               "schema_name": "product-person",
               "column_name": "last_name"
+            },
+            {
+              "table_name": "person",
+              "schema_name": "product-person",
+              "column_name": "index"
             }
           ]
         },
@@ -379,6 +389,15 @@
               "name": "Last Name"
             }
           }
+        },
+        {
+          "comment": "this column was added to make sure we can accept falsy values",
+          "name": "index",
+          "type": {
+            "typename": "int4"
+          },
+          "nullok": true,
+          "default": 0
         }
       ],
       "annotations": {
@@ -828,7 +847,8 @@
           "annotations": {},
           "unique_columns": [
             "first_name",
-            "last_name"
+            "last_name",
+            "index"
           ]
         }
       ],
@@ -879,6 +899,15 @@
               "name": "Last Name"
             }
           }
+        },
+        {
+            "comment": "this column was added to make sure we can accept falsy values",
+            "name": "index",
+            "type": {
+                "typename": "int4"
+            },
+            "nullok": true,
+            "default": 0
         }
       ],
       "annotations": {

--- a/test/e2e/specs/default-config/recordedit/composite-key.spec.js
+++ b/test/e2e/specs/default-config/recordedit/composite-key.spec.js
@@ -2,10 +2,11 @@ var chaisePage = require('../../../utils/chaise.page.js');
 var recordEditHelpers = require('../../../utils/recordedit-helpers.js');
 var testParams = {
     table_name: "accommodation",
-    column_names: ["first_name", "last_name", "0YGNuO_bvxoczJ6ms2k0tQ"],
+    column_names: ["first_name", "last_name", "index", "0YGNuO_bvxoczJ6ms2k0tQ"],
     column_values: {
         first_name: "John",
         last_name: "Doe",
+        index: "0",
         "0YGNuO_bvxoczJ6ms2k0tQ": "John Doe" // person foreignkey column
     }
 };

--- a/test/e2e/specs/default-config/recordedit/multi-col-types.spec.js
+++ b/test/e2e/specs/default-config/recordedit/multi-col-types.spec.js
@@ -128,7 +128,7 @@ describe('When editing a record', function() {
     beforeAll(function() {
         browser.ignoreSynchronization = true;
         browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/multi-column-types:" + testParams.table_w_generated_columns.tableName + '/' + testParams.table_w_generated_columns.key.columnName + testParams.table_w_generated_columns.key.operator + testParams.table_w_generated_columns.key.value);
-        chaisePage.waitForElement(element(by.id("submit-record-button")));
+        chaisePage.recordeditPageReady();
 
         if (!process.env.TRAVIS && files.length > 0) {
             // create files that will be uploaded
@@ -158,7 +158,7 @@ describe('When editing a record', function() {
     describe('if the user made no edits', function() {
         beforeAll(function() {
             browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/multi-column-types:" + testParams.table_1.tableName + '/' + testParams.table_1.key.columnName + testParams.table_1.key.operator + testParams.table_1.key.value);
-            chaisePage.waitForElement(element(by.id("submit-record-button"))).then(function() {
+            chaisePage.recordeditPageReady().then(function() {
                 return recordEditPage.submitForm();
             });
         });
@@ -186,7 +186,7 @@ describe('When editing a record', function() {
     describe('if the user did make edits', function() {
         beforeAll(function() {
             browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/multi-column-types:" + testParams.table_1.tableName + '/' + testParams.table_1.key.columnName + testParams.table_1.key.operator + testParams.table_1.key.value);
-            chaisePage.waitForElement(element(by.id("submit-record-button")));
+            chaisePage.recordeditPageReady();
         });
 
         // Test each column type to check that the app converts the submission data correctly for each type

--- a/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
+++ b/test/e2e/specs/default-config/recordedit/remove-edit-form.spec.js
@@ -27,7 +27,7 @@ describe('Edit a record,', function() {
             filters.push(testParams.filter.key + testParams.filter.operator + testParams.filter.value);
             browser.ignoreSynchronization=true;
             browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/multi-edit:" + testParams.table_name + "/" + filters.join("&"));
-            chaisePage.waitForElement(element(by.id("submit-record-button")));
+            chaisePage.recordeditPageReady();
         });
 
         it("remove 2 forms and edit some of the data", function(done) {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1233,7 +1233,7 @@ function chaisePage() {
     }
     this.recordeditPageReady = function() {
         this.waitForElement(element(by.id("submit-record-button")));
-        this.waitForElementInverse(element(by.id("spinner")));
+        return this.waitForElementInverse(element(by.id("recordedit-main-spinner")));
     }
     this.setAuthCookie = function(url, authCookie) {
         if (url && authCookie) {


### PR DESCRIPTION
If any of the foreign key column values had a falsy (`0`, `false`) value, recorddeit was ignoring them. This PR will fix that. 

I also modified our existing composite foreign key test case to test this.


**Created this PR just to make sure everything is stable on travis**