### PR TITLE
Change makefile targets to fix Github Actions issues

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Setup the system
         run: |
           node --version
+          npm --version
           sudo timedatectl set-timezone America/Los_Angeles
           export TZ=America/Los_Angeles
           export PATH="$(systemd-path user-binaries):$PATH"
@@ -105,8 +106,7 @@ jobs:
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          sudo npm install
-          sudo npm list protractor
+          sudo make deps
           sudo make install
       - name: Add tests users
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -139,6 +139,8 @@ jobs:
         continue-on-error: true
         run: |
           cd chaise
+          echo "env variables:"
+          printenv
           sudo make testfullfeaturesconfirmation
       - name: Run default config test spec
         id: test-default-config

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          sudo make install
+          make install
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1
@@ -147,19 +147,19 @@ jobs:
         continue-on-error: true
         run: |
           cd chaise
-          sudo make testdefaultconfig
+          make testdefaultconfig
       - name: Run full features test spec
         id: test-full-features
         continue-on-error: true
         run: |
           cd chaise
-          sudo make testfullfeatures
+          make testfullfeatures
       - name: Run delete prohibited test spec
         id: test-delete-prohibited
         continue-on-error: true
         run: |
           cd chaise
-          sudo make testdeleteprohibited
+          make testdeleteprohibited
       - name: Check on full features confirmation test spec
         if: always() && steps.test-full-features-confirmation.outcome != 'success'
         run: exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,8 +28,12 @@ jobs:
           path: chaise
       - name: Setup the system
         run: |
+          echo "node version:"
           node --version
+          echo "npm version:"
           npm --version
+          echo "env variables:"
+          printenv
           sudo timedatectl set-timezone America/Los_Angeles
           export TZ=America/Los_Angeles
           export PATH="$(systemd-path user-binaries):$PATH"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'debug-ci'
   pull_request:
     branches:
       - 'master'
@@ -28,6 +29,7 @@ jobs:
           path: chaise
       - name: Setup the system
         run: |
+          node --version
           sudo timedatectl set-timezone America/Los_Angeles
           export TZ=America/Los_Angeles
           export PATH="$(systemd-path user-binaries):$PATH"
@@ -104,6 +106,7 @@ jobs:
           sudo mkdir -p /var/www/html/chaise
           cd chaise
           sudo npm install
+          sudo npm list protractor
           sudo make install
       - name: Add tests users
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -141,7 +141,7 @@ jobs:
           cd chaise
           echo "env variables:"
           printenv
-          sudo make testfullfeaturesconfirmation
+          make testfullfeaturesconfirmation
       - name: Run default config test spec
         id: test-default-config
         continue-on-error: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,7 +109,8 @@ jobs:
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          make install
+          sudo make install
+          sudo make install-test-deps
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1
@@ -139,8 +140,6 @@ jobs:
         continue-on-error: true
         run: |
           cd chaise
-          echo "env variables:"
-          printenv
           make testfullfeaturesconfirmation
       - name: Run default config test spec
         id: test-default-config

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -109,8 +109,8 @@ jobs:
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          sudo make install
-          sudo make install-test-deps
+          sudo make deps-test
+          sudo make install-wo-deps
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'debug-ci'
   pull_request:
     branches:
       - 'master'
@@ -106,7 +105,6 @@ jobs:
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          sudo make deps
           sudo make install
       - name: Add tests users
         run: |
@@ -137,25 +135,25 @@ jobs:
         continue-on-error: true
         run: |
           cd chaise
-          make testfullfeaturesconfirmation
+          sudo make testfullfeaturesconfirmation
       - name: Run default config test spec
         id: test-default-config
         continue-on-error: true
         run: |
           cd chaise
-          make testdefaultconfig
+          sudo make testdefaultconfig
       - name: Run full features test spec
         id: test-full-features
         continue-on-error: true
         run: |
           cd chaise
-          make testfullfeatures
+          sudo make testfullfeatures
       - name: Run delete prohibited test spec
         id: test-delete-prohibited
         continue-on-error: true
         run: |
           cd chaise
-          make testdeleteprohibited
+          sudo make testdeleteprohibited
       - name: Check on full features confirmation test spec
         if: always() && steps.test-full-features-confirmation.outcome != 'success'
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ define make_test
 	exit $$rc;
 endef
 
-test-%: update-webdriver
+test-%:
 	$(call make_test, $($*), "0")
 
 #### Sequential make commands - these commands will run tests in sequential order

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ define make_test
 	exit $$rc;
 endef
 
-test-%: testdeps
+test-%: update-webdriver
 	$(call make_test, $($*), "0")
 
 #### Sequential make commands - these commands will run tests in sequential order
@@ -621,28 +621,28 @@ $(DIST): print_variables deps $(SASS) $(MIN) $(HTML) gitversion
 $(BUILD_VERSION):
 
 # make sure the latest webdriver is installed
-.PHONY: update_webdriver
-update_webdriver:
+.PHONY: update-webdriver
+update-webdriver:
 	node_modules/protractor/bin/webdriver-manager update --versions.standalone 3.6.0
 
 # install packages needed for production
-.PHONY: npm_install_prod_modules
-npm_install_prod_modules:
+.PHONY: npm-install-prod-modules
+npm-install-prod-modules:
 	npm install --production
 
 # install packages needed for production and development (including testing)
-.PHONY: npm_install_all_modules
-npm_install_all_modules:
+.PHONY: npm-install-all-modules
+npm-install-all-modules:
 	npm install
 
 # for test cases we have to make sure we're installing dev dependencies and
 # webdriver is always updated to the latest version
-.PHONY: testdeps
-testdeps: npm_install_all_modules update_webdriver
+.PHONY: install-test-deps
+install-test-deps: npm-install-all-modules update-webdriver
 
 # install all the dependencies
 .PHONY: deps
-deps: npm_install_prod_modules
+deps: npm-install-prod-modules
 
 .PHONY: updeps
 updeps:

--- a/Makefile
+++ b/Makefile
@@ -613,9 +613,7 @@ define bundle_js_files
 endef
 
 # Rule to create the package.
-# - we have to make sure the npm dependencies required for build are installed.
-# - we have to clean all the dist files because we need to generate new ones.
-$(DIST): print_variables deps $(SASS) $(MIN) $(HTML) gitversion
+$(DIST): print-variables $(SASS) $(MIN) $(HTML) gitversion
 
 # build version will change everytime make all or install is called
 $(BUILD_VERSION):
@@ -637,8 +635,8 @@ npm-install-all-modules:
 
 # for test cases we have to make sure we're installing dev dependencies and
 # webdriver is always updated to the latest version
-.PHONY: install-test-deps
-install-test-deps: npm-install-all-modules update-webdriver
+.PHONY: test-deps
+deps-test: npm-install-all-modules update-webdriver
 
 # install all the dependencies
 .PHONY: deps
@@ -668,15 +666,19 @@ all: $(DIST)
 
 # Rule for installing for normal deployment (build chaise and deploy)
 .PHONY: install dont_install_in_root
-install: $(DIST) dont_install_in_root
-	$(info - deploying the package)
-	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' --exclude='$(JS_CONFIG)' --exclude='$(VIEWER_CONFIG)' . $(CHAISEDIR)
+install: deps $(DIST) dont_install_in_root rsync-chaise
+
+# Rule for installing without installing dependencies
+.PHONY: install-wo-deps dont_install_in_root
+install-wo-deps: $(DIST) dont_install_in_root rsync-chaise
 
 # Rule for installing during testing (build chaise and deploy with the chaise-config)
 .PHONY: install-w-config dont_install_in_root
-install-w-config: $(DIST) dont_install_in_root $(JS_CONFIG) $(VIEWER_CONFIG)
-	$(info - deploying the package with the existing default config files)
-	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' . $(CHAISEDIR)
+install-w-config: deps $(DIST) dont_install_in_root $(JS_CONFIG) $(VIEWER_CONFIG) rsync-chaise-w-config
+
+# Rule for installing during testing without updating dependencies (build chaise and deploy with the chaise-config)
+.PHONY: install-w-config dont_install_in_root
+install-wo-deps-w-config: $(DIST) dont_install_in_root $(JS_CONFIG) $(VIEWER_CONFIG) rsync-chaise-w-config
 
 # Rule to create version.txt
 .PHONY: gitversion
@@ -687,7 +689,17 @@ gitversion:
 dont_install_in_root:
 	@echo "$(CHAISEDIR)" | egrep -vq "^/$$|.*:/$$"
 
-print_variables:
+# rsync the build files to the location
+rsync-chaise:
+	$(info - deploying the package)
+	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' --exclude='$(JS_CONFIG)' --exclude='$(VIEWER_CONFIG)' . $(CHAISEDIR)
+
+# rsync the build and config files to the location
+rsync-chaise-w-config:
+	$(info - deploying the package with the existing default config files)
+	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' . $(CHAISEDIR)
+
+print-variables:
 	@mkdir -p $(DIST)
 	$(info =================)
 	$(info BUILD_VERSION=$(BUILD_VERSION))
@@ -701,17 +713,23 @@ print_variables:
 .PHONY: help usage
 help: usage
 usage:
-	@echo "Available 'make' targets:"
-	@echo "    all       		- an alias for build"
-	@echo "    install          - installs the client (CHAISEDIR=$(CHAISEDIR))"
-	@echo "    deps      		- local install of node dependencies"
-	@echo "    updeps    		- update local dependencies"
-	@echo "    test      		- runs e2e tests"
-	@echo "    clean     		- cleans the dist dir"
-	@echo "    distclean 		- cleans the dist dir and the dependencies"
-	@echo "    testrecordadd 	- runs data entry app add e2e tests"
-	@echo "    testrecordedit 	- runs data entry app edit e2e tests"
-	@echo "    testrecord 		- runs record app e2e tests"
-	@echo "    testrecordset 	- runs recordset app e2e tests"
-	@echo "    testviewer   	- runs viewer app e2e tests"
-	@echo "    testnavbar   	- runs navbar e2e tests"
+	@echo "Usage: make [target]"
+	@echo "Available targets:"
+	@echo "  install                    local install of node dependencies, build and install the client"
+	@echo "  install-w-config           local install of node dependencies, build and install the client with chaise-config.js file"
+	@echo "  install-wo-deps            build and install the client"
+	@echo "  install-wo-deps-w-config   build and install the client with chaise-config.js file"
+	@echo "  all                        build the client"
+	@echo "  clean                      clean the files and folders created during build"
+	@echo "  distclean                  clean the files and folders created during build and npm dependencies"
+	@echo "  deps                       local install of node dependencies"
+	@echo "  updeps                     local update  of node dependencies"
+	@echo "  update-webdriver           update the protractor's webdriver"
+	@echo "  deps-test                  install dev node dependencies and update protractor's webdriver"
+	@echo "  test                       run e2e tests"
+	@echo "  testrecordadd              run data entry app add e2e tests"
+	@echo "  testrecordedit             run data entry app edit e2e tests"
+	@echo "  testrecord                 run record app e2e tests"
+	@echo "  testrecordset              run recordset app e2e tests"
+	@echo "  testviewer                 run viewer app e2e tests"
+	@echo "  testnavbar                 run navbar e2e tests"

--- a/docs/dev-docs/e2e-test.md
+++ b/docs/dev-docs/e2e-test.md
@@ -51,51 +51,56 @@ You can get your cookie by querying the database, or using the following simple 
 
 ## How To Run Tests
 ### Prerequistes
-- After setting up the environment variables, make sure that the `https://dev.isrd.isi.edu/~<your-user-directory>` directory has the public access(if not, give the folder the following permissions `chmod 755 <your-user-directory>`).
+1. After setting up the environment variables, make sure that the `https://dev.isrd.isi.edu/~<your-user-directory>` directory has the public access(if not, give the folder the following permissions `chmod 755 <your-user-directory>`).
 
-- Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository. (This will upload your local code to the remote server)
-```sh
-$ make install
-```
+2. Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository. (This will upload your local code to the remote server)
+    ```sh
+    $ make install
+    ```
 
-- Make sure all the npm dependencies are installed by running `npm install`.
+3. Make sure all the dependencies are installed by running `make install-test-deps`.
 
-```sh
-$ npm install
-```
+    ```sh
+    $ make install-test-deps
+    ```
+
+    This will install all the npm dependencies that are needed and will also make sure the Selenium's WebDriver that protractor uses is updated.
+
+    - If you just want to update the WebDriver you can do `make update_webdriver`.
+    - If the version of Chrome that is installed on your machine is different from the ChromeDriver that Selenium uses, it will throw an error. So make sure both versions are always updated and compatible.
 
 ### Test cases
 - To execute all test cases in sequential order, set the following:
-```sh
-export SHARDING=false
-```
+  ```sh
+  export SHARDING=false
+  ```
 
-and then run the following command:
+  and then run the following command:
 
-```sh
-$ make test
-```
+  ```sh
+  $ make test
+  ```
 
-This will automatically update the *selenium* web-driver that protractor is using.
+  This will automatically update the Selenium WebDriver that protractor is using.
 
 - To execute all the test cases in parallel, set the following:
 
-```sh
-export SHARDING=true
-```
+  ```sh
+  export SHARDING=true
+  ```
 
-and then run the following command:
+  and then run the following command:
 
-```sh
-$ make testparallel
-```
+  ```sh
+  $ make testparallel
+  ```
 
 - To run a specific test spec
 
     ```sh
     $ node_modules/.bin/protractor test/e2e/specs/search/data-independent/protractor.conf.js
     ```
-> Calling protractor directly won't install npm modules and will not update the selenium web-driver. So you have to do those steps manually.
+  > Calling protractor directly won't update the Selenium WebDriver and you have to do it manually.
 
 ## File structure
 
@@ -104,7 +109,7 @@ chaise/
 `-- test/
     |-- unit
     `-- e2e
-	|-- data_setup                       
+	|-- data_setup
 	|   |-- config                       # test configuration files
         |   |   |-- record
         |   |   |   |-- *.dev.json  # lists the schema config files (*.config.json)
@@ -120,10 +125,10 @@ chaise/
 	|	`-- SCHEMA_NAME.json         # Schema Definition json
 	|-- specs
 	|   `-- all-features
-	|       |-- record           
-	|       |   |-- TEST_NAME1.spec.js   
+	|       |-- record
+	|       |   |-- TEST_NAME1.spec.js
 	|       |   `-- TEST_NAME1.conf.js   # protractor configuration for similarly named single test
-	|       |-- recordedit         
+	|       |-- recordedit
 	|    	|                            # They introspect the existing schema to run the cases*/
 	|       `-- protractor.conf.js   # configuration for the parallel tests
 	`-- utils

--- a/docs/dev-docs/e2e-test.md
+++ b/docs/dev-docs/e2e-test.md
@@ -53,21 +53,28 @@ You can get your cookie by querying the database, or using the following simple 
 ### Prerequistes
 1. After setting up the environment variables, make sure that the `https://dev.isrd.isi.edu/~<your-user-directory>` directory has the public access(if not, give the folder the following permissions `chmod 755 <your-user-directory>`).
 
-2. Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository. (This will upload your local code to the remote server)
-    ```sh
-    $ make install
-    ```
-
-3. Make sure all the dependencies are installed by running `make install-test-deps`.
+2. Make sure all the dependencies are installed by running the following command:
 
     ```sh
-    $ make install-test-deps
+    $ make deps-test
     ```
 
     This will install all the npm dependencies that are needed and will also make sure the Selenium's WebDriver that protractor uses is updated.
 
-    - If you just want to update the WebDriver you can do `make update_webdriver`.
+    - If you just want to update the WebDriver you can do `make update-webdriver`.
     - If the version of Chrome that is installed on your machine is different from the ChromeDriver that Selenium uses, it will throw an error. So make sure both versions are always updated and compatible.
+
+
+3. Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository. (This will upload your local code to the remote server)
+    ```sh
+    $ make install-wo-deps
+    ```
+
+    - As the name suggests this will not install dependencies. That's why you need to install all the dependencies in step 2. The following are other available targets related to install:
+      - `install`: Will install production dependencies before installing (not advised for testing purposes and should be used for production)
+      - `install-w-config`: The same as `install` and will also copy the `chaise-config.js` file to the remote location.
+      - `install-wo-deps-w-config`: The same as `install-w-deps` and will also copy the `chaise-config.js` file to the remote location.
+
 
 ### Test cases
 - To execute all test cases in sequential order, set the following:
@@ -80,8 +87,6 @@ You can get your cookie by querying the database, or using the following simple 
   ```sh
   $ make test
   ```
-
-  This will automatically update the Selenium WebDriver that protractor is using.
 
 - To execute all the test cases in parallel, set the following:
 
@@ -100,7 +105,6 @@ You can get your cookie by querying the database, or using the following simple 
     ```sh
     $ node_modules/.bin/protractor test/e2e/specs/search/data-independent/protractor.conf.js
     ```
-  > Calling protractor directly won't update the Selenium WebDriver and you have to do it manually.
 
 ## File structure
 

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -141,6 +141,7 @@ exports.parameterize = function(config, configParams) {
 
         console.log("before launch");
         console.log(process.env.CI);
+        console.log(process.env);
 
         if (process.env.CI) {
             console.log("getting the hostname from the CI environment");

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -140,8 +140,10 @@ exports.parameterize = function(config, configParams) {
         var defer = Q.defer();
 
         console.log("before launch");
+        console.log(process.env.CI);
 
         if (process.env.CI) {
+            console.log("getting the hostname from the CI environment");
             var exec = require('child_process').exec;
             exec("hostname", function(error, stdout, stderr) {
 

--- a/test/e2e/utils/protractor.parameterize.js
+++ b/test/e2e/utils/protractor.parameterize.js
@@ -140,8 +140,6 @@ exports.parameterize = function(config, configParams) {
         var defer = Q.defer();
 
         console.log("before launch");
-        console.log(process.env.CI);
-        console.log(process.env);
 
         if (process.env.CI) {
             console.log("getting the hostname from the CI environment");


### PR DESCRIPTION
Currently for testing we use a bunch of npm dependencies that are not needed while building chaise. That's why we listed them as part of `devDepencendies` and this allows us to do `npm install --production` during `make install`, while we have to do `npm install` before testing.

I'm not sure when this happened, but it seems like the behavior of `npm install --production` is not the same as before. If you do `npm install` and then `npm install --production` it will remove all the dev dependencies. That's why the test cases in Github Actions started failing since last week.

So,
- Introduced a `deps-test` Makefile target to install dependencies after doing `make install` in Github Actions.
- Updated `test` Makefile targets to not install anything by default and only run tests. Previously we used to update webdriver as part of `test` target. This was causing issues in Github Actions as we have to use the privileged user for changing the folder, but the `CI` environment variable is not available for the privileged user in Github.
- Introduced a `update-webdriver` that can be used before running test cases.
- Updated documentation based on the changes (I need to update the docs and remove the parts that mention we're updating webdriver automatically. I didn't do it so it doesn't affect the currently running test build)
- Introduced other install targets based on whether it should also copy the chaise-config, or install dependencies.