### PR TITLE
defaults for saved query name and description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,15 @@ RECORDSET_JS_SOURCE_MIN=recordset.min.js
 $(DIST)/$(RECORDSET_JS_SOURCE_MIN): $(RECORDSET_JS_SOURCE)
 	$(call bundle_js_files,$(RECORDSET_JS_SOURCE_MIN),$(RECORDSET_JS_SOURCE))
 
-RECORDSET_JS_VENDOR_ASSET=
+# TODO why four different files for markdown? if inputswitch will be used everywhere, this should move to shared
+RECORDSET_JS_VENDOR_ASSET=$(COMMON)/vendor/MarkdownEditor/bootstrap-markdown.js \
+	$(COMMON)/vendor/MarkdownEditor/highlight.min.js \
+	$(COMMON)/vendor/MarkdownEditor/angular-highlightjs.min.js \
+	$(COMMON)/vendor/MarkdownEditor/angular-markdown-editor.js \
 
-RECORDSET_CSS_SOURCE=
+RECORDSET_CSS_SOURCE=$(COMMON)/vendor/MarkdownEditor/styles/bootstrap-markdown.min.css \
+	$(COMMON)/vendor/MarkdownEditor/styles/github.min.css \
+	$(COMMON)/vendor/MarkdownEditor/styles/angular-markdown-editor.min.css \
 
 .make-recordset-includes: $(BUILD_VERSION)
 	@> .make-recordset-includes

--- a/common/styles/scss/_recordedit-app.scss
+++ b/common/styles/scss/_recordedit-app.scss
@@ -202,21 +202,6 @@
         opacity: 1;
     }
 
-    .md-editor {
-        border-radius: $btn-border-radius;
-
-        .md-header {
-            border-top-left-radius: $btn-border-radius;
-            border-top-right-radius: $btn-border-radius;
-        }
-
-        .content-box {
-            border-bottom-left-radius: $btn-border-radius;
-            border-bottom-right-radius: $btn-border-radius;
-            border-bottom: 0;
-        }
-    }
-
     textarea {
         resize: vertical;
         height: auto;

--- a/common/styles/scss/app.scss
+++ b/common/styles/scss/app.scss
@@ -709,6 +709,22 @@ html {
         }
     }
 
+/****** longtext inputs *********/
+    .md-editor {
+        border-radius: $btn-border-radius;
+
+        .md-header {
+            border-top-left-radius: $btn-border-radius;
+            border-top-right-radius: $btn-border-radius;
+        }
+
+        .content-box {
+            border-bottom-left-radius: $btn-border-radius;
+            border-bottom-right-radius: $btn-border-radius;
+            border-bottom: 0;
+        }
+    }
+
 /******* range inputs ***********/
     range-inputs {
         .form-inline {

--- a/common/table.js
+++ b/common/table.js
@@ -1570,6 +1570,9 @@
                      *      <facet displayname> (<option1>, <option2>, <option3>, ...)
                      *   3. listing the facet displayname and number of selections if over either of the numFacetChoices or facetTextLength thresholds
                      *      <facet displayname> (6 choices)
+                     * If the name after appending all facet names together is over the nameLength threshold,
+                     * a further shortened syntax is used for the whole name:
+                     *     <reference displayname> with x facets: <facet1 displayname>, <facet2 displayname>, <facet3 displayname>, ...
                      *
                      * `description` begins with the reference displayname and "with" also. The rest of the
                      * description is created by iterating over each facet and the selections made in the facets.

--- a/common/templates/inputs/inputSwitch.html
+++ b/common/templates/inputs/inputSwitch.html
@@ -118,7 +118,7 @@
 
     <!-- longtext/textarea input -->
     <div ng-switch-when="longtext">
-        <textarea ng-model="vm.model" rows="5" name="{{::vm.column.name}}" class="content-box" ng-required="vm.isRequired" empty-to-null markdown-editor="{'iconlibrary': 'glyph', addExtraButtons:true ,fullscreen:{ enable: false, icons: {}}, resize: 'vertical'}"></textarea>
+        <textarea ng-model="vm.model" rows="5" name="{{::vm.column.name}}" class="content-box chaise-input-control" style="height: 120px" ng-required="vm.isRequired" empty-to-null markdown-editor="{iconlibrary: 'glyph', addExtraButtons: true, fullscreen: { enable: false, icons: {}}, resize: 'vertical'}"></textarea>
         <a href class="live-preview" markdown-preview textinput="vm.model"></a>
     </div>
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -2562,6 +2562,13 @@
             // NOTE: if this is not set, saved query UI should probably be turned off
             if (chaiseConfig.savedQueryConfig && typeof chaiseConfig.savedQueryConfig.storageTable == "object") {
                 var mapping = savedQuery.mapping = chaiseConfig.savedQueryConfig.storageTable;
+                // set the 3 threshold properties: facetChoicesThreshold, facetTextLengthThreshold, nameLengthThreshold
+                // thresholds for when to use a modified simpler syntax for the default name value
+                savedQuery.thresholds = {
+                    numFacetChoices: !isNaN(chaiseConfig.savedQueryConfig.facetChoicesThreshold) ? chaiseConfig.savedQueryConfig.facetChoicesThreshold : 5,
+                    facetTextLength: !isNaN(chaiseConfig.savedQueryConfig.facetTextLengthThreshold) ? chaiseConfig.savedQueryConfig.facetTextLengthThreshold : 60,
+                    nameLength: !isNaN(chaiseConfig.savedQueryConfig.nameLengthThreshold) ? chaiseConfig.savedQueryConfig.nameLengthThreshold : 200
+                }
 
                 var validMapping = isStringAndNotEmpty(mapping.catalog) && isStringAndNotEmpty(mapping.schema) && isStringAndNotEmpty(mapping.table);
 

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -661,13 +661,19 @@ system columns:
          catalog: <catalog id>
          schema: <schema name>
          table: <table name>
-       }
+       },
+       facetChoicesThreshold: <int>,
+       facetTextLengthThreshold: <int>,
+       nameLengthThreshold: <int>
      }
      ```
    - `storageTable` attributes
      - `catalog`: String - catalog id
      - `schema`: String - schema name
      - `table`: String - table name
+   - `facetChoicesThreshold`: for the default value of the name property of saved queries. Set this value to define when to show a shortened facet syntax based on how many choices are selected. By default this value is 5. Set this to 0 to always show the shortened syntax.
+   - `facetTextLengthThreshold`: for the default value of the name property of saved queries. Set this value to define when to show a shortened facet syntax based on the total string length of the facet choices when appended together. By default this value is 60. Set this to 0 to always show the shortened syntax.
+   - `nameLengthThreshold`: for the default value of the name property of saved queries. Set this value to define when to show a further shortened facet syntax based on the total string length of all facets text when appended together. By default this value is 200. Set this to 0 to always show the further shortened syntax.
    - Default value: null
    - Sample syntax:
      ```
@@ -699,4 +705,3 @@ system columns:
      ```
      assetDownloadPolicyURL: "<your url>"
      ```
-

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -43,7 +43,8 @@
         'ngSanitize',
         'ngAnimate',
         'duScroll',
-        'ui.bootstrap'
+        'ui.bootstrap',
+        'angular-markdown-editor'
     ])
 
     .config(['$compileProvider', '$cookiesProvider', '$logProvider', '$provide', '$uibTooltipProvider', 'ConfigUtilsProvider', function($compileProvider, $cookiesProvider, $logProvider, $provide, $uibTooltipProvider, ConfigUtilsProvider) {


### PR DESCRIPTION
This PR adds default values into the name and description columns during saved query creation. These values will populate the form when it is opened and can be replaced by other values by the user.

This also fixes an issue with markdown inputs not displaying correctly in the saved query popup that hasn't been encountered yet.