### PR TITLE
Markdown name support for navbar options

### DIFF
--- a/chaise-config-sample.js
+++ b/chaise-config-sample.js
@@ -63,6 +63,10 @@ var chaiseConfig = {
             //     // Use the "url" key to specify this menu item's url
             //     // URLs can be absolute or relative to the document root.
             //     name: "Create",
+            //     // Some default classes are already available without adding anything to customCSS
+            //     // overrides "name" property above
+            //     // example below and here (TODO: link to documentation)
+            //     markdownName: ":span:Create:/span:{.external-link}",
             //     url: "/chaise/recordedit/#1/YOUR_SCHEMA:YOUR_TABLE",
             //     // Define globus groups or users that can see and and be able to click the link or navigate the submenu
             //     // If either array, `show` or `enable`, or both are missing, `["*"]` will be used as the default

--- a/chaise-config-sample.js
+++ b/chaise-config-sample.js
@@ -65,7 +65,7 @@ var chaiseConfig = {
             //     name: "Create",
             //     // Some default classes are already available without adding anything to customCSS
             //     // overrides "name" property above
-            //     // example below and here (TODO: link to documentation)
+            //     // example below and https://github.com/informatics-isi-edu/ermrestjs/blob/master/docs/user-docs/markdown-formatting.md#13-span-attach-attributes-to-text
             //     markdownName: ":span:Create:/span:{.external-link}",
             //     url: "/chaise/recordedit/#1/YOUR_SCHEMA:YOUR_TABLE",
             //     // Define globus groups or users that can see and and be able to click the link or navigate the submenu

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -65,8 +65,14 @@
       $event.stopPropagation();
       $event.preventDefault();
 
-      var menuTarget = getNextSibling($event.target,".dropdown-menu"); // dropdown submenu <ul>
-      var immediateParent = $event.target.offsetParent; // parent, <li>
+      var target = $event.target;
+      // added markdownName support allows for inline template to be defined like :span:TEXT:/span:{.class-name}
+      if ($event.target.localName != "a") {
+          target = $event.target.parentElement;
+      }
+
+      var menuTarget = getNextSibling(target, ".dropdown-menu"); // dropdown submenu <ul>
+      var immediateParent = target.offsetParent; // parent, <li>
       var parent = immediateParent.offsetParent; // parent's parent, dropdown menu <ul>
       var posValues = getOffsetValue(immediateParent);
 
@@ -83,7 +89,7 @@
 
       // if we're opening this, close all the other dropdowns on navbar.
       if (open) {
-        $event.target.closest(".dropdown-menu").querySelectorAll('.show').forEach(function(el) {
+        target.closest(".dropdown-menu").querySelectorAll('.show').forEach(function(el) {
           el.parentElement.classList.remove("child-opened");
           el.classList.remove("show");
         });
@@ -217,6 +223,14 @@
         };
     }
 
+    function renderInlineMarkdown(item) {
+        if (item.markdownName) {
+            return ERMrest.renderMarkdown(item.markdownName, {inline: true});
+        }
+
+        return item.name;
+    }
+
     'use strict';
     angular.module('chaise.navbar', [
         'chaise.login',
@@ -314,7 +328,6 @@
                     scope.menu = chaiseConfig.navbarMenu ? chaiseConfig.navbarMenu.children : [];
 
                     scope.onToggle = function (open, menuObject) {
-                        console.log(this);
                         if (open) {
                             // when menu opens, calculate height needed
                             logService.logClientAction({
@@ -324,6 +337,11 @@
                         }
 
                         onToggle(open);
+                    }
+
+                    // prefer to use markdownName over name
+                    scope.renderName = function (item) {
+                        return renderInlineMarkdown(item);
                     }
 
                     // remove the height when the dropdown is toggled
@@ -440,6 +458,11 @@
                 return function(scope, el) {
                     if (!compiled) {
                         compiled = $compile(contents);
+                    }
+
+                    // prefer to use markdownName over name
+                    scope.renderName = function (item) {
+                        return renderInlineMarkdown(item);
                     }
 
                     scope.canShow = function (item) {

--- a/common/styles/scss/app.scss
+++ b/common/styles/scss/app.scss
@@ -109,7 +109,8 @@ html {
         border-left: 5px solid transparent;
     }
 
-    a.external-link-icon:not(:empty):not(.external-link-no-icon) {
+    a.external-link-icon:not(:empty):not(.external-link-no-icon),
+    a span.external-link-icon:not(:empty):not(.external-link-no-icon) {
         &::after {
             display: inline-block;
             font-size: .85rem;

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -17,8 +17,8 @@
         <div class="collapse navbar-collapse navbar-inverse" id="fb-navbar-main-collapse">
             <ul id="navbar-menu" class="nav navbar-nav">
                 <li ng-repeat="item in menu" class="dropdown" on-toggle="onToggle(open, item)" ng-if="canShow(item)" uib-dropdown>
-                    <a ng-if="!item.children || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
-                    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" uib-dropdown-toggle ng-click="::resetHeight($event)">{{item.name}} <span class="caret"></span></a>
+                    <a ng-if="!item.children || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item)}" ng-click="::onLinkClick($event, item)" ng-bind-html="renderName(item)"></a>
+                    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" uib-dropdown-toggle ng-click="::resetHeight($event)"><span ng-bind-html="renderName(item)"></span> <span class="caret"></span></a>
                     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
                 </li>
             </ul>

--- a/common/templates/navbarMenu.html
+++ b/common/templates/navbarMenu.html
@@ -1,8 +1,8 @@
 <li ng-repeat="item in menu" ng-class="{'dropdown-submenu': item.children && canEnable(item)}" ng-if="canShow(item)">
     <span ng-if="item.header == true && !item.children && !item.url" class="dropdown-header chaise-dropdown-header">{{item.name}}</span>
     <!-- the following case is for showing a url link or a disabled menu that has children -->
-    <a ng-if="(!item.children && item.url) || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item), 'chaise-dropdown-header': item.header == true}" ng-click="::onLinkClick($event, item)">{{item.name}}</a>
+    <a ng-if="(!item.children && item.url) || !canEnable(item)" ng-href="{{item.url}}" target="{{item.newTab ? '_blank' : '_self'}}" ng-class="{'disable-link': !canEnable(item), 'chaise-dropdown-header': item.header == true}" ng-click="::onLinkClick($event, item)" ng-bind-html="renderName(item)"></a>
     <!-- the following case is for showing an enabled menu that has children -->
-    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" ng-class="{'chaise-dropdown-header': item.header == true}" ng-click="::toggleSubMenu($event, item)">{{item.name}}</a>
+    <a ng-if="item.children && canEnable(item)" class="dropdown-toggle" ng-class="{'chaise-dropdown-header': item.header == true}" ng-click="::toggleSubMenu($event, item)" ng-bind-html="renderName(item)"></a>
     <ul ng-if="item.children" navbar-menu menu="item.children" class="dropdown-menu"></ul>
 </li>

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -24,6 +24,8 @@ var chaiseConfig = {
             },
             {
                 name: "Recordsets",
+                // tests markdownName is prefered
+                markdownName: "Test Recordsets",
                 children: [
                     {
                         name: "Dataset",
@@ -44,7 +46,8 @@ var chaiseConfig = {
                 }
             },
             {
-                name: "RecordEdit",
+                // should bold value instead of showing ** before and after
+                markdownName: "**Recordedit**",
                 children: [
                     {
                         name: "For Mutating Data",

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -49,6 +49,8 @@ describe('Navbar ', function() {
     });
 
     it('should render a markdown pattern using proper HTML', function () {
+        // in travis we don't have the same globus groups so the "show" ACL hides the 3rd link ("Records")
+        var idx = (!process.env.TRAVIS ? 3 : 2)
         // option #4 has only markdownName defined
         element.all(by.css('#navbar-menu > li.dropdown')).get(3).element(by.css("a")).getAttribute('innerHTML').then(function (aInnerHTML) {
             expect(aInnerHTML.indexOf("<strong>")).toBeGreaterThan(-1, "name was used instead of markdownName");

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -43,6 +43,18 @@ describe('Navbar ', function() {
         });
     });
 
+    it('should prefer markdownName over name when both are defined', function () {
+        // option #2 has both name and markdownName defined
+        expect(element.all(by.css('#navbar-menu > li.dropdown')).get(1).getText()).toBe("Test Recordsets", "name was used instead of markdownName");
+    });
+
+    it('should render a markdown pattern using proper HTML', function () {
+        // option #4 has only markdownName defined
+        element.all(by.css('#navbar-menu > li.dropdown')).get(3).element(by.css("a")).getAttribute('innerHTML').then(function (aInnerHTML) {
+            expect(aInnerHTML.indexOf("<strong>")).toBeGreaterThan(-1, "name was used instead of markdownName");
+        });
+    });
+
     if (!process.env.TRAVIS) {
         var menuDropdowns, disabledSubMenuOptions;
         it('should have a disabled "Records" link.', function () {

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -50,7 +50,7 @@ describe('Navbar ', function() {
 
     it('should render a markdown pattern using proper HTML', function () {
         // in travis we don't have the same globus groups so the "show" ACL hides the 3rd link ("Records")
-        var idx = (!process.env.TRAVIS ? 3 : 2)
+        var idx = (!process.env.TRAVIS ? 3 : 2);
         // option #4 has only markdownName defined
         element.all(by.css('#navbar-menu > li.dropdown')).get(3).element(by.css("a")).getAttribute('innerHTML').then(function (aInnerHTML) {
             expect(aInnerHTML.indexOf("<strong>")).toBeGreaterThan(-1, "name was used instead of markdownName");


### PR DESCRIPTION
Added markdown name support to navbar menu and submenu options. This allows for markdown patterns to be defined to attach extra attributes (including class) to the element being defined. 