### PR TITLE
Move spectrum to viewer and recordedit instead of shared vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,10 +258,7 @@ SHARED_JS_VENDOR_ASSET=$(JS)/vendor/angular-plotly.js \
 	$(COMMON)/vendor/angular-animate.min.js \
 	$(COMMON)/vendor/angular-scroll.min.js \
 	$(COMMON)/vendor/css-element-queries.js \
-	$(JS)/vendor/ui-bootstrap-tpls-2.5.0.min.js \
-	$(JS)/vendor/select.js \
-	$(COMMON)/vendor/mask.min.js \
-	$(COMMON)/vendor/spectrum/spectrum.min.js
+	$(JS)/vendor/ui-bootstrap-tpls-2.5.0.min.js
 
 SHARED_JS_VENDOR_ASSET_MIN=chaise.vendor.min.js
 $(DIST)/$(SHARED_JS_VENDOR_ASSET_MIN): $(SHARED_JS_VENDOR_ASSET)
@@ -269,7 +266,6 @@ $(DIST)/$(SHARED_JS_VENDOR_ASSET_MIN): $(SHARED_JS_VENDOR_ASSET)
 
 SHARED_CSS_SOURCE=$(CSS)/vendor/bootstrap.min.css \
 	$(CSS)/vendor/fontawesome.min.css \
-	$(COMMON)/vendor/spectrum/spectrum.min.css \
 	$(COMMON)/styles/app.css
 
 SASS=$(COMMON)/styles/app.css
@@ -368,11 +364,14 @@ $(DIST)/$(RECORDEDIT_JS_SOURCE_MIN): $(RECORDEDIT_JS_SOURCE)
 RECORDEDIT_JS_VENDOR_ASSET=$(COMMON)/vendor/MarkdownEditor/bootstrap-markdown.js \
 	$(COMMON)/vendor/MarkdownEditor/highlight.min.js \
 	$(COMMON)/vendor/MarkdownEditor/angular-highlightjs.min.js \
-	$(COMMON)/vendor/MarkdownEditor/angular-markdown-editor.js
+	$(COMMON)/vendor/MarkdownEditor/angular-markdown-editor.js \
+	$(COMMON)/vendor/mask.min.js \
+	$(COMMON)/vendor/spectrum/spectrum.min.js
 
 RECORDEDIT_CSS_SOURCE=$(COMMON)/vendor/MarkdownEditor/styles/bootstrap-markdown.min.css \
 	$(COMMON)/vendor/MarkdownEditor/styles/github.min.css \
-	$(COMMON)/vendor/MarkdownEditor/styles/angular-markdown-editor.min.css
+	$(COMMON)/vendor/MarkdownEditor/styles/angular-markdown-editor.min.css \
+	$(COMMON)/vendor/spectrum/spectrum.min.css
 
 .make-recordedit-includes: $(BUILD_VERSION)
 	@> .make-recordedit-includes
@@ -435,13 +434,14 @@ VIEWER_JS_VENDOR_ASSET=$(COMMON)/vendor/re-tree.js \
 	$(COMMON)/vendor/MarkdownEditor/bootstrap-markdown.js \
 	$(COMMON)/vendor/MarkdownEditor/highlight.min.js \
 	$(COMMON)/vendor/MarkdownEditor/angular-highlightjs.min.js \
-	$(COMMON)/vendor/MarkdownEditor/angular-markdown-editor.js
+	$(COMMON)/vendor/MarkdownEditor/angular-markdown-editor.js \
+	$(COMMON)/vendor/mask.min.js \
+	$(COMMON)/vendor/spectrum/spectrum.min.js
 
-VIEWER_CSS_SOURCE=$(CSS)/vendor/select.css \
-	$(CSS)/vendor/select2.css \
-	$(COMMON)/vendor/MarkdownEditor/styles/bootstrap-markdown.min.css \
+VIEWER_CSS_SOURCE=$(COMMON)/vendor/MarkdownEditor/styles/bootstrap-markdown.min.css \
 	$(COMMON)/vendor/MarkdownEditor/styles/github.min.css \
-	$(COMMON)/vendor/MarkdownEditor/styles/angular-markdown-editor.min.css
+	$(COMMON)/vendor/MarkdownEditor/styles/angular-markdown-editor.min.css \
+	$(COMMON)/vendor/spectrum/spectrum.min.css
 
 .make-viewer-includes: $(BUILD_VERSION)
 	@> .make-viewer-includes
@@ -481,7 +481,8 @@ LOGIN_JS_VENDOR_ASSET=$(JS)/vendor/jquery-ui-tooltip.min.js \
 	$(JS)/vendor/jquery.nouislider.all.min.js \
 	$(JS)/vendor/jquery.cookie.js \
 	$(JS)/vendor/ng-grid.js \
-	$(JS)/vendor/bootstrap-tour.min.js
+	$(JS)/vendor/bootstrap-tour.min.js \
+	$(JS)/vendor/select.js
 
 LOGIN_CSS_SOURCE=$(CSS)/jquery.nouislider.min.css \
 	$(CSS)/vendor/ng-grid.css \

--- a/recordedit/recordEdit.app.js
+++ b/recordedit/recordEdit.app.js
@@ -46,7 +46,6 @@
         'ngSanitize',
         'ui.bootstrap',
         'ui.mask',
-        'ui.select',
         'angular-markdown-editor',
         'chaise.footer',
         'chaise.recordcreate'

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -48,7 +48,6 @@
         'ngSanitize',
         'ngMessages',
         'ui.mask',
-        'ui.select',
         'ui.bootstrap',
         'angular-markdown-editor'
     ])


### PR DESCRIPTION
I did this for two reasons:
- Spectrum relies on jQuery and we don't want our shared vendors to be jQuery dependent since navbar is using it and navbar app is injected in static sites (where jQuery is not included or might clash with our version.)
- Other input-switch related dependencies are in viewer and recordedit. So there's no reason for this dependency to be in shared vendor.

Review is not necessary and I created this PR to make sure CI test cases are stable.

P.S. as part of this I also removed ui-select from chaise apps since we're not using it at all. I left it for the login app since it's included in app.js and I didn't want to modify that file. 