### PR TITLE
Domain filter changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ before_install:
   - cd ..
   - git clone https://github.com/informatics-isi-edu/ermrestjs.git
   - cd ermrestjs
+  - git checkout domain-filter
   - sudo make install
   - cd ../chaise
   - sudo cp test/ermrest_config.json /home/ermrest/

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,6 @@ before_install:
   - cd ..
   - git clone https://github.com/informatics-isi-edu/ermrestjs.git
   - cd ermrestjs
-  - git checkout domain-filter
   - sudo make install
   - cd ../chaise
   - sudo cp test/ermrest_config.json /home/ermrest/

--- a/common/styles/scss/_recordset.scss
+++ b/common/styles/scss/_recordset.scss
@@ -61,22 +61,26 @@
                         padding-right: 2px;
                         text-align: left;
                         white-space: nowrap;
+
+                        // only add the colon if the title exists
+                        & ~ .chaise-btn.filter-chiclet-value {
+                            border-left: 0;
+
+                            position: relative;
+                            &:before {
+                                content: ":";
+                                position: absolute;
+                                left: 0;
+                            }
+                        }
                     }
                     .chaise-btn.filter-chiclet-value {
                         text-overflow: ellipsis;
                         overflow: hidden;
                         white-space: nowrap;
                         max-width: 200px;
-                        border-left: 0;
                         padding-left: 7px;
                         padding-right: 4px;
-
-                        position: relative;
-                        &:before {
-                            content: ":";
-                            position: absolute;
-                            left: 0;
-                        }
                     }
 
                     span {

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -68,7 +68,7 @@
                         <button ng-if="vm.reference.location.customFacets.removable" class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" ng-click="vm.removeFilter('cfacets')" tooltip-placement="bottom" uib-tooltip="Clear custom filter applied">
                             <i class="glyphicon glyphicon-remove"></i>
                         </button>
-                        <span ng-if="!vm.reference.location.customFacets.removable" class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" tooltip-placement="bottom-left" uib-tooltip="The filter is preset by the underlying record.">
+                        <span ng-if="!vm.reference.location.customFacets.removable" class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" tooltip-placement="bottom-left" uib-tooltip="Predefined filter(s)">
                             <i class="fas fa-filter"></i>
                         </span>
                         <span class="filter-chiclet-title chaise-btn chaise-btn-secondary" ng-if="vm.reference.location.customFacets.removable">Custom Filter</span>

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -56,7 +56,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="recordset-chiclets-container recordset-chiclets" ng-if="vm.reference.location.filter || vm.reference.location.customFacets || vm.hasFilter()">
+                <div class="recordset-chiclets-container recordset-chiclets" ng-if="vm.reference.location.filter || vm.hasFilter() || (vm.reference.location.customFacets && vm.reference.location.customFacets.displayname)">
                     <div class="filter-chiclet chaise-btn-group" ng-if="vm.reference.location.filter">
                         <button class="clear-custom-filters filter-chiclet-remove chaise-btn chaise-btn-secondary" ng-click="vm.removeFilter('filters')" tooltip-placement="bottom" uib-tooltip="Clear custom filter applied">
                             <i class="icon-btn glyphicon glyphicon-remove"></i>
@@ -64,12 +64,16 @@
                         <span class="filter-chiclet-title chaise-btn chaise-btn-secondary">Custom Filter</span>
                         <span class="filter-chiclet-value chaise-btn chaise-btn-secondary" ng-bind="transformCustomFilter(vm.reference.location.filtersString)" tooltip-placement="bottom-left" uib-tooltip="{{transformCustomFilter(vm.reference.location.filtersString)}}" tooltip-class="custom-filter-tooltip"></span>
                     </div>
-                    <div class="filter-chiclet chaise-btn-group" ng-if="vm.reference.location.customFacets">
-                        <button class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" ng-click="vm.removeFilter('cfacets')" tooltip-placement="bottom" uib-tooltip="Clear custom filter applied">
+                    <div class="filter-chiclet chaise-btn-group" ng-if="vm.reference.location.customFacets && vm.reference.location.customFacets.displayname">
+                        <button ng-if="vm.reference.location.customFacets.removable" class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" ng-click="vm.removeFilter('cfacets')" tooltip-placement="bottom" uib-tooltip="Clear custom filter applied">
                             <i class="glyphicon glyphicon-remove"></i>
                         </button>
-                        <span class="filter-chiclet-title chaise-btn chaise-btn-secondary">Custom Filter</span>
-                        <span class="filter-chiclet-value chaise-btn chaise-btn-secondary" ng-bind="vm.reference.location.customFacets.displayname" tooltip-placement="bottom-left" uib-tooltip="{{vm.reference.location.customFacets.displayname}}" tooltip-class="custom-filter-tooltip"></span>
+                        <span ng-if="!vm.reference.location.customFacets.removable" class="clear-custom-facets filter-chiclet-remove chaise-btn chaise-btn-secondary" tooltip-placement="bottom-left" uib-tooltip="The filter is preset by the underlying record.">
+                            <i class="fas fa-filter"></i>
+                        </span>
+                        <span class="filter-chiclet-title chaise-btn chaise-btn-secondary" ng-if="vm.reference.location.customFacets.removable">Custom Filter</span>
+                        <span class="filter-chiclet-value chaise-btn chaise-btn-secondary" ng-if="!vm.reference.location.customFacets.displayname.isHTML" ng-bind="vm.reference.location.customFacets.displayname.value" uib-tooltip="{{vm.reference.location.customFacets.displayname.value}}" tooltip-placement="bottom-left" tooltip-class="custom-filter-tooltip"></span>
+                        <span class="filter-chiclet-value chaise-btn chaise-btn-secondary" ng-if="vm.reference.location.customFacets.displayname.isHTML" ng-bind-html="vm.reference.location.customFacets.displayname.value" uib-tooltip-html="'{{vm.reference.location.customFacets.displayname.value}}'" tooltip-placement="bottom-left" tooltip-class="custom-filter-tooltip"></span>
                     </div>
                     <div class="filter-chiclet chaise-btn-group" ng-repeat="fc in vm.reference.facetColumns track by $index" ng-if="vm.hasFilter($index)">
                         <button class="filter-chiclet-remove chaise-btn chaise-btn-secondary" ng-click="vm.removeFilter($index)" tooltip-placement="bottom" uib-tooltip="Clear filter applied">
@@ -96,7 +100,8 @@
                             </span>
                         </span>
                     </div>
-                    <button ng-click="vm.removeFilter()" class="clear-all-filters chaise-btn chaise-btn-tertiary clear-all-btn" uib-tooltip="Clear all filters applied" tooltip-placement="bottom">
+                    <!-- don't show clear all filters when the custom facet is not removable -->
+                    <button ng-if="vm.reference.location.filter || vm.hasFilter() || (vm.reference.location.customFacets && vm.reference.location.customFacets.removable)" ng-click="vm.removeFilter()" class="clear-all-filters chaise-btn chaise-btn-tertiary clear-all-btn" uib-tooltip="Clear all filters applied" tooltip-placement="bottom">
                         <span>Clear all filters</span>
                     </button>
                 </div>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "devDependencies": {
     "chance": "x",
-    "closurecompiler": "x",
     "ermrest-data-utils": "x",
     "execSync": "x",
     "jasmine-spec-reporter": "^2.5.0",

--- a/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
+++ b/test/e2e/data_setup/schema/recordedit/fk-filter-pattern.json
@@ -68,7 +68,9 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "position_type_col=fixed"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "position_type_col=fixed"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -91,7 +93,9 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "position_type_col={{{_position_text_col}}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "position_type_col={{{_position_text_col}}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -114,7 +118,10 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "fk2={{{_fk1}}}&position_col={{{_position_text_col}}}",
+                                "display_markdown_pattern": "fk2 is {{{_fk1}}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -145,7 +152,7 @@
                     ]
                 },
                 {
-                    "comment": "Foreign key with domain_filter_pattern using fk_w_default values.",
+                    "comment": "Foreign key with domain_filter using fk_w_default values.",
                     "names": [["fk-filter-pattern", "fk_w_fkeys_default"]],
                     "foreign_key_columns": [
                         {
@@ -156,7 +163,10 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_default}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_default}}",
+                                "display_markdown_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_default}}**other fk values**: {{{values._fk2}}}, {{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_default}}"
+                            }
                         }
                     },
                     "referenced_columns": [
@@ -179,7 +189,9 @@
                     ],
                     "annotations": {
                         "tag:isrd.isi.edu,2016:foreign-key": {
-                            "domain_filter_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_fkeys_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_fkeys_default}}"
+                            "domain_filter": {
+                                "ermrest_path_pattern": "{{# $fkeys.fk-filter-pattern.fk_w_fkeys_default}}fk2={{{values._fk2}}}&position_col={{{values._position_col}}}{{/$fkeys.fk-filter-pattern.fk_w_fkeys_default}}"
+                            }
                         }
                     },
                     "referenced_columns": [

--- a/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
+++ b/test/e2e/specs/default-config/recordedit/domain-filter.spec.js
@@ -66,7 +66,6 @@ describe("Domain filter pattern support,", function() {
                 browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/fk-filter-pattern:" + testParams.table_name);
 
                 chaisePage.waitForElement(element(by.id("submit-record-button")));
-                browser.pause();
             });
 
             beforeEach(function () {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1365,9 +1365,8 @@ function chaisePage() {
 
     this.catchTestError = function (done) {
         return function (err) {
-            console.log(err);
-            done.fail();
-        }
+            done.fail(err);
+        };
     };
 
     this.performLogin = function(cookie, isAlertPresent, defer) {


### PR DESCRIPTION
In [ermrestjs#860](https://github.com/informatics-isi-edu/ermrestjs/pull/860) I modified the domain filter support to use `customFacets`. And this PR will modify how `recordset.html` is processing the `customFacets` property so it can properly display the custom facet used in domain filter. 

Please refer to the ermrestjs PR and issue for more information.


Other changes in this PR:

- Modifying test cases to test the new syntax and UI.
- Remove the unused `closureCompiler` dependency from `package.json` (it's deprecated and was complaining while I was using node 14.)