### PR TITLE
Failing unlink test

### DIFF
--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -1185,10 +1185,11 @@ exports.testBatchUnlinkAssociationTable = function (params, isInline, pageReadyC
 
                 expect(chaisePage.recordPage.getModalText().getText()).toBe("Are you sure you want to unlink 2 records?");
 
-                var unlinkBtn = chaisePage.recordPage.getConfirmDeleteButton();
-                expect(unlinkBtn.getText()).toBe("Unlink");
+                var confirmUnlinkBtn = chaisePage.recordPage.getConfirmDeleteButton();
+                browser.wait(EC.elementToBeClickable(confirmUnlinkBtn), browser.params.defaultTimeout);
+                expect(confirmUnlinkBtn.getText()).toBe("Unlink");
 
-                return unlinkBtn.click();
+                return confirmUnlinkBtn.click();
             }).then(function () {
                 var unlinkSummaryModal = element(by.css('.modal-error'));
                 chaisePage.waitForElement(unlinkSummaryModal);
@@ -1368,7 +1369,11 @@ exports.testBatchUnlinkDynamicAclsAssociationTable = function (params, isInline,
                 expect(text).toBe("Confirm Unlink");
                 expect(chaisePage.recordPage.getModalText().getText()).toBe("Are you sure you want to unlink 2 records?");
 
-                return chaisePage.recordPage.getConfirmDeleteButton().click();
+                var confirmUnlinkBtn = chaisePage.recordPage.getConfirmDeleteButton();
+                browser.wait(EC.elementToBeClickable(confirmUnlinkBtn), browser.params.defaultTimeout);
+                expect(confirmUnlinkBtn.getText()).toBe("Unlink");
+
+                return confirmUnlinkBtn.click();
             }).then(function () {
                 var unlinkSummaryModal = element(by.css('.modal-error'));
                 chaisePage.waitForElement(unlinkSummaryModal);
@@ -1425,7 +1430,11 @@ exports.testBatchUnlinkDynamicAclsAssociationTable = function (params, isInline,
                 expect(text).toBe("Confirm Unlink");
                 expect(chaisePage.recordPage.getModalText().getText()).toBe("Are you sure you want to unlink 1 record?");
 
-                return chaisePage.recordPage.getConfirmDeleteButton().click();
+                var confirmUnlinkBtn = chaisePage.recordPage.getConfirmDeleteButton();
+                browser.wait(EC.elementToBeClickable(confirmUnlinkBtn), browser.params.defaultTimeout);
+                expect(confirmUnlinkBtn.getText()).toBe("Unlink");
+
+                return confirmUnlinkBtn.click();
             }).then(function () {
                 var unlinkSummaryModal = element(by.css('.modal-error'));
                 chaisePage.waitForElement(unlinkSummaryModal);


### PR DESCRIPTION
Opening this PR to continue investigating failing tests in github actions after turning off ngAnimate.

Current failure was because of the confirm unlink modal not actually showing before trying ot click the ok button. More investigation might be needed. 

One issue I have noticed is how repaint events work in the sauce labs environment. If we use a promise chain, triggering a promise callback seems to repaint the UI and give modals a chance to finish loading before working with them.