### PR TITLE
Fix navbar link click events

### DIFF
--- a/common/navbar.js
+++ b/common/navbar.js
@@ -189,16 +189,11 @@
                     }
 
                     scope.logBranding = function ($event, link) {
-                        // prevent the default link behavior, so we log the action first
-                        $event.preventDefault();
                         $event.stopPropagation();
 
                         logService.logClientAction({
                             action: logService.getActionString(logService.logActions.NAVBAR_BRANDING, "", "")
                         });
-
-                        // change the window location (do the default link behavior)
-                        $window.location = link;
                     }
 
                     scope.onLinkClick = MenuUtils.onLinkClick();

--- a/common/table.js
+++ b/common/table.js
@@ -1972,7 +1972,12 @@
                         };
                         ErrorService.handleException(res.issues, false, false, cb, cb);
                     } else {
-                        if ($rootScope.savedQuery && $rootScope.savedQuery.showUI && !$rootScope.savedQuery.updated) {
+                        // execute the following if:
+                        //   - the savedQuery UI is being shown
+                        //   - a savedQuery rid is present in the url on page load
+                        //   - the updated flag is not true
+                        //     - savedQuery.updated is initialized to true unless there is a proper savedQuery mapping and defined savedQuery rid is set
+                        if ($rootScope.savedQuery && $rootScope.savedQuery.showUI && $rootScope.savedQuery.rid && !$rootScope.savedQuery.updated) {
                             // to prevent the following code and request from triggering more than once
                             // NOTE: doesn't matter if the update is successful or not, we are only preventing this block from triggering more than once
                             $rootScope.savedQuery.updated = true;
@@ -2013,7 +2018,7 @@
                             config.headers[ERMrest.contextHeaderName] = logObj;
                             // attributegroup/CFDE:saved_query/RID;last_execution_status
                             ConfigUtils.getHTTPService().put($window.location.origin + $rootScope.savedQuery.ermrestAGPath + "/RID;last_execution_time", rows, config).then(function (response) {
-                              // do nothing
+                                // do nothing
                             }).catch(function (error) {
                                 $log.warn("saved query last executed time could not be updated");
                                 $log.warn(error);

--- a/common/utils.js
+++ b/common/utils.js
@@ -1447,7 +1447,6 @@
          */
         function onLinkClick() {
             return function ($event, menuObject) {
-                $event.preventDefault();
                 $event.stopPropagation();
 
                 // NOTE: if link goes to a chaise app, client logging is not necessary (we're using ppid, pcid instead)
@@ -1458,12 +1457,6 @@
                         action: logService.getActionString(action, "", ""),
                         names: menuObject.names
                     });
-                }
-
-                if (menuObject.newTab) {
-                    $window.open(menuObject.url, '_blank');
-                } else {
-                    $window.location = menuObject.url;
                 }
             };
         }
@@ -2557,7 +2550,13 @@
             // initalize to null as if there is no saved query table
             // savedQuery object should be defined with showUI true || false for UI purposes
             var savedQuery = {
-                showUI: reference.display.showSavedQuery
+                defaultNameLimits: {},
+                ermrestTablePath: null,
+                ermrestAGPath: null,
+                mapping: {},
+                rid: null,
+                showUI: reference.display.showSavedQuery,
+                updated: true
             }
 
             // NOTE: if this is not set, saved query UI should be turned off
@@ -2581,8 +2580,8 @@
 
                     // should only be set if mapping is valid as well since we can't update the last_execution_time without a valid mapping
                     if (queryParams && queryParams.savedQueryRid) {
-                      savedQuery.rid = queryParams.savedQueryRid;
-                      savedQuery.updated = false; // initialized here to track that the query's last execution time has been updated
+                        savedQuery.rid = queryParams.savedQueryRid;
+                        savedQuery.updated = false; // initialized here to track that the query's last execution time has been updated
                     }
                 } else {
                     // if mapping is invalid, the config is ill-defined and the feature will be turned off


### PR DESCRIPTION
Changes included remove the preventDefault function call from navbar branding and navbar menu click events.

Other changes included makes sure that saved query properties are initialized before any of the functionality is triggered. Fixed a bug that Karl brought up regarding a request triggering that was failing silently in the background on app-dev.nih-cfde.org.

Related message:
> Mike showed me some app-dev logs which imply to me that something might be wrong with the saved query event logging
> it was a two-column access with RID and last execution time, complaining that RID was null