### PR TITLE
Change configuration app constant name

### DIFF
--- a/common/config.js
+++ b/common/config.js
@@ -25,7 +25,7 @@
         'ui.bootstrap'
     ])
 
-    .run(['appName', 'ConfigUtils', 'ERMrest', 'headInjector', 'MathUtils', 'UriUtils', '$rootScope', '$window', function(appName, ConfigUtils, ERMrest, headInjector, MathUtils, UriUtils, $rootScope, $window) {
+    .run(['settings', 'ConfigUtils', 'ERMrest', 'headInjector', 'MathUtils', 'UriUtils', '$rootScope', '$window', function(settings, ConfigUtils, ERMrest, headInjector, MathUtils, UriUtils, $rootScope, $window) {
 
         // TODO navbar changes (these should move to ConfigUtils)
         // because we might call that one first. these should be in the setter...
@@ -55,7 +55,7 @@
         // initialize dcctx object
         $window.dcctx = {
             contextHeaderParams: {
-                cid: appName,
+                cid: settings.appName,
                 pid: MathUtils.uuid(),
                 wid: $window.name
             },
@@ -77,14 +77,14 @@
                     // we already setup the defaults and the configuration based on chaise-config.js
                     if (response && response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
 
-                    return headInjector.setupHead();
+                    return headInjector.setupHead(settings);
                 }).then(function () {
                     $rootScope.$emit("configuration-done");
                 })
                 // no need to add a catch block here, errors has been includedso handleException has been configured to be the default handler
             } else {
                 // there's no catalog to fetch (may be an index page)
-                headInjector.setupHead().then(function () {
+                headInjector.setupHead(settings).then(function () {
                     $rootScope.$emit("configuration-done");
                 });
             }

--- a/common/utils.js
+++ b/common/utils.js
@@ -3122,14 +3122,12 @@
             addCanonicalTag();                              // controlled by chaise-config value to turn on/off
             setWindowName();                                // will only update if not already set
 
-            if (!settings.disableHeadTitle) addTitle();     // controlled by settings in config.js
+            if (settings.overrideHeadTitle) addTitle();     // controlled by settings in config.js
 
-            if (!settings.disableOnclickBehavior) {
-                overrideDownloadClickBehavior();            // controlled by settings in config.js
-                overrideExternalLinkBehavior();             // controlled by settings in config.js
-            }
+            if (settings.overrideDownloadClickBehavior) overrideDownloadClickBehavior();    // controlled by settings in config.js
+            if (settings.overrideExternalLinkBehavior) overrideExternalLinkBehavior();      // controlled by settings in config.js
 
-            return addCustomCSS();                          // controlled by chaise-config value to attach or not
+            return addCustomCSS();                          // controlled by chaise-config value to attach
         }
 
         return {

--- a/common/utils.js
+++ b/common/utils.js
@@ -3113,16 +3113,23 @@
 
         /**
          * Will return a promise that is resolved when the setup is done
+         *
+         * NOTE: should only be called by config.js (or equivalent configuration app)
          */
-        function setupHead() {
-            addPolyfills();
-            addCanonicalTag();
-            addTitle();
-            setWindowName();
-            overrideDownloadClickBehavior();
-            overrideExternalLinkBehavior();
-            addBodyClasses();
-            return addCustomCSS();
+        function setupHead(settings) {
+            addPolyfills();                                 // needs to be set for navbar functionality (and other chaise functionality)
+            addBodyClasses();                               // doesn't need to be controlled since it relies on .chaise-body class being present
+            addCanonicalTag();                              // controlled by chaise-config value to turn on/off
+            setWindowName();                                // will only update if not already set
+
+            if (!settings.disableHeadTitle) addTitle();     // controlled by settings in config.js
+
+            if (!settings.disableOnclickBehavior) {
+                overrideDownloadClickBehavior();            // controlled by settings in config.js
+                overrideExternalLinkBehavior();             // controlled by settings in config.js
+            }
+
+            return addCustomCSS();                          // controlled by chaise-config value to attach or not
         }
 
         return {

--- a/docs/dev-docs/config-app.md
+++ b/docs/dev-docs/config-app.md
@@ -17,9 +17,10 @@ angular.module('<NAMESPACE>.configure-<APP_NAME>', ['chaise.config'])
 
 // this constant is used to control the configuration of the angular app
 .constant('settings', {
-    appName: '<APP_NAME>',              // used for `cid` (e.g. recordset)
-    disableHeadTitle: true|false,       // set to true to disable chaise's heuristics for the headTitle
-    disableOnclickBehavior: true|false, // set to true to disable onclick behavior overrides
+    appName: '<APP_NAME>',                      // used for `cid` (e.g. recordset)
+    overrideHeadTitle: true|false,              // enables chaise's heuristics for the headTitle
+    overrideDownloadClickBehavior: true|false,  // enables onclick behavior for asset with the asset-permission class
+    overrideExternalLinkBehavior: true|false    // enables onclick behavior for external links
 })
 
 .run(['$rootScope', function ($rootScope) {

--- a/docs/dev-docs/config-app.md
+++ b/docs/dev-docs/config-app.md
@@ -15,8 +15,12 @@ The following is how you should define the configuration app:
 // define the configure-appname app which is using the chaise.config
 angular.module('<NAMESPACE>.configure-<APP_NAME>', ['chaise.config'])
 
-// this constant is used for `cid` (e.g. recordset)
-.constant('appName', '<APP_NAME>')
+// this constant is used to control the configuration of the angular app
+.constant('settings', {
+    appName: '<APP_NAME>',              // used for `cid` (e.g. recordset)
+    disableHeadTitle: true|false,       // set to true to disable chaise's heuristics for the headTitle
+    disableOnclickBehavior: true|false, // set to true to disable onclick behavior overrides
+})
 
 .run(['$rootScope', function ($rootScope) {
     $rootScope.$on("configuration-done", function () {
@@ -65,7 +69,7 @@ This will,
   - Hide the main content and show a loading spinner while getting the catalog annotation.
 
 Note:
-Each app will need to handle making sure the dependencies are available still. `record`, `recordset`, and `recordedit` all include the dependencies as part of the `make all` command. When that is run, the dependencies are added to the `index.html` templates as proper source tags. 
+Each app will need to handle making sure the dependencies are available still. `record`, `recordset`, and `recordedit` all include the dependencies as part of the `make all` command. When that is run, the dependencies are added to the `index.html` templates as proper source tags.
 
 `Login` and `Navbar` app handle this differently. Those depencies are defined in `*.app.js` because of how those apps are used. The intent is that they can be injected into a static page and all you need to do is include the `app.js` as a source and the rest of the dependencies are handled by that script. Those 2 scripts will attach the necesssary dependencies to the html as part of the execution of the script.
 

--- a/help/help.app.js
+++ b/help/help.app.js
@@ -3,7 +3,9 @@
 
     angular.module('chaise.configure-help', ['chaise.config'])
 
-    .constant('appName', 'help')
+    .constant('settings', {
+        appName: "help"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/help/help.app.js
+++ b/help/help.app.js
@@ -4,7 +4,9 @@
     angular.module('chaise.configure-help', ['chaise.config'])
 
     .constant('settings', {
-        appName: "help"
+        appName: "help",
+        overrideDownloadClickBehavior: true,    // links in navbar might need this
+        overrideExternalLinkBehavior: true      // links in navbar might need this
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/lib/login/login.app.js
+++ b/lib/login/login.app.js
@@ -4,7 +4,11 @@ function loadModule() {
 
         angular.module('chaise.configure-login', ['chaise.config'])
 
-        .constant('appName', 'login')
+        .constant('settings', {
+            appName: "login",
+            disableHeadTitle: true,
+            disableOnclickBehavior: true
+        })
 
         .run(['$rootScope', function ($rootScope) {
             // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/lib/login/login.app.js
+++ b/lib/login/login.app.js
@@ -5,9 +5,7 @@ function loadModule() {
         angular.module('chaise.configure-login', ['chaise.config'])
 
         .constant('settings', {
-            appName: "login",
-            disableHeadTitle: true,
-            disableOnclickBehavior: true
+            appName: "login"
         })
 
         .run(['$rootScope', function ($rootScope) {

--- a/lib/navbar/navbar.app.js
+++ b/lib/navbar/navbar.app.js
@@ -5,9 +5,7 @@ function loadModule() {
         angular.module('chaise.configure-navbar', ['chaise.config'])
 
         .constant('settings', {
-            appName: "navbar",
-            disableHeadTitle: true,
-            disableOnclickBehavior: true
+            appName: "navbar"
         })
 
         .run(['$rootScope', function ($rootScope) {

--- a/lib/navbar/navbar.app.js
+++ b/lib/navbar/navbar.app.js
@@ -4,7 +4,11 @@ function loadModule() {
 
         angular.module('chaise.configure-navbar', ['chaise.config'])
 
-        .constant('appName', 'navbar')
+        .constant('settings', {
+            appName: "navbar",
+            disableHeadTitle: true,
+            disableOnclickBehavior: true
+        })
 
         .run(['$rootScope', function ($rootScope) {
             // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/lib/switchUserAccounts.app.js
+++ b/lib/switchUserAccounts.app.js
@@ -5,7 +5,9 @@
     angular.module('chaise.configure-switchUserAccounts', ['chaise.config'])
 
     .constant('settings', {
-        appName: "switchUserAccounts"
+        appName: "switchUserAccounts",
+        overrideDownloadClickBehavior: true,    // links in navbar might need this
+        overrideExternalLinkBehavior: true      // links in navbar might need this
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/lib/switchUserAccounts.app.js
+++ b/lib/switchUserAccounts.app.js
@@ -4,7 +4,9 @@
 /* Configuration of the md help App */
     angular.module('chaise.configure-switchUserAccounts', ['chaise.config'])
 
-    .constant('appName', 'switchUserAccounts')
+    .constant('settings', {
+        appName: "switchUserAccounts"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -4,7 +4,9 @@
 /* Configuration of the Record App */
     angular.module('chaise.configure-record', ['chaise.config'])
 
-    .constant('appName', 'record')
+    .constant('settings', {
+        appName: "record"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/record/record.app.js
+++ b/record/record.app.js
@@ -5,7 +5,10 @@
     angular.module('chaise.configure-record', ['chaise.config'])
 
     .constant('settings', {
-        appName: "record"
+        appName: "record",
+        overrideHeadTitle: true,
+        overrideDownloadClickBehavior: true,
+        overrideExternalLinkBehavior: true
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/recordedit/mdHelp.app.js
+++ b/recordedit/mdHelp.app.js
@@ -5,7 +5,9 @@
     angular.module('chaise.configure-mdHelp', ['chaise.config'])
 
     .constant('settings', {
-        appName: "mdHelp"
+        appName: "mdHelp",
+        overrideDownloadClickBehavior: true,    // links in navbar might need this
+        overrideExternalLinkBehavior: true      // links in navbar might need this
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/recordedit/mdHelp.app.js
+++ b/recordedit/mdHelp.app.js
@@ -4,7 +4,9 @@
 /* Configuration of the md help App */
     angular.module('chaise.configure-mdHelp', ['chaise.config'])
 
-    .constant('appName', 'mdHelp')
+    .constant('settings', {
+        appName: "mdHelp"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -4,7 +4,9 @@
 /* Configuration of the Recordedit App */
     angular.module('chaise.configure-recordedit', ['chaise.config'])
 
-    .constant('appName', 'recordedit')
+    .constant('settings', {
+        appName: "recordedit"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -5,7 +5,10 @@
     angular.module('chaise.configure-recordedit', ['chaise.config'])
 
     .constant('settings', {
-        appName: "recordedit"
+        appName: "recordedit",
+        overrideHeadTitle: true,
+        overrideDownloadClickBehavior: true,
+        overrideExternalLinkBehavior: true
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -5,7 +5,10 @@
     angular.module('chaise.configure-recordset', ['chaise.config'])
 
     .constant('settings', {
-        appName: "recordset"
+        appName: "recordset",
+        overrideHeadTitle: true,
+        overrideDownloadClickBehavior: true,
+        overrideExternalLinkBehavior: true
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -4,7 +4,9 @@
 /* Configuration of the Recordset App */
     angular.module('chaise.configure-recordset', ['chaise.config'])
 
-    .constant('appName', 'recordset')
+    .constant('settings', {
+        appName: "recordset"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -23,7 +23,9 @@ angular.module('configure-search', [
     'ngCookies'
 ])
 
-.constant('appName', 'search')
+.constant('settings', {
+    appName: "search"
+})
 
 .run(['$rootScope', function ($rootScope) {
     // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -24,7 +24,9 @@ angular.module('configure-search', [
 ])
 
 .constant('settings', {
-    appName: "search"
+    appName: "search",
+    overrideDownloadClickBehavior: true,    // links in navbar might need this
+    overrideExternalLinkBehavior: true      // links in navbar might need this
 })
 
 .run(['$rootScope', function ($rootScope) {

--- a/scripts/controller/ermrestLoginController.js
+++ b/scripts/controller/ermrestLoginController.js
@@ -4,7 +4,9 @@
 
 var ermLoginController = angular.module('ermLoginController', ['chaise.config']);
 
-ermLoginController.constant('appName', 'oldlogin');
+ermLoginController.constant('settings', {
+    appName: "oldlogin"
+});
 ermLoginController.controller('LoginCtrl', ['$sce', '$scope', 'ermrest', 'UriUtils','$cookies',
                                            function($sce, $scope, ermrest, uriUtils, $cookies) {
 

--- a/scripts/controller/ermrestLoginController.js
+++ b/scripts/controller/ermrestLoginController.js
@@ -5,7 +5,9 @@
 var ermLoginController = angular.module('ermLoginController', ['chaise.config']);
 
 ermLoginController.constant('settings', {
-    appName: "oldlogin"
+    appName: "oldlogin",
+    overrideDownloadClickBehavior: true,    // links in navbar might need this
+    overrideExternalLinkBehavior: true      // links in navbar might need this
 });
 ermLoginController.controller('LoginCtrl', ['$sce', '$scope', 'ermrest', 'UriUtils','$cookies',
                                            function($sce, $scope, ermrest, uriUtils, $cookies) {

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -4,7 +4,10 @@
     angular.module('chaise.configure-viewer', ['chaise.config'])
 
     .constant('settings', {
-        appName: "viewer"
+        appName: "viewer",
+        overrideHeadTitle: true,
+        overrideDownloadClickBehavior: true,
+        overrideExternalLinkBehavior: true
     })
 
     .run(['$rootScope', function ($rootScope) {

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -3,7 +3,9 @@
 
     angular.module('chaise.configure-viewer', ['chaise.config'])
 
-    .constant('appName', 'viewer')
+    .constant('settings', {
+        appName: "viewer"
+    })
 
     .run(['$rootScope', function ($rootScope) {
         // When the configuration module's run block emits the `configuration-done` event, attach the app to the DOM


### PR DESCRIPTION
This PR changes the way each app interacts with the configuration app. It changes the constant `appName` to `settings`. It's now an object that has 3 properties (`appName`, `disableHeadTitle`, `disableOnclickBehavior`). Each of these are explained in further detail in `config-app.md`.

Made changes to each individual `app.js` file. I think only navbar app and login app should refrain from modifying the head title and the onclick behavior of links (even thought they relay on specific classes being defined).

Appropriate changes will be made in deriva-webapps to booleansearch, lineplot, and plot app (the three that currently integrate with config.js from chaise).