### PR TITLE
Keep table header fixed while scrolling to improve user context of content

### DIFF
--- a/common/styles/scss/_record-app.scss
+++ b/common/styles/scss/_record-app.scss
@@ -267,6 +267,7 @@
                         padding: 10px 0px 10px 0px;
 
                         .accordion-content {
+                            position: static;
                             padding-left: 40px;
                             padding-right: 8px;
                         }
@@ -419,10 +420,12 @@
           .chaise-table.table {
               border-top: 1px solid #BBBBBB;
               border-bottom: 1px solid #BBBBBB;
+              border-left: 1px solid $table-border-color;
+              border-collapse: initial;
 
               tr {
                     border-left: 1px solid #BBBBBB;
-                    border-bottom: none;
+                    border-bottom: 1px solid #BBBBBB;
                  }
 
               >thead>tr>th,
@@ -438,7 +441,7 @@
               th
               {
                     background-color: unset !important;
-                    border-top: none;
+                    border-top: 1px solid #BBBBBB;
                     border-bottom: 1px solid #BBBBBB;
               }
           }

--- a/common/styles/scss/_recordset.scss
+++ b/common/styles/scss/_recordset.scss
@@ -157,8 +157,6 @@
 // chaise table
 .outer-table {
     overflow-x: auto;
-    height: max-content;
-    max-height: 60vh;
 }
 
 .chaise-table-header {
@@ -187,7 +185,8 @@
 }
 
 .chaise-table.table {
-    border-top: 1px solid $table-border-color;
+    border-collapse: initial;
+    border-left: 1px solid $table-border-color;
     border-bottom: 1px solid $table-border-color;
     margin: 0;
 
@@ -231,6 +230,9 @@
     }
 
     .table-heading {
+        position: relative;
+        top: 0px;
+        z-index: 1;
         background-color: $table-header-background-color;
         color: $black-color;
 
@@ -267,6 +269,7 @@
 
     >thead>tr>th {
         border-bottom: 1px solid $table-border-color;
+        border-top: 1px solid $table-border-color !important;
     }
 
     >thead>tr>th,
@@ -540,4 +543,8 @@ faceting {
 // selected rows
 .selected-rows {
     min-height: 45px;
+}
+
+#overflow-container-facet .chaise-checkbox {
+    z-index: 0;
 }

--- a/common/styles/scss/_recordset.scss
+++ b/common/styles/scss/_recordset.scss
@@ -157,6 +157,8 @@
 // chaise table
 .outer-table {
     overflow-x: auto;
+    height: max-content;
+    max-height: 60vh;
 }
 
 .chaise-table-header {

--- a/common/styles/scss/app.scss
+++ b/common/styles/scss/app.scss
@@ -511,6 +511,7 @@ html {
             position: relative;
             overflow-x: hidden;
             overflow-y: auto;
+            scroll-behavior: smooth;
 
             // we're going to adjust this dynamically for dynamic-padding
             &:not(.dynamic-padding) {

--- a/common/table.js
+++ b/common/table.js
@@ -1477,6 +1477,13 @@
                     UiUtils.attachFooterResizeSensor(0);
                 }
 
+                if (scope.vm.config.displayMode === recordsetDisplayModes.facetPopup) {
+                    var overflowContainerFacet = document.getElementById('overflow-container-facet');
+                    if (overflowContainerFacet) {
+                        overflowContainerFacet.onscroll =  fixHeader;
+                    }
+                }
+
                 // capture and log the right click event on the permalink button
                 var permalink = document.getElementById('permalink');
                 if (permalink) {
@@ -1487,7 +1494,18 @@
                         }, scope.vm.reference.defaultLogInfo);
                     });
                 }
-            };
+
+                var overflowContainer = document.getElementById('overflow-container');
+                if (overflowContainer) {
+                    overflowContainer.onscroll =  fixHeader;
+                }
+
+            };  
+
+            var fixHeader = function(e) {
+                var header = document.getElementById('fixed-table-header');
+                header.style.top = e.target.scrollTop + "px";
+            }
 
             var attachDOMElementsToScope = function (scope) {
                 // set the parentContainer element

--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -118,7 +118,7 @@
         <div class="side-panel-resizable" resizable r-directions=["right"] r-flex="true" r-partners="resizePartners" ng-show="vm.config.showFaceting && vm.reference" ng-class="{'open-panel': vm.config.facetPanelOpen, 'close-panel': !vm.config.facetPanelOpen, 'initializing': !vm.initialized}">
             <faceting vm="vm"></faceting>
         </div>
-        <div class="main-container dynamic-padding">
+        <div class="main-container dynamic-padding" id="overflow-container">
             <div class="main-body">
 
                 <!-- record table -->

--- a/common/templates/recordsetSelectFaceting.html
+++ b/common/templates/recordsetSelectFaceting.html
@@ -34,7 +34,7 @@
     </div>
     <div class="bottom-panel-container">
         <div class="side-panel-resizable close-panel"></div>
-        <div class="main-container dynamic-padding">
+        <div class="main-container dynamic-padding" id="overflow-container-facet">
             <div class="main-body">
                 <!-- record table -->
                 <div class="recordset-table-container" ng-show="vm.initialized">

--- a/common/templates/table.html
+++ b/common/templates/table.html
@@ -1,7 +1,7 @@
 <div class="outer-table recordset-table s_{{makeSafeIdAttr(vm.reference.table.schema.name)}} t_{{makeSafeIdAttr(vm.reference.table.name)}}">
     <table class="table chaise-table table-striped table-hover">
         <!-- sortable column header -->
-        <thead class="table-heading">
+        <thead class="table-heading" id="fixed-table-header">
             <tr>
                 <th ng-switch="vm.config.selectMode" ng-if="(vm.config.viewable || vm.config.editable || vm.config.deletable || vm.config.selectMode != noSelect)" class="actions-header"
                     ng-class="{'view-header': !vm.reference.canUpdate && !vm.reference.canDelete, 'single-select-header': vm.config.selectMode == 'single-select','multi-select-header': vm.config.selectMode == 'multi-select'}">

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -632,12 +632,18 @@
             });
         }
 
-        mainContainerEl.on('scroll', $scope.$apply.bind($scope, function () {
+        /**
+         * based on scroll position:
+         *  - TODO summarize what you're doing
+         *  - toggle the back-to-top button
+         */
+        mainContainerEl[0].onscroll = function () {
+            // TODO comment what this is doing
             var top =  mainContainerEl[0].getBoundingClientRect().top;
             var headers = [].slice.call(mainContainerEl.querySelectorAll("thead"));
             headers.some(function(header) {
                 var tableRect = header.parentNode.getBoundingClientRect();
-                if (tableRect.top != 0 && tableRect.top <= $window.innerHeight && tableRect.bottom > mainContainerEl[0].getBoundingClientRect().top) {
+                if (tableRect.top != 0 && tableRect.top <= $window.innerHeight && tableRect.bottom > top) {
                     if (tableRect.top > top) {
                         header.style.top = 0;
                     }
@@ -648,11 +654,16 @@
                 } 
             });
             
+            // determine whether we need the back-to-top button
+            var showTopBtn = false;
             if (mainContainerEl.scrollTop() > 300) {
-              $scope.showTopBtn = true;
-            } else {
-              $scope.showTopBtn = false;
+                showTopBtn = true;
             }
-        }));
+            // only run the digest cycle when we have to
+            if (showTopBtn != $scope.showTopBtn) {
+                $scope.showTopBtn = showTopBtn;
+                $scope.$apply();
+            }
+        };
     }]);
 })();

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -632,8 +632,8 @@
             });
         }
 
-        var top =  mainContainerEl[0].getBoundingClientRect().top;
         mainContainerEl.on('scroll', $scope.$apply.bind($scope, function () {
+            var top =  mainContainerEl[0].getBoundingClientRect().top;
             var headers = [].slice.call(mainContainerEl.querySelectorAll("thead"));
             headers.some(function(header) {
                 var tableRect = header.parentNode.getBoundingClientRect();

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -632,38 +632,119 @@
             });
         }
 
+
+        var checkStickyHeader;
+        var lastUpdatedHeader;
+        var scrollListener = function() {
+                if (lastUpdatedHeader) {
+                    lastUpdatedHeader.style.top = 0;
+                }
+             
+                clearTimeout(checkStickyHeader);
+                checkStickyHeader = setTimeout(function() {
+                console.log("checkStickyHeader");
+                var header;
+                var tableRect;
+                // TODO comment what this is doing
+                var top =  mainContainerEl[0].getBoundingClientRect().top;
+                //console.time("count");
+
+                var headers = mainContainerEl[0].getElementsByTagName("thead");
+                //console.timeLog("count");
+                for (var i = 0; i < headers.length; i++) {
+                    header = headers[i];
+                    tableRect = header.parentNode.getBoundingClientRect();
+                    if (tableRect.bottom > top && tableRect.top <= window.innerHeight) {
+                        if (tableRect.top > top) {
+                            header.style.top = 0;
+                        }
+                        else {
+                            lastUpdatedHeader = header;
+                            header.style.top = parseInt(parseInt(header.style.top) + (top - header.getBoundingClientRect().top))+  "px";
+                        }
+                        break;
+                    } 
+                }
+            }, 60);
+        }
         /**
          * based on scroll position:
          *  - TODO summarize what you're doing
          *  - toggle the back-to-top button
          */
-        mainContainerEl[0].onscroll = function () {
-            // TODO comment what this is doing
-            var top =  mainContainerEl[0].getBoundingClientRect().top;
-            var headers = [].slice.call(mainContainerEl.querySelectorAll("thead"));
-            headers.some(function(header) {
-                var tableRect = header.parentNode.getBoundingClientRect();
-                if (tableRect.top != 0 && tableRect.top <= $window.innerHeight && tableRect.bottom > top) {
-                    if (tableRect.top > top) {
-                        header.style.top = 0;
-                    }
-                    else {
-                        header.style.top = parseInt(parseInt(header.style.top) + (top - header.getBoundingClientRect().top))+  "px";
-                    }
-                    return true;   
-                } 
-            });
+        mainContainerEl[0].onscroll = scrollListener;
+        // function () {
+        //     var header;
+        //     var tableRect;
+        //     // TODO comment what this is doing
+        //     var top =  mainContainerEl[0].getBoundingClientRect().top;
+        //     console.time("count");
+
+        //     // var header = document.getElementById("fixed-table-header");
+        //     // console.timeLog("count");
+        //     // var tableRect = header.parentNode.getBoundingClientRect();
+        //     // if (tableRect.top > top) {
+        //     //     header.style.top = 0;
+        //     // }
+        //     // else {
+        //     //     header.style.top = parseInt(parseInt(header.style.top) + (top - header.getBoundingClientRect().top))+  "px";
+        //     // }
+
+        //     //var headers = mainContainerEl[0].querySelectorAll("thead");
+            
+        //     var headers = mainContainerEl[0].getElementsByTagName("thead");
+        //     console.timeLog("count");
+        //     for (var i = 0; i < headers.length; i++) {
+        //         header = headers[i];
+        //         tableRect = header.parentNode.getBoundingClientRect();
+        //         if (tableRect.bottom > top && tableRect.top <= window.innerHeight) {
+        //             if (tableRect.top > top) {
+        //                 header.style.top = 0;
+        //             }
+        //             else {
+        //                 console.timeLog("count");
+        //                 header.style.top = parseInt(parseInt(header.style.top) + (top - header.getBoundingClientRect().top))+  "px";
+        //                 console.timeLog("count");
+        //             }
+        //             break;
+        //         } 
+        //     }
+
+        //     // var headers = mainContainerEl[0].getElementsByTagName("thead");
+        //     // console.timeLog("count");
+        //     // for (var i = 0; i < headers.length; i++) {
+        //     //     header = headers[i];
+        //     //     tableRect = header.parentNode.getBoundingClientRect();
+
+        //     //     if (tableRect.bottom > top && tableRect.top <= window.innerHeight) {
+        //     //         if (tableRect.top > top) {
+        //     //             header.style.position="relative";
+        //     //             header.style.top = 0;
+        //     //         }
+        //     //         else {
+        //     //             if(header.style.top == "" || header.style.top == 0 || header.style.top == "0px") {
+        //     //                 header.style.top = top +  "px";
+        //     //             }
+        //     //             header.style.position="fixed"
+        //     //         }
+        //     //         break;
+        //     //     } 
+                
+        //     // }
+
+        //     console.timeEnd("count");
+        //     console.log("\n");
             
             // determine whether we need the back-to-top button
-            var showTopBtn = false;
-            if (mainContainerEl.scrollTop() > 300) {
-                showTopBtn = true;
-            }
-            // only run the digest cycle when we have to
-            if (showTopBtn != $scope.showTopBtn) {
-                $scope.showTopBtn = showTopBtn;
-                $scope.$apply();
-            }
-        };
+            // var showTopBtn = false;
+            // if (mainContainerEl.scrollTop() > 300) {
+            //     showTopBtn = true;
+            // }
+            // // only run the digest cycle when we have to
+            // if (showTopBtn != $scope.showTopBtn) {
+            //     $scope.showTopBtn = showTopBtn;
+            //     $scope.$apply();
+            // }
+        //};
     }]);
 })();

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -632,7 +632,22 @@
             });
         }
 
+        var top =  mainContainerEl[0].getBoundingClientRect().top;
         mainContainerEl.on('scroll', $scope.$apply.bind($scope, function () {
+            var headers = [].slice.call(mainContainerEl.querySelectorAll("thead"));
+            headers.some(function(header) {
+                var tableRect = header.parentNode.getBoundingClientRect();
+                if (tableRect.top != 0 && tableRect.top <= $window.innerHeight && tableRect.bottom > mainContainerEl[0].getBoundingClientRect().top) {
+                    if (tableRect.top > top) {
+                        header.style.top = 0;
+                    }
+                    else {
+                        header.style.top = parseInt(parseInt(header.style.top) + (top - header.getBoundingClientRect().top))+  "px";
+                    }
+                    return true;   
+                } 
+            });
+            
             if (mainContainerEl.scrollTop() > 300) {
               $scope.showTopBtn = true;
             } else {


### PR DESCRIPTION
When scrolling all the way to the bottom, the table headings might not be remembered by user so they have been made fixed. 3 scenarios -

1. Recordset
2. Facet 
3. Record

<img width="1382" alt="Screen Shot 2021-06-30 at 4 52 15 PM" src="https://user-images.githubusercontent.com/78573171/124045021-a5e48880-d9c3-11eb-9cdc-09538e705f07.png">


The CSS way using position:sticky does not work for this scenario since we cannot restrict the height of the table hence we use JavaScript to make the appropriate DOM changes ourselves. 

Note - These changes unfortunately do not work in Safari, the problem is similar to existing problems like mentioned here - https://github.com/informatics-isi-edu/chaise/issues/2090 and a simple fix could not be found.

It can be tested here -
https://dev.facebase.org/~kpherwan/chaise/recordset/#1/isa:experiment@sort(RID)
https://dev.facebase.org/~kpherwan/chaise/record/#1/isa:experiment/RID=1-3SZP