### PR TITLE
Fix recordset facet panel resizable behavior

### DIFF
--- a/common/templates/recordset.html
+++ b/common/templates/recordset.html
@@ -1,6 +1,6 @@
 <div class="recordset-container app-content-container" ng-class="vm.config.showFaceting ? 'with-faceting':'without-faceting'" >
     <loading-spinner id="main-spinner" ng-show="(!vm.initialized || $root.showSpinner || !vm.hasLoaded) && !$root.error"></loading-spinner>
-    <div class="top-panel-container" ng-if="vm.reference">
+    <div class="top-panel-container" ng-show="vm.reference">
         <alerts alerts="$root.alerts"></alerts>
         <div class="top-flex-panel">
             <div class="top-left-panel also-resizeable" ng-class="{'open-panel': vm.config.facetPanelOpen, 'close-panel': !vm.config.facetPanelOpen}">


### PR DESCRIPTION
Changing the width of facet panel doesn't properly change the size of top-panel as well.

This is cased because in recent changes I changed `ng-show` to `ng-if` in the facet validation changes. I did that in combination with other changes and assumed that this change is needed, but it's not needed at all.

Because of `ng-if`, the top-panel element is not part of DOM when we're creating the `resizablePartners` in `table.js` (`resizablePartners` are the elements that should resize while resizing the main element) and therefore it doesn't resize the top-panel at all.

P.S. This is a very simple change. I created this PR to run test cases on Actions before merging it.