### PR TITLE
Handle 404 for rid search input

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -590,7 +590,7 @@
                     // if no logged in user, change the message
                     var messageReplacement = (exception instanceof Errors.noRecordError ? messageMap.noRecordForFilter : messageMap.noRecordForRid);
                     message = messageReplacement + '<br>' + messageMap.maybeUnauthorizedMessage;
-                }else {
+                } else {
                     message += " " + messageMap.maybeNeedLogin;
                 }
             }

--- a/common/modal.js
+++ b/common/modal.js
@@ -40,11 +40,6 @@
             var modalInstance = $uibModal.open(params);
 
             modalInstance.rendered.then(function () {
-                try {
-                    // angular.element(document.querySelector(".modal-body")).scrollTop(0);
-                } catch (err) {
-                    $log.warn(err);
-                }
                 if (postRenderCB) postRenderCB();
             }).catch(function (error) {
                 $log.warn(error);

--- a/common/modal.js
+++ b/common/modal.js
@@ -75,7 +75,7 @@
          */
         function openSharePopup (tuple, reference, extraParams) {
             var defer = $q.defer();
-            
+
             var refTable = reference.table;
             var params = extraParams || {};
 
@@ -87,7 +87,7 @@
             params.versionLink = UriUtils.resolvePermalink(tuple, reference, versionString);
             params.versionDateRelative = UiUtils.humanizeTimestamp(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
             params.versionDate = UiUtils.versionDate(ERMrest.versionDecodeBase32(refTable.schema.catalog.snaptime));
-            
+
             var stack = params.logStack ? params.logStack : logService.getStackObject();
             var snaptimeHeader = {
                 action: logService.getActionString(logService.logActions.SHARE_OPEN, params.logStackPath),
@@ -108,10 +108,10 @@
                         params: params
                     }
                 }, false, false, false); // not defining any extra callbacks
-                
+
                 defer.resolve();
             });
-            
+
             return defer.promise;
         }
 
@@ -206,9 +206,11 @@
             vm.clickActionMessage =  messageMap.clickActionMessage.multipleRecords;
         } else if (exception instanceof Errors.noRecordError) {
             vm.clickActionMessage = messageMap.clickActionMessage.noRecordsFound;
+        } else if (exception instanceof Errors.NoRecordRidError) {
+            vm.clickActionMessage = exception.errorData.clickActionMessage;
         } else if (exception instanceof Errors.DifferentUserConflictError) {
             vm.showOkBtn = false;
-            vm.showReloadBtn = exception.showReloadBtn;;
+            vm.showReloadBtn = exception.showReloadBtn;
             vm.showContinueBtn = exception.showContinueBtn;
             // contains the `reloadMessage` already since it's customized in the error
             vm.clickActionMessage = exception.errorData.clickActionMessage;
@@ -355,7 +357,7 @@
             // log related attributes
             logStack:                  logStack,
             logStackPath:              params.logStackPath ? params.logStackPath : null,
-            logAppMode:                params.logAppMode ? params.logAppMode : null, 
+            logAppMode:                params.logAppMode ? params.logAppMode : null,
 
             // used for the recordset height and sticky section logic
             // TODO different modals should pass different strings (ultimatly it should be the element and not selector)
@@ -484,7 +486,7 @@
      *   - {Object[]} extraInformation (optional) - An array of objects that will be displayed. Each element can be either
      *                {value: "string", title: "string"} or {title: "string", value: "string", link: "string", type: "link"}
      *   - {Object} logStackPath (optional) - if you want to change the default log stack path of the app
-     *   - {Object} logStack (optional) - if you want to change the default log stack object of the app 
+     *   - {Object} logStack (optional) - if you want to change the default log stack object of the app
      */
     .controller('ShareCitationController', ['logService', 'params', '$rootScope', '$uibModalInstance', '$window', function (logService, params, $rootScope, $uibModalInstance, $window) {
         var vm = this;

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -395,6 +395,7 @@
                             $window.open(url, '_blank');
                         }).catch(function (err) {
                             console.log(err);
+                            $rootScope.showSpinner = false;
                             AlertsService.addAlert("No record with input RID, " + scope.ridSearchTerm + ", exists. Please check the input value is valid and try again.", "warning");
                         });
 

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -214,7 +214,7 @@
         'chaise.login',
         'chaise.utils'
     ])
-    .directive('navbar', ['AlertsService', 'ConfigUtils', 'ERMrest', 'Errors', 'ErrorService', 'logService', 'Session', 'UriUtils', '$rootScope', '$sce', '$timeout', '$window', function(AlertsService, ConfigUtils, ERMrest, Errors, ErrorService, logService, Session, UriUtils, $rootScope, $sce, $timeout, $window) {
+    .directive('navbar', ['ConfigUtils', 'ERMrest', 'Errors', 'ErrorService', 'logService', 'Session', 'UriUtils', '$rootScope', '$sce', '$timeout', '$window', function(ConfigUtils, ERMrest, Errors, ErrorService, logService, Session, UriUtils, $rootScope, $sce, $timeout, $window) {
         var chaiseConfig = ConfigUtils.getConfigJSON();
 
         // One-time transformation of chaiseConfig.navbarMenu to set the appropriate newTab setting at each node

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -214,7 +214,7 @@
         'chaise.login',
         'chaise.utils'
     ])
-    .directive('navbar', ['AlertsService', 'ConfigUtils', 'ERMrest', 'logService', 'Session', 'UriUtils', '$rootScope', '$sce', '$timeout', '$window', function(AlertsService, ConfigUtils, ERMrest, logService, Session, UriUtils, $rootScope, $sce, $timeout, $window) {
+    .directive('navbar', ['AlertsService', 'ConfigUtils', 'ERMrest', 'Errors', 'ErrorService', 'logService', 'Session', 'UriUtils', '$rootScope', '$sce', '$timeout', '$window', function(AlertsService, ConfigUtils, ERMrest, Errors, ErrorService, logService, Session, UriUtils, $rootScope, $sce, $timeout, $window) {
         var chaiseConfig = ConfigUtils.getConfigJSON();
 
         // One-time transformation of chaiseConfig.navbarMenu to set the appropriate newTab setting at each node
@@ -396,9 +396,11 @@
                             scope.showRidSpinner = false;
                             $window.open(url, '_blank');
                         }).catch(function (err) {
-                            console.log(err);
                             scope.showRidSpinner = false;
-                            AlertsService.addAlert("No record with input RID, " + scope.ridSearchTerm + ", exists. Please check the input value is valid and try again.", "warning");
+                            if (err.status == 404) {
+                                err = new Errors.NoRecordRidError();
+                            }
+                            throw err;
                         });
 
                     }

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -365,7 +365,7 @@
                     //  - if resolverImplicitCatalog === catalogId:   /id/RID
                     //  - otherwise:                                  /id/catalogId/RID
                     scope.ridSearch = function () {
-                        $rootScope.showSpinner = true;
+                        scope.showRidSpinner = true;
                         var resolverId = chaiseConfig.resolverImplicitCatalog,
                             url = "/id/", catId, splitId;
 
@@ -384,18 +384,20 @@
                         // implicitly does the isCatalogDefined(catalogId) check with how function returns true/false
                         if (scope.isVersioned()) url += "@" + splitId.version;
 
-                        logService.logClientAction({
-                            action: logService.getActionString(logService.logActions.NAVBAR_RID_SEARCH, "", ""),
-                            rid: scope.ridSearchTerm
-                        });
+                        var logObj = ConfigUtils.getContextHeaderParams(), headers = {};
+
+                        logObj.action = logService.getActionString(logService.logActions.NAVBAR_RID_SEARCH, "", "");
+                        logObj.rid = scope.ridSearchTerm;
+
+                        headers[ERMrest.contextHeaderName] = logObj;
 
                         // try to fetch the resolver link to see if the path resolves before sending the user
-                        ConfigUtils.getHTTPService().get(url, {}).then(function (response) {
-                            $rootScope.showSpinner = false;
+                        ConfigUtils.getHTTPService().get(url, {headers: headers}).then(function (response) {
+                            scope.showRidSpinner = false;
                             $window.open(url, '_blank');
                         }).catch(function (err) {
                             console.log(err);
-                            $rootScope.showSpinner = false;
+                            scope.showRidSpinner = false;
                             AlertsService.addAlert("No record with input RID, " + scope.ridSearchTerm + ", exists. Please check the input value is valid and try again.", "warning");
                         });
 

--- a/common/navbar.js
+++ b/common/navbar.js
@@ -390,18 +390,9 @@
                         });
 
                         // try to fetch the resolver link to see if the path resolves before sending the user
-                        // NOTE: .head returns a 405 error (not allowed) for proper RIDs, maybe ask Karl if this is expected
-                        ConfigUtils.getHTTPService().head(url, {}).then(function (response) {
+                        ConfigUtils.getHTTPService().get(url, {}).then(function (response) {
                             $rootScope.showSpinner = false;
                             $window.open(url, '_blank');
-                        }, function (rejResponse) {
-                            $rootScope.showSpinner = false;
-
-                            if (rejResponse.status == 405) {
-                                $window.open(url, '_blank');
-                            } else {
-                                throw rejResponse;
-                            }
                         }).catch(function (err) {
                             console.log(err);
                             AlertsService.addAlert("No record with input RID, " + scope.ridSearchTerm + ", exists. Please check the input value is valid and try again.", "warning");

--- a/common/styles/scss/_navbar.scss
+++ b/common/styles/scss/_navbar.scss
@@ -133,6 +133,10 @@ body > .container {
         border-color: $black-color;
         border-radius: 4px 0px 0px 4px;
     }
+
+    .chaise-search-btn .glyphicon-refresh {
+        color: white;
+    }
 }
 
 #rid-search-input {

--- a/common/templates/navbar.html
+++ b/common/templates/navbar.html
@@ -32,7 +32,7 @@
                     <input id="rid-search-input" class="chaise-input-control chaise-input-control-sm has-feedback" type="text" ng-model="ridSearchTerm" on-enter="::ridSearch()" placeholder="Go to RID"></input>
                     <div class="chaise-input-group-append">
                         <button class="chaise-search-btn chaise-btn chaise-btn-sm chaise-btn-primary" ng-click="::ridSearch()" role="button">
-                            <span class="glyphicon glyphicon-share-alt"></span>
+                            <span class="glyphicon chaise-btn-icon" ng-class="{'glyphicon-share-alt': !showRidSpinner, 'glyphicon-refresh glyphicon-refresh-animate': showRidSpinner}"></span>
                         </button>
                     </div>
                 </div>

--- a/common/utils.js
+++ b/common/utils.js
@@ -114,6 +114,7 @@
         "unauthorizedMessage" : "You are not authorized to perform this action.",
         "reportErrorToAdmin" : " Please report this problem to your system administrators.",
         "noRecordForFilter" : "No matching record found for the given filter or facet.",
+        "noRecordForRid" : "No matching record found for the given RID.",
         "loginRequired": "Login Required",
         "permissionDenied": "Permission Denied",
         "loginStatusChanged": "Unexpected Change of Login Status",

--- a/test/e2e/data_setup/config/record/links.config.json
+++ b/test/e2e/data_setup/config/record/links.config.json
@@ -1,5 +1,9 @@
 {
-    "catalog": {},
+    "catalog": {
+        "acls": {
+            "enumerate": ["*"]
+        }
+    },
     "schema": {
         "name": "links",
         "createNew": true,

--- a/test/e2e/specs/all-features-confirmation/chaise-config.js
+++ b/test/e2e/specs/all-features-confirmation/chaise-config.js
@@ -6,6 +6,7 @@ var chaiseConfig = {
     deleteRecord: true,
     CONFIRMDELETE: false, //testing case-insensitive properties
     confirmDelete: true, //testing case-insensitive properties, this one is used over the previous one
+    dataBrowser: '/',
     deFAuLtCaTAlog: 1, //testing case-insensitive properties
     maxRelatedTablesOpen: 6,
     maxRecordsetRowHeight: false, // triggers (ignores) some logic in ellipsis.js. Tests view buttons having proper links

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -12,7 +12,7 @@ var testParams = {
     deletionErrTextBooking : "This entry cannot be deleted as it is still referenced from the booking table. All dependent entries must be removed before this item can be deleted. If you have trouble removing dependencies please contact the site administrator.\n\nClick OK to go to the Accommodations.\nShow Error Details",
     deletionErrTextAccommodationImg : "This entry cannot be deleted as it is still referenced from the accommodation_image table. All dependent entries must be removed before this item can be deleted.\n\nClick OK to go to the Accommodations.\nShow Error Details",
     uniqueConstraint : "Error The entry cannot be created/updated. Please use a different ID for this record.",
-    recordNotFoundModalText : "The record does not exist or may be hidden. If you continue to face this issue, please contact the system administrator.\n\nClick OK to show the list of all records.\nShow Error Details",
+    recordNotFoundModalText : "The record does not exist or may be hidden.\nIf you continue to face this issue, please contact the system administrator.\n\nClick OK to show the list of all records.\nShow Error Details",
     multipleRecordFoundModalText : "There are more than 1 record found for the filters provided.\n\nClick OK to show all the matched records.\nShow Error Details",
     tableNotFoundModalText : function() { return "Table " + this.tableNotFound + " not found in schema.\n\nClick OK to go to the Home Page."},
     sizeNotValidModalText : function() { return "'limit' must be greater than 0\n\nClick OK to go to the " + this.multipleRecordsTable + ".\nClick Reload to start over."},

--- a/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
+++ b/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
@@ -1,4 +1,5 @@
 var chaisePage = require('../../../utils/chaise.page.js');
+var EC = protractor.ExpectedConditions;
 var testParams = {
     table_name: "accommodation",
     key: {
@@ -48,39 +49,33 @@ describe('View existing record,', function() {
             done();
         });
 
-        if (process.env.TRAVIS) {
-            // test RID search and resolverImplicitCatalog
-            it('should navigate to a record page if a proper RID is typed into the RID search box', function (done) {
-                var rid = chaisePage.getEntityRow("product-record", testParams.table_name, [{column: "id",value: "2004"}]).RID
-                var allWindows;
+        // test RID search and resolverImplicitCatalog
+        // NOTE: resolverImplicitCatalog=4 so locally catalog 4 does not exist and resolver should fail since no RID exists in catalog 4
+        // in travis, resolver isn't configured
+        it('should show a warning message if an improper RID is typed into the RID search box', function (done) {
+            var rid = chaisePage.getEntityRow("product-record", testParams.table_name, [{column: "id",value: "2004"}]).RID
+            var allWindows;
 
-                element(by.id('rid-search-input')).sendKeys(rid);
-                element(by.css('.rid-search .chaise-search-btn')).click().then(function () {
-                    return browser.getAllWindowHandles();
-                }).then(function (tabs) {
-                    allWindows = tabs;
-                    expect(allWindows.length).toBe(2, "new tab wasn't opened");
+            element(by.id('rid-search-input')).sendKeys(rid);
+            element(by.css('.rid-search .chaise-search-btn')).click().then(function () {
+                // wait for the alert to show before continuing
+                var alert = element(by.repeater('alert in alerts').row(0));
+                browser.wait(EC.visibilityOf(alert), browser.params.defaultTimeout);
 
-                    return browser.switchTo().window(allWindows[1]);
-                }).then(function () {
+                return chaisePage.recordEditPage.getAlertWarning();
+            }).then(function (alertElement) {
+                return alertElement.getText();
+            }).then(function(text) {
+                expect(text.indexOf("Warning No record with input RID, " + rid + ", exists. Please check the input value is valid and try again.")).toBeGreaterThan(-1, "The alert warning message was incorrect");
 
-                    return browser.driver.getCurrentUrl();
-                }).then(function (url) {
-                    // runs in travis when resolverImplicitCatalog is the same as catalogId on catalog 4
-                    var newTabUrl = browser.params.origin + "/id/" + rid;
-                    // resolver isn't on in travis so testing the output of search by RID without a redirect
-                    expect(url).toBe(newTabUrl, "new tab url doesn't include the resolver path with rid and no catalog");
-                    browser.close();
-
-                    return browser.switchTo().window(allWindows[0]);
-                }).then(function () {
-                    done();
-                }).catch(function (err) {
-                    console.dir(err);
-                    done.fail();
-                });
+                done();
+            }).catch(function (err) {
+                console.dir(err);
+                done.fail();
             });
+        });
 
+        if (process.env.TRAVIS) {
             it ("Should have the proper permalink in the share popup if resolverImplicitCatalog is the same as catalogId", function (done) {
                 var permalink = browser.params.origin+"/id/"+chaisePage.getEntityRow("product-record", testParams.table_name, [{column: "id",value: "4004"}]).RID;
 


### PR DESCRIPTION
I modified go to RID function to send a head request to the server first to see if the resource exists before trying to navigate there. If the server returns 405 (not allowed), we know the RID exists and should continue with navigating the user to the record page with the input RID.

I added a test that only runs locally to verify the resolver is working properly with a valid RID input into the RID search box. I modified the other test to run in both cases since locally catalog 4 shouldn't exist and in travis the resolver isn't configured even though we have the chaise config property (`resolverImplicitCatalog` set). Both of these cases should throw a warning message.