### PR TITLE
Change behvaior of links in viewer when inside an iframe

### DIFF
--- a/common/config.js
+++ b/common/config.js
@@ -62,7 +62,12 @@
             },
             settings: {
                 hideNavbar: hideNavbar,
-                openLinksInTab: openLinksInTab
+                // the settings constant is not accessible from chaise apps,
+                // therefore we're capturing them here so they can be used in chaise
+                openLinksInTab: openLinksInTab,
+                overrideHeadTitle: settings.overrideHeadTitle,
+                overrideDownloadClickBehavior: settings.overrideDownloadClickBehavior,
+                overrideExternalLinkBehavior: settings.overrideExternalLinkBehavior
             }
         };
         // set chaise configuration based on what is in `chaise-config.js` first
@@ -81,14 +86,14 @@
                     // we already setup the defaults and the configuration based on chaise-config.js
                     if (response && response.chaiseConfig) ConfigUtils.setConfigJSON(response.chaiseConfig);
 
-                    return headInjector.setupHead(settings);
+                    return headInjector.setupHead();
                 }).then(function () {
                     $rootScope.$emit("configuration-done");
                 })
                 // no need to add a catch block here, errors has been includedso handleException has been configured to be the default handler
             } else {
                 // there's no catalog to fetch (may be an index page)
-                headInjector.setupHead(settings).then(function () {
+                headInjector.setupHead().then(function () {
                     $rootScope.$emit("configuration-done");
                 });
             }

--- a/common/config.js
+++ b/common/config.js
@@ -51,6 +51,7 @@
          *      - doesn't matter if in an iframe or not, if true, hide it
          */
         var hideNavbar = (inIframe && hideNavbarParam !== false) || hideNavbarParam === true;
+        var openLinksInTab = inIframe && settings.openIframeLinksInTab;
 
         // initialize dcctx object
         $window.dcctx = {
@@ -59,7 +60,10 @@
                 pid: MathUtils.uuid(),
                 wid: $window.name
             },
-            hideNavbar: hideNavbar
+            settings: {
+                hideNavbar: hideNavbar,
+                openLinksInTab: openLinksInTab
+            }
         };
         // set chaise configuration based on what is in `chaise-config.js` first
         ConfigUtils.setConfigJSON();

--- a/common/export.js
+++ b/common/export.js
@@ -5,7 +5,7 @@
 
     .directive('export', ['AlertsService', 'ConfigUtils', 'DataUtils', 'ErrorService', 'logService', 'modalUtils', '$rootScope', '$timeout', 'UriUtils', '$window', function (AlertsService, ConfigUtils, DataUtils, ErrorService, logService, modalUtils, $rootScope, $timeout, UriUtils, $window) {
         var chaiseConfig = ConfigUtils.getConfigJSON();
-        var context = ConfigUtils.getContextJSON();
+        var settings = ConfigUtils.getSettings();
         /**
          * Cancel the current export request
          */
@@ -128,7 +128,7 @@
                 scope.isLoading = false;
                 scope.exporter = null;
                 scope.makeSafeIdAttr = DataUtils.makeSafeIdAttr;
-                scope.hideNavbar = context.hideNavbar;
+                scope.hideNavbar = settings.hideNavbar;
 
                 if (!DataUtils.isNoneEmptyString(scope.csvOptionName)) {
                     scope.csvOptionName = "Search results (CSV)";

--- a/common/utils.js
+++ b/common/utils.js
@@ -3075,12 +3075,9 @@
         }
 
         /**
-         * if in iframe, make sure links open in new tab
+         * make sure links open in new tab
          */
-        function openIframeLinksInTab () {
-            // only do it for iframe
-            if ($window.self === $window.parent) return;
-
+        function openLinksInTab () {
             addClickListener('a[href]', function (e, element) {
                 element.target = "_blank";
             });
@@ -3133,17 +3130,17 @@
          *
          * NOTE: should only be called by config.js (or equivalent configuration app)
          */
-        function setupHead(settings) {
+        function setupHead() {
             addPolyfills();                                 // needs to be set for navbar functionality (and other chaise functionality)
             addBodyClasses();                               // doesn't need to be controlled since it relies on .chaise-body class being present
             addCanonicalTag();                              // controlled by chaise-config value to turn on/off
             setWindowName();                                // will only update if not already set
 
-            if (settings.overrideHeadTitle) addTitle();     // controlled by settings in config.js
-
-            if (settings.openIframeLinksInTab) openIframeLinksInTab();
-            if (settings.overrideDownloadClickBehavior) overrideDownloadClickBehavior();    // controlled by settings in config.js
-            if (settings.overrideExternalLinkBehavior) overrideExternalLinkBehavior();      // controlled by settings in config.js
+            var settings = ConfigUtils.getSettings();
+            if (settings.overrideHeadTitle) addTitle();
+            if (settings.openLinksInTab) openLinksInTab();
+            if (settings.overrideDownloadClickBehavior) overrideDownloadClickBehavior();
+            if (settings.overrideExternalLinkBehavior) overrideExternalLinkBehavior();
 
 
             return addCustomCSS();                          // controlled by chaise-config value to attach

--- a/common/utils.js
+++ b/common/utils.js
@@ -466,12 +466,12 @@
             var url = chaiseBaseURL() + appPath + "/#" + location.catalog + "/" + location.path;
             var pcontext = [];
 
-            var contextObj = ConfigUtils.getContextJSON();
+            var settingsObj = ConfigUtils.getSettings();
             var contextHeaderParams = ConfigUtils.getContextHeaderParams();
             pcontext.push("pcid=" + contextHeaderParams.cid);
             pcontext.push("ppid=" + contextHeaderParams.pid);
             // only add the value to the applink function if it's true
-            if (contextObj.hideNavbar) pcontext.push("hideNavbar=" + contextObj.hideNavbar)
+            if (settingsObj.hideNavbar) pcontext.push("hideNavbar=" + settingsObj.hideNavbar)
 
             // TODO we might want to allow only certian query parameters
             if (location.queryParamsString) {
@@ -1121,9 +1121,9 @@
             }
 
             // add hideNavbar if present/defined
-            var dcctx = ConfigUtils.getContextJSON();
-            if (dcctx.hideNavbar) {
-                url = url + (reference.location.queryParamsString ? "&" : "?") + "hideNavbar=" + dcctx.hideNavbar;
+            var settings = ConfigUtils.getSettings();
+            if (settings.hideNavbar) {
+                url = url + (reference.location.queryParamsString ? "&" : "?") + "hideNavbar=" + settings.hideNavbar;
             }
 
             return url;
@@ -1935,6 +1935,10 @@
             return $window.dcctx;
         };
 
+        function getSettings() {
+            return getContextJSON().settings;
+        }
+
         function getConfigJSON() {
             return getContextJSON().chaiseConfig;
         };
@@ -2140,7 +2144,8 @@
             setConfigJSON: setConfigJSON,
             getHTTPService: getHTTPService,
             getContextHeaderParams: getContextHeaderParams,
-            systemColumnsMode: systemColumnsMode
+            systemColumnsMode: systemColumnsMode,
+            getSettings: getSettings
         }
     }])
 
@@ -3070,6 +3075,18 @@
         }
 
         /**
+         * if in iframe, make sure links open in new tab
+         */
+        function openIframeLinksInTab () {
+            // only do it for iframe
+            if ($window.self === $window.parent) return;
+
+            addClickListener('a[href]', function (e, element) {
+                element.target = "_blank";
+            });
+        }
+
+        /**
          * Will call the handler function upon clicking on the elements represented by selector
          * @param {string} selector the selector string
          * @param {function} handler  the handler callback function.
@@ -3124,8 +3141,10 @@
 
             if (settings.overrideHeadTitle) addTitle();     // controlled by settings in config.js
 
+            if (settings.openIframeLinksInTab) openIframeLinksInTab();
             if (settings.overrideDownloadClickBehavior) overrideDownloadClickBehavior();    // controlled by settings in config.js
             if (settings.overrideExternalLinkBehavior) overrideExternalLinkBehavior();      // controlled by settings in config.js
+
 
             return addCustomCSS();                          // controlled by chaise-config value to attach
         }

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -33,7 +33,6 @@
                     <div class="top-right-panel">
                         <div class="title-container" ng-if="pageTitle">
                             <h1 id="page-title" ng-bind-html="pageTitle"></h1>
-                            <a href="https://example.com">TEST LINK</a>
                         </div>
                         <div class="btn-group btn-group-sm pull-left menu-btn-container" ng-class="{'open-panel': !hideAnnotationSidebar, 'close-panel': hideAnnotationSidebar}" role="group">
                             <button ng-click="osd.openAnnotations();" class="btn chaise-btn chaise-btn-primary" type="button" ng-class="{'pick':!hideAnnotationSidebar}" role="button" uib-tooltip="List the Image annotations" ng-disabled="disableAnnotationSidebar"  id="edit-btn">

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -33,6 +33,7 @@
                     <div class="top-right-panel">
                         <div class="title-container" ng-if="pageTitle">
                             <h1 id="page-title" ng-bind-html="pageTitle"></h1>
+                            <a href="https://example.com">TEST LINK</a>
                         </div>
                         <div class="btn-group btn-group-sm pull-left menu-btn-container" ng-class="{'open-panel': !hideAnnotationSidebar, 'close-panel': hideAnnotationSidebar}" role="group">
                             <button ng-click="osd.openAnnotations();" class="btn chaise-btn chaise-btn-primary" type="button" ng-class="{'pick':!hideAnnotationSidebar}" role="button" uib-tooltip="List the Image annotations" ng-disabled="disableAnnotationSidebar"  id="edit-btn">

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -7,7 +7,8 @@
         appName: "viewer",
         overrideHeadTitle: true,
         overrideDownloadClickBehavior: true,
-        overrideExternalLinkBehavior: true
+        overrideExternalLinkBehavior: true,
+        openIframeLinksInTab: true
     })
 
     .run(['$rootScope', function ($rootScope) {


### PR DESCRIPTION
### Summary of the issue
Viewer app is currently used in an iframe in the record page. So users can click on the "share" button for any of the annotation and by clicking on the link, the iframe (and not the whole page or new tab) will navigate to the "Image Annotation" table.

This is confusing as users don't have a proper way to get back to the previous page. And also they might think that clicking on "share" in the record page and navigating to that link should show the current state of the page (with "Image Annotation" record being in the iframe and not the viewer app).

### Implementation details

I know that for now we want a solution that is limited to viewer app. But I didn't want to implement this just for the viewer app. So the actual implementation is independent of the app. And then using the config `settings` constant I'm making sure only viewer app is using this.

The general solution was adding a click listened and adding the `blank="_true"` as you can see in `openLinksInTab` function that `setupHead` calls. But this won't support the links in navbar as we've defined a custom `ng-click` for those. And even though navbar is currentlt not visible in the iframe of viewer app in rbk, I wanted my solution to be general enough and you could also have navbar in iframe.

So I had to make some modifications to the `navbar.js` as well. Since `settings` is a constant for the config-app (and not chaise apps), I had to make sure that this variable is stored somewhere in our `$dcctx` object so I can access it in navbar. I added a `$dcctx.settings` object that holds the existing `hideNavbar` and the newly added `openLinksInTab`.  I'm not very good with names and if you thing having two `settings` might be confusing, I can change it. 


To test this you can use the following link:

https://dev.rebuildingakidney.org/~ashafaei/iframe-link.html