### PR TITLE
Handle empty csvDownloadLink and template list

### DIFF
--- a/common/export.js
+++ b/common/export.js
@@ -21,6 +21,16 @@
          * Update the list of templates in UI
          */
         function _updateExportFormats(scope) {
+            // add the default csv option
+            if (scope.reference.csvDownloadLink) {
+                scope.exportOptions.supportedFormats.push({
+                    outputs: [],
+                    displayname: scope.csvOptionName,
+                    type: "DIRECT"
+                });
+            }
+
+            // add the export templates
             var templates = scope.reference.getExportTemplates(!chaiseConfig.disableDefaultExport);
 
             templates.forEach(function (template) {
@@ -142,13 +152,7 @@
                 };
 
                 scope.exportOptions = {
-                    supportedFormats: [
-                        {
-                            outputs: [],
-                            displayname: scope.csvOptionName,
-                            type: "DIRECT"
-                        }
-                    ]
+                    supportedFormats: []
                 };
 
                 scope.submit = function (template) {
@@ -157,9 +161,12 @@
                     _doExport(scope, template);
                 };
 
-                scope.$watch('reference', function (newValue, oldValue) {
-                    if (newValue && scope.exportOptions.supportedFormats.length === 1) {
+                var watcher = scope.$watch('reference', function (newValue, oldValue) {
+                    if (newValue && scope.exportOptions.supportedFormats.length === 0) {
                         _updateExportFormats(scope);
+                        
+                        // unbind the watcher
+                        watcher();
                     }
                 });
             }

--- a/common/templates/export.html
+++ b/common/templates/export.html
@@ -1,5 +1,5 @@
 <div class="chaise-btn-group" uib-dropdown>
-    <button class="dropdown-toggle chaise-btn chaise-btn-primary" uib-dropdown-toggle ng-click="logDropdownOpened()" ng-disabled="disabled" tooltip-placement="{{ hideNavbar ? 'left' : 'top-right'}}" uib-tooltip= "Click to choose an export format.">
+    <button class="dropdown-toggle chaise-btn chaise-btn-primary" uib-dropdown-toggle ng-click="logDropdownOpened()" ng-disabled="disabled || exportOptions.supportedFormats.length == 0" tooltip-placement="{{ hideNavbar ? 'left' : 'top-right'}}" uib-tooltip= "Click to choose an export format.">
         <span class="glyphicon chaise-btn-icon" ng-class="{'glyphicon-export': !isLoading, 'glyphicon-refresh glyphicon-refresh-animate': isLoading}"></span>
         <span>Export </span>
         <span class="caret "></span>

--- a/test/e2e/data_setup/schema/record/editable-id.json
+++ b/test/e2e/data_setup/schema/record/editable-id.json
@@ -57,7 +57,8 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["RID", "id", "text", "int", "generated"]
+                    "*": ["RID", "id", "text", "int", "generated"],
+                    "export": []
                 },
                 "tag:misd.isi.edu,2015:display" : {
                     "markdown_name": "**Editable Id Table**"
@@ -65,6 +66,23 @@
                 "tag:isrd.isi.edu,2016:table-display" : {
                     "row_name": {
                         "row_markdown_pattern": "**{{id}}**"
+                    }
+                },
+                "tag:isrd.isi.edu,2019:export": {
+                    "*": {
+                        "templates": [{
+                            "outputs": [{
+                                "source": {
+                                    "api": "entity"
+                                },
+                                "destination": {
+                                    "type": "csv",
+                                    "name": "table_bag"
+                                }
+                            }],
+                            "displayname": "some_name",
+                            "type": "BAG"
+                        }]
                     }
                 }
             }
@@ -115,7 +133,8 @@
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["id", "text", "int"]
+                    "*": ["id", "text", "int"],
+                    "export": []
                 },
                 "tag:misd.isi.edu,2015:display" : {
                     "name": "<strong>Html Name</strong>"

--- a/test/e2e/data_setup/schema/record/editable-id.json
+++ b/test/e2e/data_setup/schema/record/editable-id.json
@@ -80,7 +80,7 @@
                                     "name": "table_bag"
                                 }
                             }],
-                            "displayname": "some_name",
+                            "displayname": "Defined template",
                             "type": "BAG"
                         }]
                     }

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -63,7 +63,7 @@ describe('View existing record,', function() {
 
     });
 
-    // tests for subtitle link, resolverImplicitCatalog, and no citation in share modal
+    // tests for subtitle link, resolverImplicitCatalog, and no citation in share modal, and disabled export button
     describe("For table " + testParams.html_table_name + ",", function() {
 
         var currentBrowserUrl;
@@ -84,6 +84,11 @@ describe('View existing record,', function() {
             browser.executeScript("return chaiseConfig;").then(function(chaiseConfig) {
                 expect(chaiseConfig.resolverImplicitCatalog).toBeFalsy();
             });
+        });
+
+        // we're not using default tempaltes and csv option is disabled
+        it ("export button should be disabled", function () {
+            expect(chaisePage.recordsetPage.getExportDropdown().getAttribute("disabled")).toBeTruthy();
         });
 
         it("should hide the column headers and collapse the table of contents based on table-display annotation.", function () {
@@ -150,7 +155,7 @@ describe('View existing record,', function() {
         });
     });
 
-    // below are the tests for the copy button
+    // below are the tests for the copy button, and no csv option
     describe("For table " + testParams.table_name + ",", function() {
 
         var table, record;
@@ -170,6 +175,19 @@ describe('View existing record,', function() {
             browser.executeScript("return chaiseConfig;").then(function(chaiseConfig) {
                 expect(chaiseConfig.editRecord).toBe(true);
             });
+        });
+
+        it ("should not have the default csv export option and only the defined template should be available", function (done) {
+            var options = chaisePage.recordsetPage.getExportOptions();
+            expect(options.count()).toBe(1, "count missmatch");
+
+            chaisePage.recordsetPage.getExportDropdown().click().then(function () {
+                var csvOption = chaisePage.recordsetPage.getExportOption("Defined template");
+                expect(csvOption.getText()).toBe("Defined template");
+                done();
+            }).catch(function(err) {
+                done.fail(err);
+            })
         });
 
         describe("for the copy record button,", function() {


### PR DESCRIPTION
With the changes described in https://github.com/informatics-isi-edu/ermrestjs/pull/897, `csvDownloadLink` might not be available. So In this PR I modified the code to handle this.

This PR will also disable the button if both the export templates as well as `csvDownloadLink` are empty.

It's a very simple change but I decided to create this PR just for history.

issue: #2100 