### PR TITLE
Allow submission of empty set when facet popup loaded with selections made

### DIFF
--- a/common/modal.js
+++ b/common/modal.js
@@ -384,7 +384,12 @@
             switch (params.selectMode) {
                 case modalBox.multiSelectMode:
                     if (params.onSelectedRowsChanged) {
-                        return params.onSelectedRowsChanged(getMultiSelectionResult());
+                        var res = params.onSelectedRowsChanged(getMultiSelectionResult());
+
+                        // if it returns false, then we should disable submit button
+                        // since we cannot apply the change (url limit issue)
+                        vm.disableSubmit = (res === false);
+                        return res;
                     }
                     break;
                 default:

--- a/common/modal.js
+++ b/common/modal.js
@@ -309,6 +309,9 @@
         function SearchPopupController(ConfigUtils, DataUtils, params, Session, logService, modalBox, recordsetDisplayModes, $rootScope, $timeout, $uibModalInstance) {
         var vm = this;
 
+        // rowOnLoad is used to determine if the submit button should be disabled
+        // if there are selected rows from the facet options when the modal loads, don't disable the submit button when there are 0 rows selected
+        // the submit button can be disabled when there are no selected rows on load and there are none selected
         vm.rowsOnLoad = params.selectedRows.length > 0;
         vm.params = params;
         vm.onSelectedRowsChanged = onSelectedRowsChanged;

--- a/common/modal.js
+++ b/common/modal.js
@@ -309,6 +309,7 @@
         function SearchPopupController(ConfigUtils, DataUtils, params, Session, logService, modalBox, recordsetDisplayModes, $rootScope, $timeout, $uibModalInstance) {
         var vm = this;
 
+        vm.rowsOnLoad = params.selectedRows.length > 0;
         vm.params = params;
         vm.onSelectedRowsChanged = onSelectedRowsChanged;
         vm.onFavoritesChanged = params.onFavoritesChanged;
@@ -383,12 +384,7 @@
             switch (params.selectMode) {
                 case modalBox.multiSelectMode:
                     if (params.onSelectedRowsChanged) {
-                        var res = params.onSelectedRowsChanged(getMultiSelectionResult());
-
-                        // if it returns false, then we should disable submit button
-                        // since we cannot apply the change (url limit issue)
-                        vm.disableSubmit = (res === false);
-                        return res;
+                        return params.onSelectedRowsChanged(getMultiSelectionResult());
                     }
                     break;
                 default:

--- a/common/templates/searchPopup.modal.html
+++ b/common/templates/searchPopup.modal.html
@@ -6,7 +6,7 @@
                 <div class="recordset-title-container title-container">
                     <div class="search-popup-controls recordset-title-buttons title-buttons">
                         <button id="multi-select-submit-btn" ng-if="ctrl.tableModel.config.selectMode=='multi-select'"
-                                tooltip-placement="bottom" uib-tooltip="Apply the selected rows" class="chaise-btn chaise-btn-primary" type="button" ng-click="ctrl.submit()" ng-disabled="!ctrl.rowsOnLoad && ctrl.tableModel.selectedRows.length < 1">
+                                tooltip-placement="bottom" uib-tooltip="Apply the selected rows" class="chaise-btn chaise-btn-primary" type="button" ng-click="ctrl.submit()" ng-disabled="(!ctrl.rowsOnLoad && ctrl.tableModel.selectedRows.length < 1) || ctrl.disableSubmit">
                             <span class="chaise-btn-icon glyphicon glyphicon-saved"></span>
                             <span>{{ctrl.mode == "selectFaceting" ? "Submit" : "Save" }}</span>
                         </button>

--- a/common/templates/searchPopup.modal.html
+++ b/common/templates/searchPopup.modal.html
@@ -6,7 +6,7 @@
                 <div class="recordset-title-container title-container">
                     <div class="search-popup-controls recordset-title-buttons title-buttons">
                         <button id="multi-select-submit-btn" ng-if="ctrl.tableModel.config.selectMode=='multi-select'"
-                                tooltip-placement="bottom" uib-tooltip="Apply the selected rows" class="chaise-btn chaise-btn-primary" type="button" ng-click="ctrl.submit()" ng-disabled="ctrl.tableModel.selectedRows.length < 1 || ctrl.disableSubmit">
+                                tooltip-placement="bottom" uib-tooltip="Apply the selected rows" class="chaise-btn chaise-btn-primary" type="button" ng-click="ctrl.submit()" ng-disabled="!ctrl.rowsOnLoad && ctrl.tableModel.selectedRows.length < 1">
                             <span class="chaise-btn-icon glyphicon glyphicon-saved"></span>
                             <span>{{ctrl.mode == "selectFaceting" ? "Submit" : "Save" }}</span>
                         </button>

--- a/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
@@ -14,7 +14,8 @@ var testParams = {
         modalOption: 2,
         totalNumOptions: 11,
         numRows: 10,
-        numRowsAfterModal: 11
+        numRowsAfterModal: 11,
+        removingOptionsNumRowsAfterModal: 25
     },
     facet_order: [
         {
@@ -71,7 +72,7 @@ var testParams = {
             facetIdx: 11,
             displayingText: "Displaying\nall 13\nrecords",
             numModalOptions: 13
-            
+
         },
         shown: {
             facetIdx: 10,
@@ -305,8 +306,36 @@ describe("Other facet features, ", function() {
                     });
                 }, browser.params.defaultTimeout, "Number of facet options is incorrect after returning from modal");
 
-                return chaisePage.clickButton(chaisePage.recordsetPage.getClearAllFilters());
+                done();
+            }).catch(chaisePage.catchTestError(done));
+        });
+
+        it ("removing values in the modal should allow for submitting to remove the set of selected options for that facet.", function (done) {
+            chaisePage.clickButton(chaisePage.recordsetPage.getShowMore(idx)).then(function () {
+                chaisePage.waitForElementInverse(element.all(by.id("spinner")).first());
+
+                expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(2, "number of checked rows missmatch.");
+
+                // clear selections in modal to remove selections in facet
+                return chaisePage.clickButton(chaisePage.recordsetPage.getModalClearSelection());
             }).then(function () {
+                expect(chaisePage.recordsetPage.getCheckedModalOptions().count()).toBe(0, "number of checked rows missmatch after clearing selection.");
+
+                return chaisePage.clickButton(chaisePage.recordsetPage.getModalSubmit());
+            }).then(function () {
+                browser.wait(function() {
+                    return chaisePage.recordsetPage.getRows().count().then(function(ct) {
+                        return (ct == testParams.filter_secondary_key.removingOptionsNumRowsAfterModal);
+                    });
+                }, browser.params.defaultTimeout, "number of visible rows after selecting a second option missmatch.");
+
+                browser.wait(function() {
+                    return  chaisePage.recordsetPage.getCheckedFacetOptions(idx).count().then(function(ct) {
+                        return (ct == 0);
+                    });
+                }, browser.params.defaultTimeout, "Number of facet options is incorrect after returning from modal");
+
+                //no need to clear all filters, this test removed the last selected facet options
                 done();
             }).catch(chaisePage.catchTestError(done));
         });
@@ -647,7 +676,7 @@ describe("Other facet features, ", function() {
 
                 return browser.driver.getCurrentUrl();
             }).then (function(currentUrl) {
-                
+
                 var newURL = uriPrefix + "/*::facets::" + currParams.facetBlobAfterOK;
                 expect(currentUrl).toContain(newURL, "The redirection from record page to recordset in case of multiple records failed");
                 done();
@@ -716,7 +745,7 @@ describe("Other facet features, ", function() {
                 done();
             }).catch(chaisePage.catchTestError(done));
         });
-        
+
     });
 
     describe("navigating to recordset with filters that faceting doesn't support.", function () {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1144,6 +1144,10 @@ var recordsetPage = function() {
         return element(by.css(".modal-body .recordset-table")).all(by.css(".chaise-checkbox input")).get(index);
     };
 
+    this.getModalClearSelection = function () {
+        return element(by.css(".modal-body")).element(by.css(".clear-all-btn"));
+    }
+
     this.getModalSubmit = function () {
         return element(by.id("multi-select-submit-btn"));
     }


### PR DESCRIPTION
This PR addresses an issue with the facet "Show More" popup not allowing the user to submit a selection of 0 rows when the popup loaded with more than 0 rows. More details can be found in the attached issue.