### PR TITLE
Viewer app configuration changes

### DIFF
--- a/common/authen.js
+++ b/common/authen.js
@@ -538,7 +538,7 @@
 
     // If app is not search, viewer and login then attach the unauthorised 401 http handler to ermrestjs
 
-    if (pathname.indexOf('/search/') == -1 && pathname.indexOf('/viewer/') == -1 && pathname.indexOf('/login') == -1) {
+    if (pathname.indexOf('/login') == -1) {
 
         angular.module('chaise.authen')
 

--- a/common/errors.js
+++ b/common/errors.js
@@ -514,8 +514,8 @@
             // if network is offline, use offline dialog workflow
             if (!$window.navigator.onLine) return offlineModalTemplate(exception, "Please check that you are still connected to your network. ", null, true);
 
-            // don't throw an angular error if in search/viewer or one has already been thrown
-            if (exceptionFlag || window.location.pathname.indexOf('/search/') != -1 || window.location.pathname.indexOf('/viewer/') != -1) return;
+            // don't throw an angular error if has already been thrown
+            if (exceptionFlag) return;
 
             // If not authorized, ask user to sign in first
             if (ERMrest && exception instanceof ERMrest.UnauthorizedError) {

--- a/common/utils.js
+++ b/common/utils.js
@@ -2566,6 +2566,7 @@
 
             // - server:
             VIEWER_ANNOT_FETCH: clientPathActionSeparator + "fetch",
+            VIEWER_CHANNEL_DEFAULT_LOAD: "z-default" + clientPathActionSeparator + "load",
 
             // - client:
             VIEWER_ANNOT_PANEL_SHOW: "toolbar/panel" + clientPathActionSeparator + "show",

--- a/viewer/constant.js
+++ b/viewer/constant.js
@@ -13,6 +13,8 @@
             IMAGE_URL_QPARAM: "url",
             CHANNEL_NAME_QPARAM: "channelName",
             PSEUDO_COLOR_QPARAM: "pseudoColor",
+            PIXEL_PER_METER_QPARAM: "meterScaleInPixels",
+            WATERMARK_QPARAM: "waterMark",
             IS_RGB_QPARAM: "isRGB",
             CHANNEL_QPARAMS: [
                 "url", "aliasName", "channelName", "pseudoColor", "isRGB"
@@ -24,26 +26,68 @@
         },
         image: {
             URI_COLUMN_NAME: "uri",
-            DEFAULT_Z_INDEX_COLUMN_NAME: "Default_Z" // the default value of the zindex in the form TODO
+            DEFAULT_Z_INDEX_COLUMN_NAME: "Default_Z", // the default value of the zindex in the form
+
+            // used for meterScaleInPixels qparam
+            PIXEL_PER_METER_COLUMN_NAME: "Pixels_Per_Meter",
+
+            // used for watermark
+            CONSORTIUM_VISIBLE_COLUMN_NAME: "Pq797msQqRnD3Je3Jp01HQ",
+            CONSORTIUM_URL_COLUMN_NAME: "URL"
+        },
+        processedImage: {
+            // how many at a time should we read from database
+            PAGE_SIZE: 25,
+
+            PROCESSED_IMAGE_TABLE_SCHEMA_NAME: "Gene_Expression",
+            PROCESSED_IMAGE_TABLE_NAME: "Processed_Image",
+
+            // the sort criteria
+            COLUMN_ORDER: [{
+                "column": "Z_Index",
+                "descending": false
+            }, {
+                "column": "Channel_Number",
+                "descending": false
+            }],
+
+            // where to filter based on z_index and the iamge
+            Z_INDEX_COLUMN_NAME: "Z_Index",
+            REFERENCE_IMAGE_COLUMN_NAME: "Reference_Image",
+
+            IMAGE_URL_COLUMN_NAME: "File_URL",
+
+            //{"source": [{"outbound": ["Gene_Expression", "Processed_Image_Reference_Image_Channel_Number_fkey"]}, "RID"], "entity": true}
+            CHANNEL_VISIBLE_COLUMN_NAME: "AeweZsAMVSdW7Vf91boEfw",
+
+            DISPLAY_METHOD_COLUMN_NAME: "Display_Method",
+
+            // how to generate the url
+            IIIF_VERSION: "2",
+            IMAGE_URL_PATTERN: {
+                "iiif": "/iiif/{{{iiif_version}}}/{{#encode url}}{{/encode}}/info.json"
+            }
+
         },
         channel: {
+            // how many channels at a time should we read from database
+            PAGE_SIZE: 25,
+
             CHANNEL_TABLE_NAME: "Image_Channel",
             CHANNE_TABLE_SCHEMA_NAME: "Gene_Expression",
 
+            // the sort criteria
             CHANNEL_TABLE_COLUMN_ORDER: [{
                 "column": "Channel_Number",
                 "descending": false
             }],
 
             REFERENCE_IMAGE_COLUMN_NAME: "Image",
-
             CHANNEL_NAME_COLUMN_NAME: "Name",
             PSEUDO_COLOR_COLUMN_NAME: "Pseudo_Color",
-            IS_RGB_COLUMN_NAME: "IS_RGB",
-            IMAGE_URL_COLUMN_NAME: "Image_URL",
+            IS_RGB_COLUMN_NAME: "Is_RGB",
+            IMAGE_URL_COLUMN_NAME: "Image_URL"
 
-            // how many channels at a time should we read from database
-            PAGE_COUNT: 25,
         },
         annotation: {
             // how much should we wait for user action and then log
@@ -51,7 +95,7 @@
             LINE_THICKNESS_LOG_TIMEOUT: 1000,
 
             // how many annotations at a time should we read from database
-            PAGE_COUNT: 25,
+            PAGE_SIZE: 25,
 
             // annotation table
             ANNOTATION_TABLE_NAME: "Image_Annotation",
@@ -78,7 +122,7 @@
             ANNOTATED_TERM_TABLE_NAME: "Anatomy",
             ANNOTATED_TERM_TABLE_SCHEMA_NAME: "Vocabulary",
             ANNOTATED_TERM_ID_COLUMN_NAME: "ID",
-            ANNOTATED_TERM_NAME_COLUMN_NAME: "Name",
+            ANNOTATED_TERM_NAME_COLUMN_NAME: "Name"
         }
     })
 })();

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -319,7 +319,7 @@
                 // osd controller uses this attribute to parameterize OSD viewer
                 // TODO should eventually be a proper object and not just query parameters
                 $rootScope.osdViewerParameters = osdViewerQueryParams;
-                if (!DataUtils.isObjectAndKeyDefined(osdViewerQueryParams, "url")) {
+                if (!DataUtils.isObjectAndNotNull(osdViewerQueryParams) || !(osdConstant.IMAGE_URL_QPARAM in osdViewerQueryParams)) {
                     console.log("there wasn't any parameters that we could send to OSD viewer");
                     // TODO better error
                     throw new ERMrest.MalformedURIError("Image information is missing.");

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -144,7 +144,7 @@
         var rectangles = [];
         var sections = [];
         var session;
-        var imageURI, svgURIs = [];
+        var imageURI, svgURIs = [], imageTuple;
         var config = ConfigUtils.getContextJSON();
         var annotConstant = viewerConstant.annotation;
         var imageConstant = viewerConstant.image;
@@ -225,7 +225,7 @@
                 if (pcid) logObj.pcid = pcid;
                 if (ppid) logObj.ppid = ppid;
                 if (isQueryParameter) logObj.cqp = 1;
-                return imageReference.contextualize.detailed.read(1, logObj, true, true);
+                return imageReference.contextualize.detailed.read(1, logObj, false, true);
             })
             // read the main (image) reference
             .then(function (imagePage) {
@@ -237,13 +237,13 @@
                     return false;
                 }
 
-                image.entity = imagePage.tuples[0].data;
+                imageTuple = imagePage.tuples[0];
+                image.entity = imageTuple.data;
                 context.imageID = image.entity.RID;
                 imageURI = image.entity[imageConstant.URI_COLUMN_NAME];
 
-                // TODO some sort of warning maybe?
                 if (!imageURI) {
-                    console.log("The " + imageConstant.URI_COLUMN_NAME + " value is empty. We cannot show any image from database.");
+                    console.log("The " + imageConstant.URI_COLUMN_NAME + " value is empty in Image table.");
                 }
 
                 // TODO this feels hacky
@@ -256,6 +256,20 @@
                 var res = viewerAppUtils.populateOSDViewerQueryParams(pageQueryParams, imageURI);
 
                 osdViewerQueryParams = res.osdViewerQueryParams;
+
+                // add meterScaleInPixels query param if missing
+                var val = parseFloat(imageTuple.data[imageConstant.PIXEL_PER_METER_COLUMN_NAME]);
+                var qParamName = osdConstant.PIXEL_PER_METER_QPARAM;
+                if (!(qParamName in osdViewerQueryParams) && !isNaN(val)) {
+                    osdViewerQueryParams[qParamName] = val;
+                }
+
+                // add waterMark query param if missing
+                val = imageTuple.linkedData[imageConstant.CONSORTIUM_VISIBLE_COLUMN_NAME];
+                qParamName = osdConstant.WATERMARK_QPARAM;
+                if (!(qParamName in osdViewerQueryParams) && DataUtils.isObjectAndNotNull(val) && DataUtils.isNoneEmptyString(val[imageConstant.CONSORTIUM_URL_COLUMN_NAME])) {
+                    osdViewerQueryParams[qParamName] = val[imageConstant.CONSORTIUM_URL_COLUMN_NAME];
+                }
 
                 // if channel info was avaibale on queryParams or imageURI, don't fetch it from DB.
                 if (!res.readChannelInfo) {
@@ -305,7 +319,7 @@
                 // osd controller uses this attribute to parameterize OSD viewer
                 // TODO should eventually be a proper object and not just query parameters
                 $rootScope.osdViewerParameters = osdViewerQueryParams;
-                if (!DataUtils.isObjectAndNotNull(osdViewerQueryParams)) {
+                if (!DataUtils.isObjectAndKeyDefined(osdViewerQueryParams, "url")) {
                     console.log("there wasn't any parameters that we could send to OSD viewer");
                     // TODO better error
                     throw new ERMrest.MalformedURIError("Image information is missing.");


### PR DESCRIPTION
This PR will modify the viewer app so it's more aligned with the recent changes in RBK. Summary of changes are:


- Use the value of `Pixels_Per_Meter` column in the `Image` table for  `meterScaleInPixels` if it's missing from the page query parameters.
- Use the value of `URL` column in the `Consortium` table (it's a foreign key column in `Image` table) for  `waterMark` if it's missing from the page query parameters.
- If channel information is missing from the page query parameters, we will try to retrieve them from the `Process_Image` table. If it was missing from this table, we will fallback to `Image_Channel`.


Based on this, these are the newly added assumption (configurations):

`Image` table:
  - Has a `Pixels_Per_Meter` column (the name is configurable.)
  - Has a visible foreign key column to a table that has a `URL` column (visible column name is configurable.)

`Proccesssed_Image` table:
  - There's a table that has a many-to-one relationship to `Image` table based on `Z_Index` and `Reference_Image` columns (the name of the table and columns are configurable.)
  - Has a `File_URL` column for retrieving the value of channel URLs (th name is configurable.)
  - Has a visible foreign key column to a table that has the extra channel information (visible column name and channel column names are configurable.)
  - Has a `Display_Method` column that can be used for figuring out how to use the `File_URL` value (the name is configurable.)



P.S. The changes in this PR are only affecting viewer app. I modified `errors.js` and `authn.js` to make sure the errors that are thrown from the viewer app are displayed. As part of another task, I need to clean up the errors that the viewer app is throwing.


