### PR TITLE
Iframe fullscreen button

### DIFF
--- a/common/styles/scss/_markdown-container.scss
+++ b/common/styles/scss/_markdown-container.scss
@@ -33,6 +33,7 @@
         }
 
         .iframe-btn-container {
+            float: right;
             text-align: right;
             margin-top: 10px;
 

--- a/common/styles/scss/_markdown-container.scss
+++ b/common/styles/scss/_markdown-container.scss
@@ -21,6 +21,26 @@
         margin: 5px 5px 5px 0;
     }
 
+    figure {
+        // overflow-x: auto;
+    }
+
+    .iframe-btn-container {
+        width: 20%;
+        text-align: right;
+
+        .chaise-btn.chaise-btn-iframe {
+            border: 2px solid #ccc;
+            border-bottom: none;
+            border-bottom-right-radius: 0px;
+            border-bottom-left-radius: 0px;
+        }
+    }
+
+    .chaise-btn-iframe:hover {
+        text-decoration: none;
+    }
+
     .chaise-autofill {
         height: 90%;
         height: -webkit-fill-available;

--- a/common/styles/scss/_markdown-container.scss
+++ b/common/styles/scss/_markdown-container.scss
@@ -27,8 +27,6 @@
         }
 
         .figcaption-wrapper {
-            min-height: 35px; // to account for margin + button height since button is "floating"
-
             figcaption {
                 display: inline;
             }
@@ -47,6 +45,12 @@
 
             .chaise-btn-iframe:hover {
                 text-decoration: none;
+            }
+        }
+
+        &.fullscreen-off  {
+            .iframe-btn-container {
+                display: none;
             }
         }
 

--- a/common/styles/scss/_markdown-container.scss
+++ b/common/styles/scss/_markdown-container.scss
@@ -22,23 +22,39 @@
     }
 
     figure {
-        // overflow-x: auto;
-    }
-
-    .iframe-btn-container {
-        width: 20%;
-        text-align: right;
-
-        .chaise-btn.chaise-btn-iframe {
-            border: 2px solid #ccc;
-            border-bottom: none;
-            border-bottom-right-radius: 0px;
-            border-bottom-left-radius: 0px;
+        figcaption {
+            min-height: 20px;
         }
-    }
 
-    .chaise-btn-iframe:hover {
-        text-decoration: none;
+        .figcaption-wrapper {
+            min-height: 35px; // to account for margin + button height since button is "floating"
+            margin-top: 5px;
+
+            figcaption {
+                display: inline;
+            }
+        }
+
+        .iframe-btn-container {
+            text-align: right;
+            margin-top: 5px;
+
+            .chaise-btn.chaise-btn-iframe {
+                border: 2px solid #ccc;
+                border-bottom: none;
+                border-bottom-right-radius: 0px;
+                border-bottom-left-radius: 0px;
+            }
+
+            .chaise-btn-iframe:hover {
+                text-decoration: none;
+            }
+        }
+
+        // override the browser's default border
+        iframe {
+            border: 2px solid #ccc;
+        }
     }
 
     .chaise-autofill {
@@ -48,11 +64,6 @@
         width: 100%;
         width: -webkit-fill-available;
         width: -moz-available;
-    }
-
-    // override the browser's default border
-    iframe {
-        border: 2px solid #ccc;
     }
 
     // chaise-color-preview

--- a/common/styles/scss/_markdown-container.scss
+++ b/common/styles/scss/_markdown-container.scss
@@ -28,7 +28,6 @@
 
         .figcaption-wrapper {
             min-height: 35px; // to account for margin + button height since button is "floating"
-            margin-top: 5px;
 
             figcaption {
                 display: inline;
@@ -37,7 +36,7 @@
 
         .iframe-btn-container {
             text-align: right;
-            margin-top: 5px;
+            margin-top: 10px;
 
             .chaise-btn.chaise-btn-iframe {
                 border: 2px solid #ccc;


### PR DESCRIPTION
Styles added to chaise stylesheets to add a fullscreen button to the top right of all iframes generated using the iframe template in markdown. This also adds styles to hide that button when the `fullscreen-off` class is attached to the encompassing `<figure>`.