### PR TITLE
Test the session expired alert

### DIFF
--- a/test/e2e/data_setup/config/record/links.config.json
+++ b/test/e2e/data_setup/config/record/links.config.json
@@ -1,9 +1,5 @@
 {
-    "catalog": {
-        "acls": {
-            "enumerate": ["*"]
-        }
-    },
+    "catalog": {},
     "schema": {
         "name": "links",
         "createNew": true,

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -152,7 +152,7 @@ describe('Error related test cases,', function() {
             chaisePage.clickButton(chaisePage.recordPage.getErrorModalOkButton()).then (function (){
                 return browser.driver.getCurrentUrl();
             }).then (function(currentUrl) {
-                var newapplink = url.replace("record", "recordset");
+                var newapplink = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable;
                 expect(currentUrl).toContain(newapplink, "The redirection from record page to recordset in case of multiple records failed");
                 done();
             }).catch(chaisePage.catchTestError(done));

--- a/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
+++ b/test/e2e/specs/all-features-confirmation/errors/errors.spec.js
@@ -65,7 +65,7 @@ describe('Error related test cases,', function() {
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
                 expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
 
         it('On click of OK button the page should redirect to recordset page', function(done){
@@ -77,7 +77,7 @@ describe('Error related test cases,', function() {
                   recordsetUrl = newapplink.slice(0, lastSlash);
                 expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -113,7 +113,7 @@ describe('Error related test cases,', function() {
                   }
                 expect(currentUrl).toBe(homePage, "The redirection from record page to Home page failed");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -145,7 +145,7 @@ describe('Error related test cases,', function() {
                 expect(showDetails.getText()).toBe(testParams.hideErrors, "The Show/Hide message in modal pop is not correct");
                 expect(errorDetails.getText()).toContain("Error", "error missmatch.");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
 
         it('On click of OK button the page should redirect to recordset page', function(done){
@@ -155,7 +155,7 @@ describe('Error related test cases,', function() {
                 var newapplink = url.replace("record", "recordset");
                 expect(currentUrl).toContain(newapplink, "The redirection from record page to recordset in case of multiple records failed");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -191,7 +191,7 @@ describe('Error related test cases,', function() {
                   }
                  expect(currentUrl).toBe(homePage, "The redirection from recordset page to Home page failed");
                  done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -221,7 +221,7 @@ describe('Error related test cases,', function() {
                 // Added OR case to avoid discrepancy in error message when table is deleted
                 expect(errorText == testParams.conflictRecordEditErrorBooking || errorText == testParams.conflictRecordEditErrorAccommodationImg ).toBe(true, "409 Conflict could not be matched! Check conflict during deletion in RecordEdit.");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
 
         it('On click of Reload button the page should reload itself in Recordedit app', function(done){
@@ -230,7 +230,7 @@ describe('Error related test cases,', function() {
             }).then (function(currentUrl) {
                 expect(currentUrl).toBe(currentUrl, "Reload button could not refresh the recordedit page.");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     }).pend("no button on Recordedit for delete");
 
@@ -265,7 +265,7 @@ describe('Error related test cases,', function() {
               // Added OR case to avoid discrepancy in error message when table is deleted
               expect(errorText == testParams.deletionErrTextBooking || errorText == testParams.deletionErrTextAccommodationImg).toBe(true, "409 Conflict could not be matched! Check conflict during deletion.");
               done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
     });
 
@@ -290,7 +290,7 @@ describe('Error related test cases,', function() {
             }).then (function(currentUrl) {
                 expect(currentUrl).toContain('id=269111', "The back button failed to go back to previous page.");
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
 
     });
@@ -316,7 +316,7 @@ describe('Error related test cases,', function() {
                 chaisePage.waitForElement(closeModal);
                 expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -341,7 +341,7 @@ describe('Error related test cases,', function() {
                 chaisePage.waitForElement(closeModal);
                 expect(closeModal.isDisplayed()).toBeTruthy('Close modal option is not available for conflict/forbiddden errors');
                 done();
-            }).catch(catchError(done));
+            }).catch(chaisePage.catchTestError(done));
         });
     });
 
@@ -364,7 +364,7 @@ describe('Error related test cases,', function() {
           }).then(function (errorText) {
               expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
               done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
 
       it('On click of OK button the page should reload the page without paging condition but with invalid filter conditions', function(done){
@@ -378,7 +378,7 @@ describe('Error related test cases,', function() {
            }).then(function (errorText) {
                expect(errorText).toBe(testParams.facetErrorstext.invalidFilterOperatorErrorBody, "Error action text did not match");
                done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
 
       it('On click of OK button the page should redirect to RecordSet', function(done){
@@ -388,7 +388,7 @@ describe('Error related test cases,', function() {
              recordsetWithoutFacetUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name + "/";
              expect(currentUrl).toBe(recordsetWithoutFacetUrl, "The redirection to Recordset page failed");
              done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
 
     });
@@ -416,7 +416,7 @@ describe('Error related test cases,', function() {
           }).then(function (errorText) {
               expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
               done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
 
       it('On click of OK button the page should reload the page without paging conditions', function(done){
@@ -426,115 +426,151 @@ describe('Error related test cases,', function() {
              recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
              expect(currentUrl).toBe(recordsetPage, "The redirection to RecordEdit page failed");
              done();
-          }).catch(catchError(done));
+          }).catch(chaisePage.catchTestError(done));
       });
 
     });
 
-        describe("Error check for invalid paging changes in RecordSet", function(){
+    describe("Error check for invalid paging changes in RecordSet", function(){
 
-          beforeAll(function() {
-            browser.ignoreSynchronization = true;
-              pageTestUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
-              browser.get(pageTestUrl);
-          });
+      beforeAll(function() {
+        browser.ignoreSynchronization = true;
+          pageTestUrl = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2002@after()";
+          browser.get(pageTestUrl);
+      });
 
-          it("should be returned Invalid Page Criteria", function (done) {
-              var modalTitle = chaisePage.recordEditPage.getModalTitle(),
-                  modalActionBody = chaisePage.recordEditPage.getModalActionBody();
+      it("should be returned Invalid Page Criteria", function (done) {
+          var modalTitle = chaisePage.recordEditPage.getModalTitle(),
+              modalActionBody = chaisePage.recordEditPage.getModalActionBody();
 
-              chaisePage.waitForElement(modalTitle).then(function(){
-                  return modalTitle.getText();
-              }).then(function (text) {
-                  expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
-                  return modalActionBody.getText();
-              }).then(function (errorText) {
-                  expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
-                  done();
-              }).catch(catchError(done));
-          });
+          chaisePage.waitForElement(modalTitle).then(function(){
+              return modalTitle.getText();
+          }).then(function (text) {
+              expect(text).toBe(testParams.facetErrorstext.invalidPageCriteriaTitle, "Invalid Page Criteria error pop-up could not be opened!");
+              return modalActionBody.getText();
+          }).then(function (errorText) {
+              expect(errorText).toBe(testParams.facetErrorstext.invalidPageCriteriaBody, "Error action text did not match");
+              done();
+          }).catch(chaisePage.catchTestError(done));
+      });
 
-          it('On click of OK button the page should reload the page without paging conditions', function(done){
-              chaisePage.clickButton(chaisePage.recordPage.getErrorModalOkButton()).then(function() {
-                  return browser.driver.getCurrentUrl();
-              }).then(function(currentUrl) {
-                 recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
-                 expect(currentUrl).toBe(recordsetPage, "The redirection to Recordset page failed");
-                 done();
-              }).catch(catchError(done));
-          });
+      it('On click of OK button the page should reload the page without paging conditions', function(done){
+          chaisePage.clickButton(chaisePage.recordPage.getErrorModalOkButton()).then(function() {
+              return browser.driver.getCurrentUrl();
+          }).then(function(currentUrl) {
+             recordsetPage = pageTestUrl.slice(0, pageTestUrl.search('@'));
+             expect(currentUrl).toBe(recordsetPage, "The redirection to Recordset page failed");
+             done();
+          }).catch(chaisePage.catchTestError(done));
+      });
 
+    });
+
+    describe("For no record found in RecordEdit app", function() {
+
+        beforeAll(function() {
+          browser.ignoreSynchronization = true;
+            url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
+            browser.refresh();
+            browser.get(url);
         });
 
-        describe("For no record found in RecordEdit app", function() {
+        it('An error modal window should appear with Record Not Found title', function(done){
+          chaisePage.waitForElement(element(by.css('.modal-dialog '))).then(function() {
+              return chaisePage.recordPage.getErrorModalTitle();
+            }).then(function(modalTitle) {
+              expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
+              done();
+            }).catch(chaisePage.catchTestError(done));
+        });
 
-            beforeAll(function() {
-              browser.ignoreSynchronization = true;
-                url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=11223312121";
-                browser.refresh();
-                browser.get(url);
-            });
+        it('On click of OK button the page should redirect to recordset page', function(done){
+            chaisePage.clickButton(chaisePage.recordPage.getErrorModalOkButton()).then(function(){
+                return browser.driver.getCurrentUrl();
+            }).then (function(currentUrl) {
+                var newapplink = url.replace("recordedit", "recordset"),
+                    lastSlash = newapplink.lastIndexOf("/"),
+                    recordsetUrl = newapplink.slice(0, lastSlash);
+                expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
+                done();
+            }).catch(chaisePage.catchTestError(done));
+        });
+    });
 
-            it('An error modal window should appear with Record Not Found title', function(done){
-              chaisePage.waitForElement(element(by.css('.modal-dialog '))).then(function() {
-                  return chaisePage.recordPage.getErrorModalTitle();
-                }).then(function(modalTitle) {
-                  expect(modalTitle).toBe("Record Not Found", "The title of no record error pop is not correct");
-                  done();
-                }).catch(catchError(done));
-            });
+    describe("For negative page limit in Recordedit app", function() {
 
-            it('On click of OK button the page should redirect to recordset page', function(done){
-                chaisePage.clickButton(chaisePage.recordPage.getErrorModalOkButton()).then(function(){
-                    return browser.driver.getCurrentUrl();
-                }).then (function(currentUrl) {
-                    var newapplink = url.replace("recordedit", "recordset"),
-                        lastSlash = newapplink.lastIndexOf("/"),
-                        recordsetUrl = newapplink.slice(0, lastSlash);
-                    expect(currentUrl).toContain(recordsetUrl, "The redirection from record page to recordset in case of multiple records failed");
+        beforeAll(function() {
+          browser.ignoreSynchronization = true;
+            url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable +"/?limit=-1";
+            browser.refresh();
+            browser.get(url);
+            chaisePage.waitForElement(element(by.css('.modal-dialog ')));
+        });
+
+        it('An error modal window should appear with Invalid Input title', function(){
+            var modalTitle = chaisePage.recordPage.getErrorModalTitle();
+            expect(modalTitle).toBe("Invalid Input", "The title of Invalid Input error pop is not correct");
+        });
+
+        it('Error modal text indicates users about error and provides them with navigation options to Home Page', function(){
+            var modalText = chaisePage.recordPage.getModalText();
+            expect(modalText.getText()).toBe(testParams.sizeNotValidModalText(), "The message in modal pop is not correct");
+        });
+
+        it('On click of OK button the page should redirect to RecordSet', function(done){
+            // This has to be .click(), if we use clickButton then it won't show the alert
+            chaisePage.recordPage.getErrorModalOkButton().click().then(function(){
+                return browser.switchTo().alert().accept();
+            }).then(function(){
+                return browser.driver.getCurrentUrl();
+            }).then (function(currentUrl) {
+              var newapplink = url.replace("recordedit", "recordset"),
+                  lastSlash = newapplink.lastIndexOf("/"),
+                  recordsetUrl = newapplink.slice(0, lastSlash);
+                expect(currentUrl).toContain(recordsetUrl, "The redirection from recordedit page to recordset failed");
+                done();
+            }).catch(chaisePage.catchTestError(done));
+        });
+    });
+
+    if (!process.env.CI) {
+        describe("For the expired session alert,", function () {
+            var testExpiredSession = function (url, done) {
+                browser.ignoreSynchronization = true;
+                browser.get(url).then(function () {
+                    // manually remove the cookie
+                    return browser.manage().deleteCookie('webauthn');
+                }).then(function () {
+                    // refresh the page
+                    return browser.navigate().refresh();
+                }).then(function () {
+                    return browser.wait(function() {
+                        return chaisePage.recordEditPage.getAlertWarning();
+                    }, browser.params.defaultTimeout);
+                }).then(function (alert) {
+                    return alert.getText();
+                }).then(function (text) {
+                    expect(text).toContain("Your login session has expired. You are now accessing data anonymously", "alert message missmatch");
+                    return chaisePage.performLogin(process.env.AUTH_COOKIE, false);
+                }).then(function () {
                     done();
-                }).catch(catchError(done));
+                }).catch(chaisePage.catchTestError(done));
+            }
+
+
+            it ("should be displayed in record app", function (done) {
+                testExpiredSession(
+                    browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name +  "/id=2004",
+                    done
+                );
             });
+
+            it ("should be displayed in recordset app", function (done) {
+                testExpiredSession(
+                    browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name,
+                    done
+                );
+            })
         });
-
-        describe("For negative page limit in Recordedit app", function() {
-
-            beforeAll(function() {
-              browser.ignoreSynchronization = true;
-                url = browser.params.url + "/recordedit/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.multipleRecordsTable +"/?limit=-1";
-                browser.refresh();
-                browser.get(url);
-                chaisePage.waitForElement(element(by.css('.modal-dialog ')));
-            });
-
-            it('An error modal window should appear with Invalid Input title', function(){
-                var modalTitle = chaisePage.recordPage.getErrorModalTitle();
-                expect(modalTitle).toBe("Invalid Input", "The title of Invalid Input error pop is not correct");
-            });
-
-            it('Error modal text indicates users about error and provides them with navigation options to Home Page', function(){
-                var modalText = chaisePage.recordPage.getModalText();
-                expect(modalText.getText()).toBe(testParams.sizeNotValidModalText(), "The message in modal pop is not correct");
-            });
-
-            it('On click of OK button the page should redirect to RecordSet', function(done){
-                // This has to be .click(), if we use clickButton then it won't show the alert
-                chaisePage.recordPage.getErrorModalOkButton().click().then(function(){
-                    return browser.switchTo().alert().accept();
-                }).then(function(){
-                    return browser.driver.getCurrentUrl();
-                }).then (function(currentUrl) {
-                  var newapplink = url.replace("recordedit", "recordset"),
-                      lastSlash = newapplink.lastIndexOf("/"),
-                      recordsetUrl = newapplink.slice(0, lastSlash);
-                    expect(currentUrl).toContain(recordsetUrl, "The redirection from recordedit page to recordset failed");
-                    done();
-                }).catch(catchError(done));
-            });
-        });
-        var catchError =function (done) {
-          return function (err) {
-           done.fail(err);
-         }
-        }
+    }
 });

--- a/test/e2e/specs/all-features/recordedit/permissions-visibility.spec.js
+++ b/test/e2e/specs/all-features/recordedit/permissions-visibility.spec.js
@@ -139,7 +139,6 @@ describe('When viewing RecordEdit app', function() {
 
             browser.get(url);
             chaisePage.waitForElement(modalBody).then(function() {
-                expect(element(by.id('page-title')).isDisplayed()).toBe(false, "Page title is present");
                 expect(modalBody.isDisplayed()).toBe(true, "modal body is not displayed");
                 expect(element(by.css('.modal-title')).isPresent()).toBe(true, "modal title is not present");
                 expect(element(by.css('.modal-title')).getText()).toBe('You need to be logged in to continue.', "modal title text is incorrect");

--- a/test/e2e/specs/all-features/recordset/permissions-visibility.spec.js
+++ b/test/e2e/specs/all-features/recordset/permissions-visibility.spec.js
@@ -22,9 +22,7 @@ describe('When viewing Recordset app', function() {
     describe('as a read-only user', function() {
         beforeAll(function() {
             browser.get(url + ':main_read_table/' + testParams.key.columnName + testParams.key.operator + testParams.key.value);
-            chaisePage.waitForElement(element(by.id('page-title'))).then(function() {
-                expect(element(by.id('page-title')).isDisplayed()).toBe(true);
-            });
+            chaisePage.recordsetPageReady();
         });
 
         it('should not display the add record [+] button', function() {
@@ -77,9 +75,7 @@ describe('When viewing Recordset app', function() {
     describe('a user who can only create', function() {
         beforeAll(function() {
             browser.get(url + ':main_create_table/' + testParams.key.columnName + testParams.key.operator + testParams.key.value);
-            chaisePage.waitForElement(element(by.id('page-title'))).then(function() {
-                expect(element(by.id('page-title')).isDisplayed()).toBe(true);
-            });
+            chaisePage.recordsetPageReady();
         });
 
         it('should display the add record [+] button', function() {
@@ -125,9 +121,7 @@ describe('When viewing Recordset app', function() {
     describe('as a user who can update (and create)', function() {
         beforeAll(function() {
             browser.get(url + ':main_update_table/' + testParams.key.columnName + testParams.key.operator + testParams.key.value);
-            chaisePage.waitForElement(element(by.id('page-title'))).then(function() {
-                expect(element(by.id('page-title')).isDisplayed()).toBe(true);
-            });
+            chaisePage.recordsetPageReady();
         });
 
         it('should display the add record [+] button', function() {
@@ -172,9 +166,7 @@ describe('When viewing Recordset app', function() {
     describe('as a delete-only user', function() {
         beforeAll(function() {
             browser.get(url + ':main_delete_table/' + testParams.key.columnName + testParams.key.operator + testParams.key.value);
-            chaisePage.waitForElement(element(by.id('page-title'))).then(function() {
-                expect(element(by.id('page-title')).isDisplayed()).toBe(true);
-            });
+            chaisePage.recordsetPageReady();
         });
 
         it('should not display the add record [+] button', function() {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1413,6 +1413,12 @@ function chaisePage() {
         };
     };
 
+    /**
+     * Simulate the login process by navigating to a chaise page and
+     * changing cookie and localStorage values.
+     * NOTE if we change the cookie/localStorage that we're adding during login,
+     *      this function needs to be updated too.
+     */
     this.performLogin = function(cookie, isAlertPresent, defer) {
         defer = defer || require('q').defer();
 
@@ -1425,12 +1431,14 @@ function chaisePage() {
         browser.ignoreSynchronization = true;
 
         browser.wait(protractor.ExpectedConditions.visibilityOf(element(by.id("loginApp"))), browser.params.defaultTimeout).then(function() {
-            browser.driver.executeScript('document.cookie="' + cookie + ';path=/;' + (process.env.CI ? '"' : 'secure;"')).then(function() {
-              browser.ignoreSynchronization = false;
-              defer.resolve();
-            });
-        }, function() {
-            defer.reject();
+            return browser.driver.executeScript('document.cookie="' + cookie + ';path=/;' + (process.env.CI ? '"' : 'secure;"'))
+        }).then(function() {
+            return browser.driver.executeScript('window.localStorage.setItem( \'session\', \'{"previousSession":true}\' );');
+        }).then(function () {
+            browser.ignoreSynchronization = false;
+            defer.resolve();
+        }).catch(function (err) {
+            defer.reject(err);
         });
 
         return defer.promise;

--- a/test/e2e/utils/protractor.import.js
+++ b/test/e2e/utils/protractor.import.js
@@ -157,6 +157,10 @@ var bulkImportSchemas = function(configs, defer, authCookie, catalogId, entities
     configs.forEach(function (config) {
         // copy annotations and ACLs over to the submitted catalog object
         if (config.catalog && typeof config.catalog === "object") {
+            if (!("acls" in config.catalog)) {
+                config.catalog["acls"] = { "select": ["*"] };
+            }
+
             // if empty object, this loop is skipped
             for (var prop in config.catalog) {
                 // if property is set already
@@ -181,7 +185,7 @@ var bulkImportSchemas = function(configs, defer, authCookie, catalogId, entities
 
     // reuse the same catalogid
     if (catalogId) settings.setup.catalog.id = catalogId;
-    
+
     http.get(process.env.ERMREST_URL).then(function (res) {
         return ermrestUtils.createSchemasAndEntities(settings);
     }).then(function (data) {


### PR DESCRIPTION
This PR will add e2e test for making sure the session expired alert is displayed. To achieve this,

- I had to modify the `performLogin` function that we have to modify the `localStorage`. 
- Since as part of the test I'm performing a logout. I have to make sure anonymous users can see the data. So I made sure test catalogs are readable by anyone. I could make this specific to only one spec, but I feel like this is actually a good change that we should have done a long time ago. We're not doing any testing based on user ACLs so there really is no need to hide the catalogs. That being said, this change might have an effect on CI e2e which I have not anticipated. If that's the case, I have to think about other ways of doing this.
- Added two tests to the errors spec. These two tests open a chaise page (record and recordset), manually remove the cookie, refresh, and check the alert. I'm also logging in after each one to ensure user has all the previous access to data.


P.S. At first I was thinking about doing schema-level ACLs in the test spec. That's why in Slack I mentioned a change in ErmrestDataUtils. But After going through it, the specification and also code was very messy. So I decided against it and now doing the catalog-level ACL.