### PR TITLE
Preformat boolean

### DIFF
--- a/common/inputs.js
+++ b/common/inputs.js
@@ -4,8 +4,6 @@
     angular.module('chaise.inputs', ['chaise.validators', 'chaise.utils'])
 
     .factory('InputUtils', ['dataFormats', 'defaultDisplayname', '$rootScope', function(dataFormats, defaultDisplayname, $rootScope) {
-        var defaultBooleanValues = [true, false];
-
         /* Functions for all input types */
         // determines if input should be disabled based on ermrestJS API
         function isDisabled(column) {
@@ -22,6 +20,22 @@
             } else if (column.isAsset) {
                 return "No file Selected";
             }
+        }
+
+        /* boolean specific function */
+        var defaultBooleanValues = [true, false];
+
+        // checks for preformat config before returning true/false
+        function formatBoolean(column, value, context) {
+            if (column.display.preformatConfig) {
+                return column.formatvalue(value, context, {});
+            }
+
+            return value;
+        }
+
+        function unformatBoolean(columnModel, value) {
+            return columnModel.booleanMap[value];
         }
 
         /* numeric specific functions */
@@ -117,6 +131,8 @@
             defaultBooleanValues: defaultBooleanValues,
             clearDatetime: clearDatetime,
             fileExtensionTypes: fileExtensionTypes,
+            formatBoolean: formatBoolean,
+            unformatBoolean: unformatBoolean,
             formatDatetime: formatDatetime,
             formatFloat: formatFloat,
             formatInt: formatInt,

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -26,12 +26,8 @@
         var defaultBooleanValues = [true, false];
 
         // checks for preformat config before returning true/false
-        function formatBoolean(column, value, context) {
-            if (column.display.preformatConfig) {
-                return column.formatvalue(value, context, {});
-            }
-
-            return value;
+        function formatBoolean(column, value) {
+            return column.formatvalue(value);
         }
 
         function unformatBoolean(columnModel, value) {

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -4,7 +4,7 @@
     angular.module('chaise.inputs', ['chaise.validators', 'chaise.utils'])
 
     .factory('InputUtils', ['dataFormats', 'defaultDisplayname', '$rootScope', function(dataFormats, defaultDisplayname, $rootScope) {
-        var booleanValues = [true, false];
+        var defaultBooleanValues = [true, false];
 
         /* Functions for all input types */
         // determines if input should be disabled based on ermrestJS API
@@ -114,7 +114,7 @@
         return {
             applyCurrentDatetime: applyCurrentDatetime,
             blurElement: blurElement,
-            booleanValues: booleanValues,
+            defaultBooleanValues: defaultBooleanValues,
             clearDatetime: clearDatetime,
             fileExtensionTypes: fileExtensionTypes,
             formatDatetime: formatDatetime,
@@ -365,7 +365,7 @@
 
                 vm.customErrorMessage = null;
                 vm.blurElement = InputUtils.blurElement;
-                vm.booleanValues = InputUtils.booleanValues;
+                vm.defaultBooleanValues = InputUtils.defaultBooleanValues;
                 vm.dataFormats = dataFormats;
                 vm.fileExtensionTypes = InputUtils.fileExtensionTypes;
                 vm.maskOptions = maskOptions;

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -514,8 +514,27 @@
                 type =  UiUtils.getInputType(column.type);
             }
 
+            if (type == 'boolean') {
+                var booleanArray = InputUtils.defaultBooleanValues,
+                    trueVal = "true",
+                    falseVal = "false";
+
+                if (column.display.preformatConfig) {
+                    trueVal = InputUtils.formatBoolean(column, true, "entry");
+                    falseVal = InputUtils.formatBoolean(column, false, "entry");
+                    booleanArray = [trueVal, falseVal];
+                }
+
+                // create map
+                var booleanMap = {};
+                booleanMap[trueVal] = true;
+                booleanMap[falseVal] = false;
+            }
+
             return {
                 allInput: undefined,
+                booleanArray: booleanArray || [],
+                booleanMap: booleanMap || {},
                 column: column,
                 isDisabled: isDisabled,
                 isRequired: !column.nullok && !isDisabled,
@@ -717,6 +736,11 @@
                         // formatDatetime takes care of column.default if null || undefined
                         initialModelValue = InputUtils.formatDatetime(defaultValue, tsOptions);
                         break;
+                    case "boolean":
+                        if (defaultValue != null) {
+                            initialModelValue = InputUtils.formatBoolean(column, defaultValue, "entry/create");
+                        }
+                        break;
                     default:
                         if (column.isAsset) {
                             var metaObj = {};
@@ -850,6 +874,9 @@
                         // If input is disabled, there's no need to transform the column value.
                         value = colModel.inputType == "disabled" ? values[i] : InputUtils.formatFloat(values[i]);
                         break;
+                    case "boolean":
+                        value = InputUtils.formatBoolean(column, values[i], "entry/edit");
+                        break;
                     default:
                         // the structure for asset type columns is an object with a 'url' property
                         if (column.isAsset) {
@@ -951,7 +978,10 @@
                                 break;
                             case "json":
                             case "jsonb":
-                                rowVal=JSON.parse(rowVal);
+                                rowVal = JSON.parse(rowVal);
+                                break;
+                            case "boolean":
+                                rowVal = InputUtils.unformatBoolean(columnToColumnModel(column), rowVal);
                                 break;
                             default:
                                 break;

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -515,15 +515,9 @@
             }
 
             if (type == 'boolean') {
-                var booleanArray = InputUtils.defaultBooleanValues,
-                    trueVal = "true",
-                    falseVal = "false";
-
-                if (column.display.preformatConfig) {
-                    trueVal = InputUtils.formatBoolean(column, true, "entry");
-                    falseVal = InputUtils.formatBoolean(column, false, "entry");
+                var trueVal = InputUtils.formatBoolean(column, true),
+                    falseVal = InputUtils.formatBoolean(column, false),
                     booleanArray = [trueVal, falseVal];
-                }
 
                 // create map
                 var booleanMap = {};
@@ -738,7 +732,7 @@
                         break;
                     case "boolean":
                         if (defaultValue != null) {
-                            initialModelValue = InputUtils.formatBoolean(column, defaultValue, "entry/create");
+                            initialModelValue = InputUtils.formatBoolean(column, defaultValue);
                         }
                         break;
                     default:
@@ -875,7 +869,7 @@
                         value = colModel.inputType == "disabled" ? values[i] : InputUtils.formatFloat(values[i]);
                         break;
                     case "boolean":
-                        value = InputUtils.formatBoolean(column, values[i], "entry/edit");
+                        value = InputUtils.formatBoolean(column, values[i]);
                         break;
                     default:
                         // the structure for asset type columns is an object with a 'url' property
@@ -981,6 +975,7 @@
                                 rowVal = JSON.parse(rowVal);
                                 break;
                             case "boolean":
+                                // call columnToColumnModel to set booleanArray and booleanMap for proper un-formatting
                                 rowVal = InputUtils.unformatBoolean(columnToColumnModel(column), rowVal);
                                 break;
                             default:

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -110,7 +110,7 @@
         <!-- So that the boolean input can be validated -->
         <input type="hidden" ng-model="vm.model" ng-required="vm.isRequired" />
         <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="inputWidth">
-            <li ng-repeat="option in ::vm.booleanValues" ng-click="vm.model = option">
+            <li ng-repeat="option in ::vm.defaultBooleanValues" ng-click="vm.model = option">
                 <a ng-bind-html="option" style="min-height: 20px;"></a>
             </li>
         </ul>

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -110,7 +110,7 @@
         <!-- So that the boolean input can be validated -->
         <input type="hidden" ng-model="vm.model" ng-required="vm.isRequired" />
         <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="inputWidth">
-            <li ng-repeat="option in ::vm.defaultBooleanValues" ng-click="vm.model = option">
+            <li ng-repeat="option in ::vm.columnModel.booleanArray" ng-click="vm.model = option">
                 <a ng-bind-html="option" style="min-height: 20px;"></a>
             </li>
         </ul>

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -49,7 +49,6 @@
         vm.int8max = integerLimits.INT_8_MAX;
 
         vm.booleanValues = booleanValues;
-        vm.defaultBooleanValues = InputUtils.defaultBooleanValues;
 
         vm.applyCurrentDatetime = applyCurrentDatetime;
         vm.toggleMeridiem = toggleMeridiem;
@@ -87,7 +86,7 @@
             }
 
             // Redirect to record or recordset app..
-            $window.location = redirectUrl;
+            // $window.location = redirectUrl;
         }
 
         /**
@@ -511,8 +510,9 @@
             return disabledValue;
         }
 
-        function booleanValues() {
-            return vm.defaultBooleanValues;
+        // returns columnModel.booleanArray for use in boolean dropdown
+        function booleanValues(colIndex) {
+            return vm.recordEditModel.columnModels[colIndex].booleanArray;
         }
 
         // Assigns the current date or timestamp to a column's model

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -806,7 +806,7 @@
                 if (DataUtils.isObjectAndNotNull(value) && value.url) noValue = false;
             } else if (columnModel.inputType === "boolean") {
                 // check if the selected value is a boolean (true|false)
-                if (typeof value === "boolean") noValue = false;
+                if (typeof value === "boolean" || (typeof value === "string" && value.length > 0)) noValue = false;
             } else {
                 if (value != null) noValue = false;
             }

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -48,7 +48,8 @@
         vm.int8min = integerLimits.INT_8_MIN;
         vm.int8max = integerLimits.INT_8_MAX;
 
-        vm.booleanValues = InputUtils.booleanValues;
+        vm.booleanValues = booleanValues;
+        vm.defaultBooleanValues = InputUtils.defaultBooleanValues;
 
         vm.applyCurrentDatetime = applyCurrentDatetime;
         vm.toggleMeridiem = toggleMeridiem;
@@ -508,6 +509,10 @@
             }
 
             return disabledValue;
+        }
+
+        function booleanValues() {
+            return vm.defaultBooleanValues;
         }
 
         // Assigns the current date or timestamp to a column's model

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -86,7 +86,7 @@
             }
 
             // Redirect to record or recordset app..
-            // $window.location = redirectUrl;
+            $window.location = redirectUrl;
         }
 
         /**

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -202,7 +202,7 @@
                                                                 <!-- So that the boolean input can be validated -->
                                                                 <input type="hidden" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" ng-required="::form.isRequired(columnIndex);" />
                                                                 <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="form.inputWidth">
-                                                                    <li ng-repeat="option in ::form.booleanValues()" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
+                                                                    <li ng-repeat="option in ::form.booleanValues(columnIndex)" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
                                                                         <a ng-bind-html="option" style="min-height: 20px;"></a>
                                                                     </li>
                                                                 </ul>

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -202,7 +202,7 @@
                                                                 <!-- So that the boolean input can be validated -->
                                                                 <input type="hidden" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" ng-required="::form.isRequired(columnIndex);" />
                                                                 <ul class="adjust-boolean-dropdown" uib-dropdown-menu role="menu" ng-style="form.inputWidth">
-                                                                    <li ng-repeat="option in ::form.booleanValues" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
+                                                                    <li ng-repeat="option in ::form.booleanValues()" ng-click="form.recordEditModel.rows[rowIndex][column.name] = option">
                                                                         <a ng-bind-html="option" style="min-height: 20px;"></a>
                                                                     </li>
                                                                 </ul>

--- a/test/e2e/data_setup/schema/recordedit/product-person.json
+++ b/test/e2e/data_setup/schema/recordedit/product-person.json
@@ -357,6 +357,15 @@
             "tag:misd.isi.edu,2015:display": {
               "name": "Is Luxurious"
             },
+            "tag:isrd.isi.edu,2016:column-display": {
+                "*": {
+                    "pre_format": {
+                        "format": "%t",
+                        "bool_true_value": "Luxurious",
+                        "bool_false_value": "Not Luxurious"
+                    }
+                }
+            },
             "tag:isrd.isi.edu,2016:ignore" : ["record"]
           }
         },

--- a/test/e2e/specs/default-config/recordedit/composite-key.spec.js
+++ b/test/e2e/specs/default-config/recordedit/composite-key.spec.js
@@ -2,13 +2,15 @@ var chaisePage = require('../../../utils/chaise.page.js');
 var recordEditHelpers = require('../../../utils/recordedit-helpers.js');
 var testParams = {
     table_name: "accommodation",
-    column_names: ["first_name", "last_name", "index", "0YGNuO_bvxoczJ6ms2k0tQ"],
+    column_names: ["luxurious", "first_name", "last_name", "index", "0YGNuO_bvxoczJ6ms2k0tQ"],
     column_values: {
+        luxurious: "Luxurious",
         first_name: "John",
         last_name: "Doe",
         index: "0",
         "0YGNuO_bvxoczJ6ms2k0tQ": "John Doe" // person foreignkey column
-    }
+    },
+    booleanOptions: ["Luxurious", "Not Luxurious"]
 };
 
 describe('Edit a record,', function() {
@@ -22,7 +24,7 @@ describe('Edit a record,', function() {
             browser.get(browser.params.url + "/recordedit/#" + browser.params.catalogId + "/product-person:" + testParams.table_name);
         });
 
-        describe("Presentation and validation for an entity with a composite key,", function() {
+        describe("Presentation and validation for an entity with a composite key and formatted boolean,", function() {
 
             var rows;
 
@@ -65,6 +67,30 @@ describe('Edit a record,', function() {
                     done();
                 }).catch(function (err) {
                     console.log(err);
+                    done.fail();
+                });
+            });
+
+            it("should show 'Luxurious' and 'Not Luxurious' as the options in the boolean dropdown menu", function (done) {
+                var trueOption = testParams.booleanOptions[0],
+                    dropdown;
+
+                chaisePage.recordEditPage.getDropdowns().then(function(el) {
+                    dropdown = el[0];
+
+                    return chaisePage.recordEditPage.getRelativeDropdownOptionsATag(dropdown);
+                }).then(function (options) {
+                    options.forEach(function (opt, idx) {
+                        expect(opt.getAttribute("innerHTML")).toBe(testParams.booleanOptions[idx], "Boolean option text with idx: " + idx + " is incorrect");
+                    });
+
+                    return chaisePage.recordEditPage.selectDropdownValue(dropdown, trueOption);
+                }).then(function(option) {
+                    expect(chaisePage.recordEditPage.getDropdownText(dropdown).getText()).toBe(trueOption, "The truthy option was not selected");
+
+                    done();
+                }).catch(function (error) {
+                    console.dir(error);
                     done.fail();
                 });
             });

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -112,8 +112,14 @@ var recordEditPage = function() {
         return element(by.id("select-all-cancel-"+columnDisplayName));
     }
 
+    // gets dropdowns relative to el
     this.getDropdownElements = function(el) {
         return el.element(by.xpath('ancestor::tr')).all(by.css(".chaise-input-control.dropdown-toggle"));
+    };
+
+    // gets all dropdowns
+    this.getDropdowns = function() {
+        return element.all(by.css(".chaise-input-control.dropdown-toggle"));
     };
 
     this.getDropdownText = function(el) {
@@ -138,9 +144,14 @@ var recordEditPage = function() {
 
     // Gets the boolean dropdown options when the dropdown is closed/hidden
     // the list is relative to the input when hidden
-    this.getRelataiveDropdownOptions = function(el) {
+    this.getRelativeDropdownOptions = function(el) {
         // el is "form-x-colname-display"
         return el.element(by.xpath('ancestor::td')).all(by.tagName('li'));
+    }
+
+    this.getRelativeDropdownOptionsATag = function(el) {
+        // el is "form-x-colname-display"
+        return el.element(by.xpath('ancestor::td')).all(by.css('li a'));
     }
 
     this.getDropdownClear = function (el) {

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -687,7 +687,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
 
                     it("should render options for a boolean field", function() {
                         dropdowns.forEach(function(dropdown) {
-                            chaisePage.recordEditPage.getRelataiveDropdownOptions(dropdown.dropdownInput).then(function(items) {
+                            chaisePage.recordEditPage.getRelativeDropdownOptions(dropdown.dropdownInput).then(function(items) {
                                 expect(items.length).toBe(2, colError(dropdown.column.name, "Number of available options is not as expected."));
                             });
                         });


### PR DESCRIPTION
Changed input utils to format boolean values based on `column.display.preformatConfig` if it is present. This was only an issue in recordedit which didn't show the pre-formatted boolean values in the dropdown. This also applies when reading data in for edit mode. Before submitting the data to ermrestJS for create/update, we have to convert the "formatted" value back to the raw boolean value. This can be tested here:
https://dev.rebuildingakidney.org/~jchudy/chaise/recordedit/#2/Common:Collection/

I think it makes sense to do this in chaise since it applies to the display of the content.