### PR TITLE
Proper dynamic ACL support in viewer app annotation list

### DIFF
--- a/chaise-config-sample.js
+++ b/chaise-config-sample.js
@@ -16,7 +16,6 @@ var chaiseConfig = {
         enable: ["*"] // [] <- disable
     },
     maxColumns: 6,
-    defaultAnnotationColor: 'red',
     feedbackURL: 'http://goo.gl/forms/f30sfheh4H',
     helpURL: '/help/using-the-data-browser/',
     editRecord: true,

--- a/common/styles/scss/_viewer-app.scss
+++ b/common/styles/scss/_viewer-app.scss
@@ -259,11 +259,31 @@
                 position: relative;
             }
 
-            .annotation-spinner {
+            .annotation-loading-spinner {
                 #spinner {
                     top: 200px;
                     // width: 160px;
                     // height: 90px;
+                }
+            }
+
+            .annotation-spinner-overlay {
+                position: absolute;
+                top: 0;
+                left: 0;
+                height: 100%;
+                width: 100%;
+                background-color: $disabled-background-color;
+                opacity: 0.5;
+                z-index: 9; // higher than form
+            }
+
+            .annotation-spinner {
+                // make sure the text is visible in one line
+                #spinner {
+                    width: 160px;
+                    height: 105px;
+                    top: 50%;
                 }
             }
 
@@ -272,29 +292,9 @@
                 border-radius: 3px;
                 background: #f8f8f8;
 
-                .form-spinner-overlay {
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                    height: 100%;
-                    width: 100%;
-                    background-color: $disabled-background-color;
-                    opacity: 0.5;
-                    z-index: 6; // higher than the clear button
-                }
-
-                .form-spinner {
-                    // make sure the text is visible in one line
-                    #spinner {
-                        width: 160px;
-                        height: 105px;
-                        top: 50%;
-                    }
-                }
-
                 &.open{
                     opacity : 1;
-                    z-index: 10;
+                    z-index: 8;
                 }
 
                 .annotationRow{
@@ -659,7 +659,7 @@
                 overflow: hidden;
                 background: $white-color;
                 flex-shrink: 0;
-                min-height: 40px;
+                min-height: 30px;
                 cursor: pointer;
 
                 &:hover{
@@ -680,26 +680,27 @@
                 }
 
 
-                &.current .editBtn, &.current .editBtn i{
+                &.current .annot-item-btn, &.current .annot-item-btn i{
                     color: $white-color;
                 }
-                .editBtn.selected{
+                .annot-item-btn.selected{
                     background: #3669ac;
                     color: $white-color;
                     padding: 3px;
                 }
+                .annot-item-btn .delete-icon {
+                    padding-top: 4px;
+                }
 
-                &.current .editBtn.selected,
-                &.current .editBtn[data-type="highlightGroup"]{
+                &.current .annot-item-btn.selected,
+                &.current .annot-item-btn[data-type="highlightGroup"]{
                     color: #ffff80;
                 }
 
                 .itemContent{
-                    display: flex;
-                    flex-direction: column;
-                    flex: 1;
-                    justify-content: center;
-                    /* cursor: pointer; */
+                    margin: auto 0;
+                    width: 100%;
+                    padding: 5px 0;
                 }
 
 
@@ -748,59 +749,17 @@
                 textarea.edit:hover{
                     color: #c1c1c1;
                 }
-                .editRow{
-                    display: flex;
-                    flex-direction: row;
-                    align-items: center;
-                }
-
-                // TODO it's called editBtn but used for all the annotation buttons
-                .editBtn{
-                    text-decoration: none;
-                    padding: 3px;
-                    border-radius: 2px;
-                    margin: 2px;
-                    color: $primary-color;
-                    cursor: pointer;
-                    font-size: 12px;
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    border: none;
-                    background: none;
-
-                    // change chaise default color
-                    .glyphicon-refresh {
-                        color: $primary-color;
-                    }
-
-                    &:focus {
-                        outline: none;
-                    }
-
-                    &:last-child{
-                        margin-right: 8px;
-                    }
-
-                    &:hover{
-                        color: #0099cce0;
-                    }
-
-                    &.disabled,&:disabled{
-                        color: $disabled-color;
-                        cursor: not-allowed;
-                    }
-                }
 
                 .itemRow{
-                    display: flex;
-                    flex-direction: row;
+                    // display: flex;
+                    // flex-direction: row;
                     .annotation-color-container {
                         width: 10px;
                         height: 10px;
                         background-color: transparent;
                         margin-top: 8px;
                         margin-right: 2px;
+                        display: inline-block;
 
                         .annotation-color-item {
                             height: 100%;
@@ -809,8 +768,42 @@
                     }
 
                     .anatomy {
-                        flex : 1;
                         padding: 3px;
+                    }
+
+                    .annot-item-toolbar{
+                        float: right;
+
+                        .annot-item-btn{
+                            text-decoration: none;
+                            padding: 3px;
+                            border-radius: 2px;
+                            // margin: 2px;
+                            color: $primary-color;
+                            cursor: pointer;
+                            font-size: 12px;
+                            border: none;
+                            background: none;
+                            display: inline-block;
+
+                            // change chaise default color
+                            .glyphicon-refresh {
+                                color: $primary-color;
+                            }
+
+                            &:focus {
+                                outline: none;
+                            }
+
+                            &:hover{
+                                color: #0099cce0;
+                            }
+
+                            &.disabled,&:disabled{
+                                color: $disabled-color;
+                                cursor: not-allowed;
+                            }
+                        }
                     }
                 }
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -5,9 +5,9 @@
 
     .constant("chaiseConfigPropertyNames", [
         "ermrestLocation", "showAllAttributes", "headTitle", "customCSS", "navbarBrand", "navbarBrandText",
-        "navbarBrandImage", "logoutURL", "maxRecordsetRowHeight", "dataBrowser", "defaultAnnotationColor",
+        "navbarBrandImage", "logoutURL", "maxRecordsetRowHeight", "dataBrowser",
         "confirmDelete", "hideSearchTextFacet", "editRecord", "deleteRecord", "defaultCatalog", "defaultTables",
-        "signUpURL", "navbarBanner", "navbarMenu", "sidebarPosition", "attributesSidebarHeading", "userGroups",
+        "signUpURL", "navbarBanner", "navbarMenu", "sidebarPosition", "attributesSidebarHeading",
         "allowErrorDismissal", "footerMarkdown", "maxRelatedTablesOpen", "showFaceting", "hideTableOfContents",
         "resolverImplicitCatalog", "disableDefaultExport", "exportServicePath", "assetDownloadPolicyURL",
         "includeCanonicalTag", "systemColumnsDisplayCompact", "systemColumnsDisplayDetailed", "systemColumnsDisplayEntry",

--- a/docs/user-docs/chaise-config-deprecated.md
+++ b/docs/user-docs/chaise-config-deprecated.md
@@ -12,6 +12,9 @@ This document contains deprecated chaise-config parameters.
    * [sidebarPosition](#sidebarPosition)
    * [attributesSidebarHeading](#attributesSidebarHeading)
    * [hideSearchTextFacet](hidesearchtextfacet)
+* [Viewer Configuration:](#viewer-configuration)
+   * [defaultAnnotationColor](#defaultannotationcolor)
+   * [userGroups](#usergroups)
 
 
 ### Login Configuration:
@@ -44,7 +47,7 @@ This document contains deprecated chaise-config parameters.
      ```
      "attributesSidebarHeading": "Attributes"
      ```
-     
+
  #### hideSearchTextFacet
  Whether the search box for attributes names and values should be hidden
    - Type: Boolean
@@ -52,4 +55,28 @@ This document contains deprecated chaise-config parameters.
    - Sample syntax:
      ```
      hideSearchTextFacet: true
+     ```
+
+
+### Viewer Configuration:
+ #### defaultAnnotationColor
+ In `/chaise/viewer`, annotations' borders and colors will default to this value.
+   - Type: String - red|orange|gold|green|blue|purple
+   - Default behavior: red will be used
+   - Sample syntax:
+     ```
+     defaultAnnotationColor: purple
+     ```
+
+ #### userGroups
+ For Viewer app only. The Viewer app assigns an authenticated user one of three permission levels depending on the user's Globus memberships. The permission levels, from highest to lowest, are `curator`, `annotator`, then `user`. The default Globus group IDs that determine who's a `curator`, `annotator`, or `user` are set by [RBK](https://github.com/informatics-isi-edu/rbk-project). To override these default group IDs for each permission level, you may specify your own via this `userGroups` setting.
+   - Type: Object
+   - Default behavior: The default Globus group IDs are set by RBK
+   - Sample syntax:
+     ```
+     userGroups: {
+       curators: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67",
+       annotators: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67",
+       user: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67"
+     }
      ```

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -45,9 +45,6 @@ If a property appears in the same configuration twice, the property defined late
    * [hideTableOfContents](#hidetableofcontents)
    * [disableExternalLinkModal](#disableexternallinkmodal)
    * [hideGoToRID](#hidegotorid)
- * [Viewer Configuration:](#viewer-configuration)
-   * [defaultAnnotationColor](#defaultannotationcolor)
-   * [userGroups](#usergroups)
  * [Export Configuration:](#export-configuration)
    * [disableDefaultExport](#disabledefaultexport)
    * [exportSerivePath](#exportservicepath)
@@ -434,7 +431,7 @@ If a property appears in the same configuration twice, the property defined late
      ```
 
  #### showWriterEmptyRelatedOnLoad
- This property only applies to users with write permission to the main record being viewed. Set to `false` to hide all empty related tables on record page load ignoring the heuristics defined for writers. Set to `true` to show all empty related tables on record page load ignoring the heuristics. 
+ This property only applies to users with write permission to the main record being viewed. Set to `false` to hide all empty related tables on record page load ignoring the heuristics defined for writers. Set to `true` to show all empty related tables on record page load ignoring the heuristics.
    - Type: Boolean
    - Default behavior: the heuristics to show empty related tables based on the user being able to write to at least one of them will be used
    - Sample syntax:
@@ -476,29 +473,6 @@ If a property appears in the same configuration twice, the property defined late
    - Sample syntax:
      ```
      hideGoToRID: true
-     ```
-
-### Viewer Configuration:
- #### defaultAnnotationColor
- In `/chaise/viewer`, annotations' borders and colors will default to this value.
-   - Type: String - red|orange|gold|green|blue|purple
-   - Default behavior: red will be used
-   - Sample syntax:
-     ```
-     defaultAnnotationColor: purple
-     ```
-
- #### userGroups
- For Viewer app only. The Viewer app assigns an authenticated user one of three permission levels depending on the user's Globus memberships. The permission levels, from highest to lowest, are `curator`, `annotator`, then `user`. The default Globus group IDs that determine who's a `curator`, `annotator`, or `user` are set by [RBK](https://github.com/informatics-isi-edu/rbk-project). To override these default group IDs for each permission level, you may specify your own via this `userGroups` setting.
-   - Type: Object
-   - Default behavior: The default Globus group IDs are set by RBK
-   - Sample syntax:
-     ```
-     userGroups: {
-       curators: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67",
-       annotators: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67",
-       user: "https://auth.globus.org/962d5add-ff9a-11eb-8932-d71f8cc57c67"
-     }
      ```
 
 ### Export Configuration:

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -1153,8 +1153,10 @@
                 };
 
                 // read the currently saved data, so we can capture the tuple in correct context
-                // dontCorrectpage, getTRS
-                resultTuple.reference.contextualize.entryEdit.read(1, logObj, false, true, true).then(function (page) {
+                // arguments that are true:
+                //  - dontCorrect page
+                //  - getTCRS: since we're using this tuple for getting the update/delete permissions and also populating edit form
+                resultTuple.reference.contextualize.entryEdit.read(1, logObj, false, true, false, true).then(function (page) {
                     if (page.length != 1) {
                         console.log("the currently added row was not visible.");
                     }

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -589,7 +589,11 @@
         function closeAnnotationForm(confirm){
             var item = vm.editingAnatomy;
 
+            if (!item || !vm.annoForm) return;
+
             var close = function () {
+                if (!item || !vm.annoForm) return;
+
                 vm.annoForm.$setPristine();
                 vm.annoForm.$setUntouched();
 
@@ -928,10 +932,14 @@
          * show delete modal to let user confirm whether to delete it
          * @param {object} item : the anatomy's annotations object
          */
-        function removeAnnotationEntry(item){
+        function removeAnnotationEntry(item, event){
             var i = 0,
                 row = null,
                 isFound = false;
+
+            if (event) {
+                event.stopPropagation();
+            }
 
             // log intend
             AnnotationsService.logAnnotationClientAction(logService.logActions.DELETE_INTEND, item);

--- a/viewer/annotations/annotations.controller.js
+++ b/viewer/annotations/annotations.controller.js
@@ -306,6 +306,8 @@
                 if(row){
                     obj.isStoredInDB = true;
                     obj.tuple = row;
+                    obj.canUpdate = row.canUpdate;
+                    obj.canDelete = row.canDelete;
 
                     obj.logStackNode = logService.getStackNode(
                         logService.logStackTypes.ANNOTATION,
@@ -1104,6 +1106,8 @@
 
                     // update the tuple
                     savedItem.tuple = tuple;
+                    savedItem.canUpdate = tuple.canUpdate;
+                    savedItem.canDelete = tuple.canDelete;
                     savedItem.isStoredInDB = true;
                     savedItem.isNew = false;
 
@@ -1149,7 +1153,8 @@
                 };
 
                 // read the currently saved data, so we can capture the tuple in correct context
-                resultTuple.reference.contextualize.entryEdit.read(1, logObj).then(function (page) {
+                // dontCorrectpage, getTRS
+                resultTuple.reference.contextualize.entryEdit.read(1, logObj, false, true, true).then(function (page) {
                     if (page.length != 1) {
                         console.log("the currently added row was not visible.");
                     }
@@ -1229,4 +1234,4 @@
             vm.matchCount = matchCount;
         }
     }]);
-})();
+  })();

--- a/viewer/annotations/annotations.js
+++ b/viewer/annotations/annotations.js
@@ -20,6 +20,8 @@
      *  - id
      *  - url
      *  - tuple
+     *  - canUpdate
+     *  - canDelete
      */
     .value('annotationModels', [])
 
@@ -50,4 +52,4 @@
         submissionRows: [{}], // rows of data converted to raw data for submission
         foreignKeyData: [{}]
     });
-})();
+  })();

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -77,163 +77,166 @@
                                     <span class='currentScale'>6</span>
                                 </div>
                             </div>
-                            <div class='annotation-form-container' ng-form="anno.annoForm" ng-if="anno.showPanel" ng-class="{'open' : anno.editingAnatomy !== null}">
-                                <div class="form-spinner-overlay" ng-if="anno.submissionButtonDisabled">
+                            <div class="annotation-content" style='position: relative;height: 100%;'>
+                                <div class="annotation-spinner-overlay" ng-if="anno.submissionButtonDisabled">
                                 </div>
-                                <loading-spinner class="form-spinner" ng-if="anno.submissionButtonDisabled" message="Saving the changes..."></loading-spinner>
-                                <div class="annotationRow">
-                                    <div class="flex-column entity-key">
-                                        <div class="annotationRowValue" ng-show="!anno.editingAnatomy.isNew && !anno.editingAnatomy.isStoredInDB">
-                                            <div class="drawingHint alert-danger">This annotation is not stored in the database.</div>
-                                        </div>
-                                        <div class="annotationRowValue" ng-show="anno.editingAnatomy.isNew">
-                                            <div class="drawingHint">Drawing is required.</div>
-                                        </div>
-                                        <div class="annotationRowHeader">
-                                            <span class="text-danger ng-scope">*</span>
-                                            <span class="column-displayname">Annotated Region</span>
-                                        </div>
-                                        <div class="annotationRowValue">
-                                            <div class='annotationToolRow'>
-                                                <div class='annotationRowValue'>
-                                                    <div class="chaise-btn chaise-btn-primary draw-btn" ng-click="anno.drawAnnotation(anno.editingAnatomy, $event)" tooltip-placement="right" ng-attr-uib-tooltip="{{anno.editingAnatomy.isDrawing ? 'Turn off the drawing tool' : 'Turn on the drawing tool'}}">
-                                                        <span class="chaise-btn-icon">
-                                                            <span ng-if="!anno.editingAnatomy.isDrawing" class="fas fa-pencil-ruler"></span>
-                                                            <span ng-if="anno.editingAnatomy.isDrawing" class="glyphicon glyphicon-eye-open"></span>
-                                                        </span>
-                                                        <span ng-if="!anno.editingAnatomy.isDrawing">Switch to drawing mode</span>
-                                                        <span ng-if="anno.editingAnatomy.isDrawing">Display all annotations</span>
+                                <loading-spinner class="annotation-spinner" message="{{anno.submissionButtonDisabled ? 'Saving the changes...': ''}}" ng-if="loadingAnnotations || anno.submissionButtonDisabled"></loading-spinner>
+                                <div class='annotation-form-container' ng-form="anno.annoForm" ng-if="anno.showPanel" ng-class="{'open' : anno.editingAnatomy !== null}">
+                                    <div class="annotationRow">
+                                        <div class="flex-column entity-key">
+                                            <div class="annotationRowValue" ng-show="!anno.editingAnatomy.isNew && !anno.editingAnatomy.isStoredInDB">
+                                                <div class="drawingHint alert-danger">This annotation is not stored in the database.</div>
+                                            </div>
+                                            <div class="annotationRowValue" ng-show="anno.editingAnatomy.isNew">
+                                                <div class="drawingHint">Drawing is required.</div>
+                                            </div>
+                                            <div class="annotationRowHeader">
+                                                <span class="text-danger ng-scope">*</span>
+                                                <span class="column-displayname">Annotated Region</span>
+                                            </div>
+                                            <div class="annotationRowValue">
+                                                <div class='annotationToolRow'>
+                                                    <div class='annotationRowValue'>
+                                                        <div class="chaise-btn chaise-btn-primary draw-btn" ng-click="anno.drawAnnotation(anno.editingAnatomy, $event)" tooltip-placement="right" ng-attr-uib-tooltip="{{anno.editingAnatomy.isDrawing ? 'Turn off the drawing tool' : 'Turn on the drawing tool'}}">
+                                                            <span class="chaise-btn-icon">
+                                                                <span ng-if="!anno.editingAnatomy.isDrawing" class="fas fa-pencil-ruler"></span>
+                                                                <span ng-if="anno.editingAnatomy.isDrawing" class="glyphicon glyphicon-eye-open"></span>
+                                                            </span>
+                                                            <span ng-if="!anno.editingAnatomy.isDrawing">Switch to drawing mode</span>
+                                                            <span ng-if="anno.editingAnatomy.isDrawing">Display all annotations</span>
+                                                        </div>
+                                                        <div class="text-danger" ng-if="anno.displayDrawingRequiredError">
+                                                            <div>Please draw annotation on the image.</div>
+                                                        </div>
+                                                        <!-- <div class="switch-btn" ng-click="anno.drawAnnotation(anno.editingAnatomy, $event)" data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{anno.editingAnatomy.isDrawing ? 'Turn off the drawing tool' : 'Turn on the drawing tool'}}">
+                                                            <span class="switch-status on" ng-class="{'selected' : anno.editingAnatomy.isDrawing}">ON</span>
+                                                            <span class="switch-status off" ng-class="{'selected' : !anno.editingAnatomy.isDrawing}">OFF</span>
+                                                        </div> -->
                                                     </div>
-                                                    <div class="text-danger" ng-if="anno.displayDrawingRequiredError">
-                                                        <div>Please draw annotation on the image.</div>
-                                                    </div>
-                                                    <!-- <div class="switch-btn" ng-click="anno.drawAnnotation(anno.editingAnatomy, $event)" data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{anno.editingAnatomy.isDrawing ? 'Turn off the drawing tool' : 'Turn on the drawing tool'}}">
-                                                        <span class="switch-status on" ng-class="{'selected' : anno.editingAnatomy.isDrawing}">ON</span>
-                                                        <span class="switch-status off" ng-class="{'selected' : !anno.editingAnatomy.isDrawing}">OFF</span>
-                                                    </div> -->
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
-                                </div>
-                                <div class="annotationRow" ng-if="!anno.editingAnatomy.isNew" ng-repeat="(columnIndex, columnModel) in anno.annotationEditForm.columnModels">
-                                    <div class="flex-column entity-key">
-                                        <div class="annotationRowHeader">
-                                            <span ng-if="columnModel.isRequired" class="text-danger ng-scope">*</span>
-                                            <span class="column-displayname" ng-class="{'chaise-icon-for-tooltip': columnModel.column.comment}" ng-attr-uib-tooltip="{{::(columnModel.column.comment) ? columnModel.column.comment : undefined}}" tooltip-placement="right">
-                                                <span ng-if="::columnModel.column.displayname.isHTML" ng-bind-html="::columnModel.column.displayname.value"></span>
-                                                <span ng-if="::!columnModel.column.displayname.isHTML" ng-bind="::columnModel.column.displayname.value"></span>
-                                            </span>
-                                        </div>
-                                        <div class="annotationRowValue">
-                                            <input-switch column="columnModel.column" column-model="columnModel" parent-reference="anno.annotationEditForm.reference" parent-tuples="anno.editingAnatomy.tuple"
-                                                          parent-model="anno.annotationEditForm" model="anno.annotationEditForm.rows[0][columnModel.column.name]"
-                                                          column-index="columnIndex" mode="edit" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
-                                                          on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired"></input-switch>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="annotationRow" ng-if="anno.editingAnatomy.isNew" ng-repeat="(columnIndex, columnModel) in anno.annotationCreateForm.columnModels">
-                                    <div class="flex-column entity-key">
-                                        <div class="annotationRowHeader">
-                                            <span ng-if="columnModel.isRequired" class="text-danger ng-scope">*</span>
-                                            <span class="column-displayname" ng-class="{'chaise-icon-for-tooltip': columnModel.column.comment}" ng-attr-uib-tooltip="{{::(columnModel.column.comment) ? columnModel.column.comment : undefined}}" tooltip-placement="right">
-                                                <span ng-if="::columnModel.column.displayname.isHTML" ng-bind-html="::columnModel.column.displayname.value"></span>
-                                                <span ng-if="::!columnModel.column.displayname.isHTML" ng-bind="::columnModel.column.displayname.value"></span>
-                                            </span>
-                                        </div>
-                                        <div class="annotationRowValue">
-                                            <input-switch column="columnModel.column" column-model="columnModel" parent-reference="anno.annotationCreateForm.reference"
-                                                          parent-model="anno.annotationCreateForm" model="anno.annotationCreateForm.rows[0][columnModel.column.name]"
-                                                          column-index="columnIndex" mode="create" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
-                                                          on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
-                                                          is-required="columnModel.isRequired"></input-switch>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="annotationRow">
-                                    <div class='flex-row row-reverse' style="justify-content: space-between;">
-                                        <div class='annotationRowValue' data-toggle='tooltip' tooltip-placement="bottom">
-                                            <!-- ng-disabled="anno.annoForm.$invalid" -->
-                                            <button class="btn chaise-btn chaise-btn-primary" type="submit" ng-click="anno.saveAnnotationRecord(anno.editingAnatomy)" >
-                                                <span class="chaise-btn-icon glyphicon glyphicon-saved"></span>
-                                                <span>Save</span>
-                                            </button>
-                                        </div>
-                                        <div class='annotationRowValue' ng-disabled="!anno.editingAnatomy.canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
-                                            <button class="btn chaise-btn chaise-btn-danger" ng-click="anno.removeAnnotationEntry(anno.editingAnatomy)">
-                                                <span class="chaise-btn-icon far fa-trash-alt"></span>
-                                                <span>Delete</span>
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class='annotation-list' ng-show="anno.editingAnatomy == null">
-                                <!-- message="Loading annotations..." -->
-                                <loading-spinner class="annotation-spinner" ng-if="loadingAnnotations"></loading-spinner>
-                                <span class='row filter' data-type='overlayVisibility'>
-                                    <span class='name'> Display : </span>
-                                    <span ng-click="anno.changeAllAnnotationsVisibility();" ng-class="anno.isDisplayAll ?'displayAllBtn selected' : 'displayAllBtn'" data-type='all'>
-                                        <i ng-class="anno.isDisplayAll ? 'glyphicon glyphicon-check' : 'glyphicon glyphicon-unchecked'"></i> All
-                                    </span>
-                                    <span ng-click="anno.changeAllAnnotationsVisibility();" ng-class="!anno.isDisplayAll ?'displayAllBtn selected' : 'displayAllBtn'" data-type='none'>
-                                        <i ng-class="anno.isDisplayAll ? 'glyphicon glyphicon-unchecked' : 'glyphicon glyphicon-check'"></i> None
-                                    </span>
-                                </span>
-                                <div class='flex-row'>
-                                    <div class="chaise-search-box chaise-input-group">
-                                        <div class="chaise-input-control has-feedback">
-                                            <input type='text' class='search-input' placeholder='Search in the list' ng-model="anno.searchKeyword" ng-change="anno.search()" />
-                                            <div class="clear-search" ng-show="anno.searchKeyword != ''"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
-                                                <span class="glyphicon glyphicon-remove coltooltiptext facet-search-clear search-remove" ng-click="anno.clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
-                                            </div>
-                                        </div>
-                                        <div class='chaise-input-group-append'>
-                                            <button id="search-submit" class="chaise-search-btn chaise-btn chaise-btn-primary" ng-click="anno.search()" role="button" tooltip-placement="bottom" uib-tooltip="Search any keyword to filter anatomy">
-                                                &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
-                                            </button>
-                                        </div>
-                                    </div>
-                                    <button ng-show="canCreateAnnotation" class='btn chaise-btn chaise-btn-primary newAnnoBtn' ng-click="anno.addNewTerm()" tooltip-placement="bottom" uib-tooltip="Create new annotation">New</button>
-                                </div>
-                                <span class='resultCount'>
-                                    <span>Displaying {{ anno.matchCount }} <span ng-if="!loadingAnnotations"> of {{ anno.totalCount }} </span>{{anno.searchKeyword ? "matching annotations": "annotations"}}</span>
-                                </span>
-                                <div class='groups'>
-                                    <div ng-if="!loadingAnnotations && anno.matchCount === 0" class="no-annotation-message">
-                                        No annotation found
-                                    </div>
-                                    <div id="{{item.svgID + item.groupID}}" class="annotationItem" ng-click="anno.highlightGroup(item, $event)" ng-repeat="item in anno.annotationModels track by $index" ng-show="item.isShow && item.svgID && item.groupID" ng-class="{'visible-annotation': item.isShow, 'current': item.isSelected}">
-                                        <div class='itemContent'>
-                                            <div class='itemRow'>
-                                                <span class="annotation-color-container">
-                                                    <span class="annotation-color-item" ng-repeat="annotColor in item.stroke" ng-style="{'background-color': annotColor, 'width': (100/item.stroke.length) + '%'}"></span>
-                                                </span>
-                                                <span class='anatomy'>
-                                                    {{ item.name }}
-                                                    <a ng-if="item.id"  href="{{item.url}}" target="_blank" tooltip-placement="auto" uib-tooltip="Click to view details and associated data">
-                                                        ({{item.id}})
-                                                    </a>
-                                                </span>
-                                                <span class='editRow'>
-                                                    <button class='editBtn' ng-click="anno.toggleDisplay(item, $event)" data-type='toggleDisplay' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{ item.isDisplay ? 'Hide annotation' : 'Show annotation'}}">
-                                                        <i ng-class="item.isDisplay ? 'glyphicon glyphicon-eye-open' : 'glyphicon glyphicon-eye-close'"></i>
-                                                    </button>
-                                                    <button ng-show="item.canUpdate" class="editBtn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
-                                                        <i class="glyphicon glyphicon-pencil"></i>
-                                                    </button>
-                                                    <button ng-if="item.tuple" class="editBtn" tooltip-placement="bottom" uib-tooltip="Share Annotation" ng-click="anno.shareAnnotation(item, $index, $event)" ng-disabled="anno.waitingForSharePopup">
-                                                        <i class="chaise-btn-icon glyphicon" ng-class="{'glyphicon-refresh glyphicon-refresh-animate': item.waitingForSharePopup, 'glyphicon-share': !item.waitingForSharePopup}"></i>
-                                                    </button>
+                                    <div class="annotationRow" ng-if="!anno.editingAnatomy.isNew" ng-repeat="(columnIndex, columnModel) in anno.annotationEditForm.columnModels">
+                                        <div class="flex-column entity-key">
+                                            <div class="annotationRowHeader">
+                                                <span ng-if="columnModel.isRequired" class="text-danger ng-scope">*</span>
+                                                <span class="column-displayname" ng-class="{'chaise-icon-for-tooltip': columnModel.column.comment}" ng-attr-uib-tooltip="{{::(columnModel.column.comment) ? columnModel.column.comment : undefined}}" tooltip-placement="right">
+                                                    <span ng-if="::columnModel.column.displayname.isHTML" ng-bind-html="::columnModel.column.displayname.value"></span>
+                                                    <span ng-if="::!columnModel.column.displayname.isHTML" ng-bind="::columnModel.column.displayname.value"></span>
                                                 </span>
                                             </div>
+                                            <div class="annotationRowValue">
+                                                <input-switch column="columnModel.column" column-model="columnModel" parent-reference="anno.annotationEditForm.reference" parent-tuples="anno.editingAnatomy.tuple"
+                                                            parent-model="anno.annotationEditForm" model="anno.annotationEditForm.rows[0][columnModel.column.name]"
+                                                            column-index="columnIndex" mode="edit" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
+                                                            on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
+                                                            is-required="columnModel.isRequired"></input-switch>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="annotationRow" ng-if="anno.editingAnatomy.isNew" ng-repeat="(columnIndex, columnModel) in anno.annotationCreateForm.columnModels">
+                                        <div class="flex-column entity-key">
+                                            <div class="annotationRowHeader">
+                                                <span ng-if="columnModel.isRequired" class="text-danger ng-scope">*</span>
+                                                <span class="column-displayname" ng-class="{'chaise-icon-for-tooltip': columnModel.column.comment}" ng-attr-uib-tooltip="{{::(columnModel.column.comment) ? columnModel.column.comment : undefined}}" tooltip-placement="right">
+                                                    <span ng-if="::columnModel.column.displayname.isHTML" ng-bind-html="::columnModel.column.displayname.value"></span>
+                                                    <span ng-if="::!columnModel.column.displayname.isHTML" ng-bind="::columnModel.column.displayname.value"></span>
+                                                </span>
+                                            </div>
+                                            <div class="annotationRowValue">
+                                                <input-switch column="columnModel.column" column-model="columnModel" parent-reference="anno.annotationCreateForm.reference"
+                                                            parent-model="anno.annotationCreateForm" model="anno.annotationCreateForm.rows[0][columnModel.column.name]"
+                                                            column-index="columnIndex" mode="create" form-container="anno.annoForm" input-container="anno.annoForm.row[0][columnModel.column.name]"
+                                                            on-search-popup-value-change="anno.onSearchPopupValueChange" search-popup-get-disabled-tuples="anno.getAnnotatedTermDisabledTuples"
+                                                            is-required="columnModel.isRequired"></input-switch>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="annotationRow">
+                                        <div class='flex-row row-reverse' style="justify-content: space-between;">
+                                            <div class='annotationRowValue' data-toggle='tooltip' tooltip-placement="bottom">
+                                                <!-- ng-disabled="anno.annoForm.$invalid" -->
+                                                <button class="btn chaise-btn chaise-btn-primary" type="submit" ng-click="anno.saveAnnotationRecord(anno.editingAnatomy)" >
+                                                    <span class="chaise-btn-icon glyphicon glyphicon-saved"></span>
+                                                    <span>Save</span>
+                                                </button>
+                                            </div>
+                                            <div class='annotationRowValue' ng-disabled="!anno.editingAnatomy.canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
+                                                <button class="btn chaise-btn chaise-btn-danger" ng-click="anno.removeAnnotationEntry(anno.editingAnatomy)">
+                                                    <span class="chaise-btn-icon far fa-trash-alt"></span>
+                                                    <span>Delete</span>
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class='annotation-list' ng-show="anno.editingAnatomy == null">
+                                    <span class='row filter' data-type='overlayVisibility'>
+                                        <span class='name'> Display : </span>
+                                        <span ng-click="anno.changeAllAnnotationsVisibility();" ng-class="anno.isDisplayAll ?'displayAllBtn selected' : 'displayAllBtn'" data-type='all'>
+                                            <i ng-class="anno.isDisplayAll ? 'glyphicon glyphicon-check' : 'glyphicon glyphicon-unchecked'"></i> All
                                         </span>
+                                        <span ng-click="anno.changeAllAnnotationsVisibility();" ng-class="!anno.isDisplayAll ?'displayAllBtn selected' : 'displayAllBtn'" data-type='none'>
+                                            <i ng-class="anno.isDisplayAll ? 'glyphicon glyphicon-unchecked' : 'glyphicon glyphicon-check'"></i> None
+                                        </span>
+                                    </span>
+                                    <div class='flex-row'>
+                                        <div class="chaise-search-box chaise-input-group">
+                                            <div class="chaise-input-control has-feedback">
+                                                <input type='text' class='search-input' placeholder='Search in the list' ng-model="anno.searchKeyword" ng-change="anno.search()" />
+                                                <div class="clear-search" ng-show="anno.searchKeyword != ''"><!-- form-control:focus changes the z-index of the form control from 2 to 3. form-control-feedback has z-index of 2. Overriding that z index to 5 so it isn't hidden when focused-->
+                                                    <span class="glyphicon glyphicon-remove coltooltiptext facet-search-clear search-remove" ng-click="anno.clearSearch()" tooltip-placement="bottom" uib-tooltip="Clear field"></span>
+                                                </div>
+                                            </div>
+                                            <div class='chaise-input-group-append'>
+                                                <button id="search-submit" class="chaise-search-btn chaise-btn chaise-btn-primary" ng-click="anno.search()" role="button" tooltip-placement="bottom" uib-tooltip="Search any keyword to filter anatomy">
+                                                    &nbsp;<span class="glyphicon glyphicon-search"></span>&nbsp;<!-- Added 2 non-breaking spaces to prevent btn's margins from collapsing and to center the icon-->
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <button ng-show="canCreateAnnotation" class='btn chaise-btn chaise-btn-primary newAnnoBtn' ng-click="anno.addNewTerm()" tooltip-placement="bottom" uib-tooltip="Create new annotation">New</button>
                                     </div>
+                                    <span class='resultCount'>
+                                        <span>Displaying {{ anno.matchCount }} <span ng-if="!loadingAnnotations"> of {{ anno.totalCount }} </span>{{anno.searchKeyword ? "matching annotations": "annotations"}}</span>
+                                    </span>
+                                    <div class='groups'>
+                                        <div ng-if="!loadingAnnotations && anno.matchCount === 0" class="no-annotation-message">
+                                            No annotation found
+                                        </div>
+                                        <div id="{{item.svgID + item.groupID}}" class="annotationItem" ng-click="anno.highlightGroup(item, $event)" ng-repeat="item in anno.annotationModels track by $index" ng-show="item.isShow && item.svgID && item.groupID" ng-class="{'visible-annotation': item.isShow, 'current': item.isSelected}">
+                                            <div class='itemContent'>
+                                                <div class='itemRow'>
+                                                    <span class='annot-item-toolbar'>
+                                                        <button class='annot-item-btn' ng-click="anno.toggleDisplay(item, $event)" data-type='toggleDisplay' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{ item.isDisplay ? 'Hide annotation' : 'Show annotation'}}">
+                                                            <i ng-class="item.isDisplay ? 'glyphicon glyphicon-eye-open' : 'glyphicon glyphicon-eye-close'"></i>
+                                                        </button>
+                                                        <button ng-show="item.canUpdate" class="annot-item-btn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
+                                                            <i class="glyphicon glyphicon-pencil"></i>
+                                                        </button>
+                                                        <button ng-show="item.isStoredInDB && item.canDelete" class="annot-item-btn" ng-click="anno.removeAnnotationEntry(item, $event)"  data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Delete Annotation">
+                                                            <i class="delete-icon chaise-btn-icon far fa-trash-alt"></i>
+                                                        </button>
+                                                        <button ng-if="item.tuple" class="annot-item-btn" tooltip-placement="bottom" uib-tooltip="Share Annotation" ng-click="anno.shareAnnotation(item, $index, $event)" ng-disabled="anno.waitingForSharePopup">
+                                                            <i class="chaise-btn-icon glyphicon" ng-class="{'glyphicon-refresh glyphicon-refresh-animate': item.waitingForSharePopup, 'glyphicon-share': !item.waitingForSharePopup}"></i>
+                                                        </button>
+                                                    </span>
+                                                    <span class="annotation-color-container">
+                                                        <span class="annotation-color-item" ng-repeat="annotColor in item.stroke" ng-style="{'background-color': annotColor, 'width': (100/item.stroke.length) + '%'}"></span>
+                                                    </span>
+                                                    <span class='anatomy'>
+                                                        {{ item.name }}
+                                                        <a ng-if="item.id"  href="{{item.url}}" target="_blank" tooltip-placement="auto" uib-tooltip="Click to view details and associated data">
+                                                            ({{item.id}})
+                                                        </a>
+                                                    </span>
+                                                </div>
+                                            </span>
+                                        </div>
 
+                                        </div>
+                                    </div>
                                 </div>
-                            </div>
                             </div>
                         </div>
                     </div>

--- a/viewer/index.html.in
+++ b/viewer/index.html.in
@@ -161,7 +161,7 @@
                                                 <span>Save</span>
                                             </button>
                                         </div>
-                                        <div class='annotationRowValue' ng-disabled="!canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
+                                        <div class='annotationRowValue' ng-disabled="!anno.editingAnatomy.canDelete" ng-show="!anno.editingAnatomy.isNew && anno.editingAnatomy.isStoredInDB" data-toggle='tooltip' tooltip-placement="bottom">
                                             <button class="btn chaise-btn chaise-btn-danger" ng-click="anno.removeAnnotationEntry(anno.editingAnatomy)">
                                                 <span class="chaise-btn-icon far fa-trash-alt"></span>
                                                 <span>Delete</span>
@@ -196,7 +196,7 @@
                                             </button>
                                         </div>
                                     </div>
-                                    <button ng-show="canCreate" class='btn chaise-btn chaise-btn-primary newAnnoBtn' ng-click="anno.addNewTerm()" tooltip-placement="bottom" uib-tooltip="Create new annotation">New</button>
+                                    <button ng-show="canCreateAnnotation" class='btn chaise-btn chaise-btn-primary newAnnoBtn' ng-click="anno.addNewTerm()" tooltip-placement="bottom" uib-tooltip="Create new annotation">New</button>
                                 </div>
                                 <span class='resultCount'>
                                     <span>Displaying {{ anno.matchCount }} <span ng-if="!loadingAnnotations"> of {{ anno.totalCount }} </span>{{anno.searchKeyword ? "matching annotations": "annotations"}}</span>
@@ -221,7 +221,7 @@
                                                     <button class='editBtn' ng-click="anno.toggleDisplay(item, $event)" data-type='toggleDisplay' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="{{ item.isDisplay ? 'Hide annotation' : 'Show annotation'}}">
                                                         <i ng-class="item.isDisplay ? 'glyphicon glyphicon-eye-open' : 'glyphicon glyphicon-eye-close'"></i>
                                                     </button>
-                                                    <button ng-show="canUpdate" class="editBtn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
+                                                    <button ng-show="item.canUpdate" class="editBtn" ng-click="anno.editAnatomyAnnotations(item, $index, $event)" data-type='editingAnatomy' data-toggle='tooltip' tooltip-placement="bottom" uib-tooltip="Edit Annotation">
                                                         <i class="glyphicon glyphicon-pencil"></i>
                                                     </button>
                                                     <button ng-if="item.tuple" class="editBtn" tooltip-placement="bottom" uib-tooltip="Share Annotation" ng-click="anno.shareAnnotation(item, $index, $event)" ng-disabled="anno.waitingForSharePopup">

--- a/viewer/viewer.app.js
+++ b/viewer/viewer.app.js
@@ -307,7 +307,7 @@
                 // disable the annotaiton sidebar:
                 //  - if there are no annotation and we cannot create
                 //  - the image type doesn't support annotation.
-                // if ($rootScope.annotationTuples.length == 0 && !$rootScope.canCreate && !hasAnnotationQueryParam) {
+                // if ($rootScope.annotationTuples.length == 0 && !$rootScope.canCreateAnnotation && !hasAnnotationQueryParam) {
                 //     $rootScope.disableAnnotationSidebar = true;
                 // }
 
@@ -362,4 +362,4 @@
         // This is to allow the dropdown button to open at the top/bottom depending on the space available
         UiUtils.setBootstrapDropdownButtonBehavior();
     }]);
-})();
+  })();

--- a/viewer/viewer.controller.js
+++ b/viewer/viewer.controller.js
@@ -18,9 +18,6 @@
         vm.showChannelList = false;
         vm.toggleChannelList = toggleChannelList;
 
-        vm.annotationsAreHidden = false;
-        vm.toggleAnnotations = toggleAnnotations;
-
         // the top-left-panel that needs to be resizable with toc
         vm.resizePartners = document.querySelector(".top-left-panel");
 
@@ -182,11 +179,6 @@
                 action: logService.getActionString(logService.logActions.VIEWER_ZOOM_RESET, null, ""),
                 stack: logService.getStackObject()
             }, $rootScope.reference.defaultLogInfo);
-        }
-
-        function toggleAnnotations() {
-            var messageType = vm.annotationsAreHidden ? 'showAllAnnotations' : 'hideAllAnnotations';
-            vm.annotationsAreHidden = !vm.annotationsAreHidden;
         }
 
         function openAnnotations() {

--- a/viewer/viewer.utils.js
+++ b/viewer/viewer.utils.js
@@ -567,8 +567,7 @@
                 imageAnnotationURL += "=" + encode(context.defaultZIndex);
             }
 
-            // dontCorrectpage, getTRS
-            ERMrest.resolve(imageAnnotationURL, ConfigUtils.getContextHeaderParams(), false, true, true).then(function (ref) {
+            ERMrest.resolve(imageAnnotationURL, ConfigUtils.getContextHeaderParams()).then(function (ref) {
 
                 if (!ref) {
                     // TODO should be changed to say annotation
@@ -643,7 +642,8 @@
                 }
 
                 // using edit, because the tuples are used in edit context (for populating edit form)
-                // since we want to check the ACL for allowing edit/delete of annotations we have to has for TCRS
+                // we need dynamic acls for: update/delete of each row, update of columns in edit mode
+                // that's why we're asking for tcrs
                 return _readPageByPage(ref, viewerConstant.DEFAULT_PAGE_SIZE, logObj, false, true, cb);
             }).then(function (res) {
                 defer.resolve(res);

--- a/viewer/viewer.utils.js
+++ b/viewer/viewer.utils.js
@@ -567,13 +567,12 @@
                 imageAnnotationURL += "=" + encode(context.defaultZIndex);
             }
 
-            ERMrest.resolve(imageAnnotationURL, ConfigUtils.getContextHeaderParams()).then(function (ref) {
+            // dontCorrectpage, getTRS
+            ERMrest.resolve(imageAnnotationURL, ConfigUtils.getContextHeaderParams(), false, true, true).then(function (ref) {
 
                 if (!ref) {
                     // TODO should be changed to say annotation
-                    $rootScope.canCreate = false;
-                    $rootScope.canUpdate = false;
-                    $rootScope.canDelete = false;
+                    $rootScope.canCreateAnnotation = false;
                     return false;
                 }
 
@@ -584,9 +583,7 @@
                 // attach to the $rootScope so it can be used in annotations.controller
                 $rootScope.annotationEditReference = ref;
 
-                $rootScope.canCreate = ref.canCreate || false;
-                $rootScope.canUpdate = ref.canUpdate || false;
-                $rootScope.canDelete = ref.canDelete || false;
+                $rootScope.canCreateAnnotation = ref.canCreate;
 
                 // TODO create and edit should be refactored to reuse the same code
                 // create the edit and create forms
@@ -596,7 +593,7 @@
                     annotConfig.z_index_column_name,
                     annotConfig.channels_column_name
                 ];
-                if ($rootScope.canCreate) {
+                if (ref.canCreate) {
                     annotationCreateForm.reference = ref.contextualize.entryCreate;
                     annotationCreateForm.columnModels = [];
                     annotationCreateForm.reference.columns.forEach(function (column) {
@@ -607,7 +604,7 @@
                     });
                 }
 
-                if ($rootScope.canUpdate) {
+                if (ref.canUpdate) {
                     annotationEditForm.reference = ref;
                     annotationEditForm.columnModels = [];
                     annotationEditForm.reference.columns.forEach(function (column) {
@@ -654,7 +651,6 @@
                 // just log the error and resolve with empty array
                 console.error("error while getting annotations: ", err);
                 $rootScope.annotationTuples = [];
-                $rootScope.canCreate = false;
                 defer.resolve(false);
             });
 
@@ -1228,4 +1224,4 @@
 
     }]);
 
-})();
+  })();


### PR DESCRIPTION
When I added support for dynamic ACLs in chaise apps, I didn't properly do so for the annotation list. This PR will ensure that we're properly showing "edit" and "delete" buttons in the annotation list based on dynamic ACLs.

While testing this I encountered a case where user can "delete" an annotation but cannot "edit" is. The current UI doesn't properly support that since the "delete" button is only available in the "edit form".

issue: #2162