### PR TITLE
Consistent history

### DIFF
--- a/record/record.app.js
+++ b/record/record.app.js
@@ -100,6 +100,13 @@
                 $rootScope.reference = reference.contextualize.detailed;
                 $rootScope.reference.session = session;
 
+                // send string to prepend to "headTitle"
+                // <table-name>: pending... until we get row information back
+                headInjector.updateHeadTitle(
+                    DataUtils.getDisplaynameInnerText($rootScope.reference.displayname) +
+                    ": pending..."
+                );
+
                 $log.info("Reference: ", $rootScope.reference);
 
                 var logObj = {};
@@ -137,9 +144,9 @@
 
                 // add hideNavbar param back if true
                 if (context.hideNavbar) url += "?hideNavbar=" + context.hideNavbar;
-                $window.history.replaceState('', '', url);
+                $window.history.replaceState({}, '', url);
 
-                //NOTE when the read is called, reference.activeList will be generated
+                // NOTE: when the read is called, reference.activeList will be generated
                 // autmoatically but we want to make sure that urls are generated using tuple,
                 // so the links are based on facet. We might be able to improve this and avoid
                 // duplicated logic.

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -14,7 +14,7 @@
 
         function updateLocation() {
             $window.scrollTo(0, 0);
-            $window.location.replace(UriUtils.getRecordsetLink(recordsetModel.reference));
+            $window.history.replaceState({}, '', UriUtils.getRecordsetLink(recordsetModel.reference));
             $rootScope.location = $window.location.href;
         }
 

--- a/recordset/recordset.controller.js
+++ b/recordset/recordset.controller.js
@@ -15,7 +15,6 @@
         function updateLocation() {
             $window.scrollTo(0, 0);
             $window.history.replaceState({}, '', UriUtils.getRecordsetLink(recordsetModel.reference));
-            $rootScope.location = $window.location.href;
         }
 
         $rootScope.$on('reference-modified', function() {


### PR DESCRIPTION
This PR changes recordset to use `replaceState` instead of `location.replace` (see attached issue for explanation on both). We also decided to add `pending...` into the head title in record app when we the reference has been resolved but the read request has not returned yet.

Looking at the code some more I found that we wrote a function called `setLocationChangeHandling` that listens for the url to change and checks if the change was made from internally or not to decide if the page should reload. This was because we were using the function `location.replace` which forces a page reload. Changing this to `replaceState` stops the need to update `$rootScope.location` to force `setLocationChangeHandling` to be called to not reload the page. 

I should clarify that there are 2 meaning of "browser history". One can be talking about the state tracked by the forward and backward buttons. The other is what is saved in by the browser in the list when you click "history" from the browser options. The first type of history is what is controlled by javascript. We can call 2 different functions to affect the history of the back button, `pushState` and `replaceState`. The former adds a new entry to the list of back urls, the latter replaces the current one.

We rely on this in recordset app when the facets change. This also appears in record app to remove the pcid/ppid parameters and to add the navbar param which makes it also necessary for record app. We have yet to make this change in recordedit app (removing pcid/ppid) from the url which is why only 1 url shows for edit app.
