### PR TITLE
Compact select association

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,6 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          git checkout compact-select-association
           sudo make install
       - name: Install chaise
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout compact-select-association
           sudo make install
       - name: Install chaise
         run: |

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1541,7 +1541,6 @@
                         params.reference = scope.reference;
                         params.selectMode = "multi-select";
                         params.faceting = false;
-                        params.facetPanelOpen = false;
 
                         // callback on each selected change (incldues the url limitation logic)
                         params.onSelectedRowsChanged = modalDataChanged(scope, false);

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -1541,6 +1541,9 @@
                         params.reference = scope.reference;
                         params.selectMode = "multi-select";
                         params.faceting = false;
+                        // NOTE: when supporting faceting in show_more popup
+                        //   contextualize params.reference to compact/select/show_more and check reference.display.facetPanelOpen before setting false
+                        params.facetPanelOpen = false;
 
                         // callback on each selected change (incldues the url limitation logic)
                         params.onSelectedRowsChanged = modalDataChanged(scope, false);

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -581,6 +581,7 @@
                     params.selectedRows = [];
                     params.selectMode = modalBox.singleSelectMode;
                     params.showFaceting = true;
+                    params.facetPanelOpen = params.reference.display.facetPanelOpen !== null ? params.reference.display.facetPanelOpen : false;
 
                     if (vm.searchPopupGetDisabledTuples) {
                         params.getDisabledTuples = vm.searchPopupGetDisabledTuples()(vm.columnModel);

--- a/common/inputs.js
+++ b/common/inputs.js
@@ -577,11 +577,10 @@
                     });
 
                     // add not null filters for key information
-                    params.reference = vm.column.filteredRef(submissionRow, rowForeignKeyData).addFacets(andFilters).contextualize.compactSelect;
+                    params.reference = vm.column.filteredRef(submissionRow, rowForeignKeyData).addFacets(andFilters).contextualize.compactSelectForeignKey;
                     params.selectedRows = [];
                     params.selectMode = modalBox.singleSelectMode;
                     params.showFaceting = true;
-                    params.facetPanelOpen = false;
 
                     if (vm.searchPopupGetDisabledTuples) {
                         params.getDisabledTuples = vm.searchPopupGetDisabledTuples()(vm.columnModel);

--- a/common/modal.js
+++ b/common/modal.js
@@ -388,7 +388,7 @@
                 editable:           (typeof params.editable === "boolean") ? params.editable : true,
                 selectMode:         params.selectMode,
                 showFaceting:       showFaceting,
-                facetPanelOpen:     params.facetPanelOpen,
+                facetPanelOpen:     showFaceting && params.facetPanelOpen,
                 showNull:           params.showNull === true,
                 hideNotNullChoice:  params.hideNotNullChoice,
                 hideNullChoice:     params.hideNullChoice,

--- a/common/modal.js
+++ b/common/modal.js
@@ -388,7 +388,7 @@
                 editable:           (typeof params.editable === "boolean") ? params.editable : true,
                 selectMode:         params.selectMode,
                 showFaceting:       showFaceting,
-                facetPanelOpen:     showFaceting && params.facetPanelOpen,
+                facetPanelOpen:     showFaceting && params.reference.display.facetPanelOpen, // set by ermrestJS based on defined chaise-config
                 showNull:           params.showNull === true,
                 hideNotNullChoice:  params.hideNotNullChoice,
                 hideNullChoice:     params.hideNullChoice,

--- a/common/modal.js
+++ b/common/modal.js
@@ -388,7 +388,7 @@
                 editable:           (typeof params.editable === "boolean") ? params.editable : true,
                 selectMode:         params.selectMode,
                 showFaceting:       showFaceting,
-                facetPanelOpen:     showFaceting && params.reference.display.facetPanelOpen, // set by ermrestJS based on defined chaise-config
+                facetPanelOpen:     showFaceting && params.facetPanelOpen,
                 showNull:           params.showNull === true,
                 hideNotNullChoice:  params.hideNotNullChoice,
                 hideNullChoice:     params.hideNullChoice,

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -347,6 +347,7 @@
             params.selectMode = isModalUpdate ? modalBox.multiSelectMode : modalBox.singleSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
+            params.facetPanelOpen =  params.reference.display.facetPanelOpen !== null ? params.reference.display.facetPanelOpen : false;
 
             // TODO (could be optimized) this is already done in recordutil getTableModel (we just don't have access to the tableModel here)
             var stackElement = logService.getStackNode(

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -343,11 +343,13 @@
                 });
             });
 
-            params.reference = domainRef.unfilteredReference.addFacets(andFilters).contextualize.compactSelect;
+            params.reference = domainRef.unfilteredReference.addFacets(andFilters).contextualize.compactSelectAssociation;
             params.selectMode = isModalUpdate ? modalBox.multiSelectMode : modalBox.singleSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = false;
+
+            var cc = ConfigUtils.getConfigJSON();
+            params.facetPanelOpen = cc.facetPanelDisplay.open.indexOf("compact/select/association") > -1;
 
             // TODO (could be optimized) this is already done in recordutil getTableModel (we just don't have access to the tableModel here)
             var stackElement = logService.getStackNode(

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -343,11 +343,10 @@
                 });
             });
 
-            params.reference = domainRef.unfilteredReference.addFacets(andFilters).contextualize.compactSelectAssociation;
+            params.reference = domainRef.unfilteredReference.addFacets(andFilters).contextualize.compactSelectAssociationLink;
             params.selectMode = isModalUpdate ? modalBox.multiSelectMode : modalBox.singleSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = params.reference.display.facetPanelOpen;
 
             // TODO (could be optimized) this is already done in recordutil getTableModel (we just don't have access to the tableModel here)
             var stackElement = logService.getStackNode(
@@ -582,7 +581,7 @@
          * @param  {Object} logObj the object will be passed to read as contextHeaderParams
          */
         function _getForeignKeyData (model, rowIndex, colNames, fkRef, logObj) {
-            fkRef.contextualize.compactSelect.read(1, logObj).then(function (page) {
+            fkRef.contextualize.compactSelectForeignKey.read(1, logObj).then(function (page) {
                 colNames.forEach(function (colName) {
                     // default value is validated
                     if (page.tuples.length > 0) {

--- a/common/recordCreate.js
+++ b/common/recordCreate.js
@@ -347,9 +347,7 @@
             params.selectMode = isModalUpdate ? modalBox.multiSelectMode : modalBox.singleSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-
-            var cc = ConfigUtils.getConfigJSON();
-            params.facetPanelOpen = cc.facetPanelDisplay.open.indexOf("compact/select/association") > -1;
+            params.facetPanelOpen = params.reference.display.facetPanelOpen;
 
             // TODO (could be optimized) this is already done in recordutil getTableModel (we just don't have access to the tableModel here)
             var stackElement = logService.getStackNode(

--- a/common/table.js
+++ b/common/table.js
@@ -1721,7 +1721,7 @@
 
                     ERMrest.resolve(scope.vm.savedQueryReference.uri + "/" + facetTxt + ERMrest.encodeFacet(facetBlob) + "@sort(last_execution_time::desc::)", ConfigUtils.getContextHeaderParams()).then(function (savedQueryReference) {
                         // we don't want to allow faceting in the popup
-                        savedQueryReference = savedQueryReference.contextualize.compactSelect.hideFacets();
+                        savedQueryReference = savedQueryReference.contextualize.compactSelectSavedQueries.hideFacets();
 
                         var params = {};
 
@@ -1732,8 +1732,6 @@
                         params.reference = savedQueryReference;
                         params.selectedRows = [];
                         params.showFaceting = false;
-                        // faceting not allowed, make sure panel is collapsed too just in case
-                        params.facetPanelOpen = false;
                         params.allowDelete = true;
 
                         // TODO: fix logging stuff

--- a/common/table.js
+++ b/common/table.js
@@ -1733,6 +1733,9 @@
                         params.selectedRows = [];
                         params.showFaceting = false;
                         params.allowDelete = true;
+                        // NOTE: when supporting faceting in saved_queries popup
+                        //   contextualize params.reference to compact/select/saved_queries and check reference.display.facetPanelOpen before setting false
+                        params.facetPanelOpen = false;
 
                         // TODO: fix logging stuff
                         var stackElement = logService.getStackNode(

--- a/common/utils.js
+++ b/common/utils.js
@@ -41,10 +41,7 @@
           "showWriterEmptyRelatedOnLoad": null,
           "savedQueryConfig": null,
           "loggedInMenu": {},
-          "facetPanelDisplay": {
-              "open": ["compact"],
-              "closed": ["compact/select"]
-          },
+          "facetPanelDisplay": {},
           "shareCiteAcls": {
               "show": ["*"],
               "enable": ["*"]

--- a/common/utils.js
+++ b/common/utils.js
@@ -1537,7 +1537,8 @@
             var chaiseConfig = ConfigUtils.getConfigJSON();
             ERMrest.setClientConfig({
                 internalHosts: chaiseConfig.internalHosts,
-                disableExternalLinkModal: chaiseConfig.disableExternalLinkModal
+                disableExternalLinkModal: chaiseConfig.disableExternalLinkModal,
+                facetPanelDisplay: chaiseConfig.facetPanelDisplay
             });
         }
 

--- a/common/utils.js
+++ b/common/utils.js
@@ -12,7 +12,7 @@
         "resolverImplicitCatalog", "disableDefaultExport", "exportServicePath", "assetDownloadPolicyURL",
         "includeCanonicalTag", "systemColumnsDisplayCompact", "systemColumnsDisplayDetailed", "systemColumnsDisplayEntry",
         "logClientActions", "disableExternalLinkModal", "internalHosts", "hideGoToRID", "showWriterEmptyRelatedOnLoad",
-        "showSavedQueryUI", "savedQueryConfig", "termsAndConditionsConfig", "loggedInMenu", "configRules"
+        "showSavedQueryUI", "savedQueryConfig", "termsAndConditionsConfig", "loggedInMenu", "facetPanelDisplay", "configRules"
     ])
 
     .constant("defaultChaiseConfig", {
@@ -41,6 +41,9 @@
           "showWriterEmptyRelatedOnLoad": null,
           "savedQueryConfig": null,
           "loggedInMenu": {},
+          "facetPanelDisplay": {
+              "open": []
+          },
           "shareCiteAcls": {
               "show": ["*"],
               "enable": ["*"]

--- a/common/utils.js
+++ b/common/utils.js
@@ -42,7 +42,8 @@
           "savedQueryConfig": null,
           "loggedInMenu": {},
           "facetPanelDisplay": {
-              "open": []
+              "open": ["compact"],
+              "closed": ["compact/select"]
           },
           "shareCiteAcls": {
               "show": ["*"],

--- a/docs/user-docs/chaise-config-change-logs.md
+++ b/docs/user-docs/chaise-config-change-logs.md
@@ -5,7 +5,7 @@ The file contains changes made to chaise-config parameters.
 #### 04/08/2022 ####
 
 ###### PR Link
-  - [chaise]()
+  - [chaise](https://github.com/informatics-isi-edu/chaise/pull/2168)
   - [ermrestJS](https://github.com/informatics-isi-edu/ermrestjs/pull/943)
 
 #### 10/20/2021 ####

--- a/docs/user-docs/chaise-config-change-logs.md
+++ b/docs/user-docs/chaise-config-change-logs.md
@@ -2,10 +2,19 @@ The file contains changes made to chaise-config parameters.
 - Refer to [chaise-config.d](chaise-config.md) for currently supported parameters
 - Refer to [chaise-config-deprecated.md](chaise-config-deprecated.md) for deprecated parameters
 
+#### 04/08/2022 ####
+
+###### PR Link
+  - [chaise]()
+  - [ermrestJS](https://github.com/informatics-isi-edu/ermrestjs/pull/943)
+
 #### 10/20/2021 ####
 
 ###### PR Link
   - [chaise](https://github.com/informatics-isi-edu/chaise/pull/2134)
+
+###### Added
+  - `facetPanelDisplay` property was added to allow customization of the facet panel visibility on page load.
 
 ###### Changed
   - `savedQueryConfig` added new object named `defaultName` to define properties related to setting the default name of the saved query feature.

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -45,6 +45,7 @@ If a property appears in the same configuration twice, the property defined late
    * [hideTableOfContents](#hidetableofcontents)
    * [disableExternalLinkModal](#disableexternallinkmodal)
    * [hideGoToRID](#hidegotorid)
+   * [facetPanelDisplay](#facetpaneldisplay)
  * [Export Configuration:](#export-configuration)
    * [disableDefaultExport](#disabledefaultexport)
    * [exportSerivePath](#exportservicepath)
@@ -473,6 +474,26 @@ If a property appears in the same configuration twice, the property defined late
    - Sample syntax:
      ```
      hideGoToRID: true
+     ```
+
+ #### facetPanelDisplay
+ Use this property to change the visibility of the facet panel on load. Currently the only property supported is `open`. This property expects an array of
+ contexts and subcontexts associated with `compact` displays.
+   - Type: Object
+   - Default behavior: The facet panel will be open in the `compact` display and closed in all others.
+   - General syntax:
+     ```
+     facetPanelDisplay: {
+         open: [_context_]
+     }
+     ```
+   - `facetPanelDisplay` attributes:
+     - `open`: An array of contexts that the facet panel should be open for on page load. NOTE: The only context supported is `compact/select/association`.
+   - Sample syntax:
+     ```
+     facetPanelDisplay: {
+         open: ["compact/select/association"]
+     }
      ```
 
 ### Export Configuration:

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -477,8 +477,8 @@ If a property appears in the same configuration twice, the property defined late
      ```
 
  #### facetPanelDisplay
- Use this property to change the visibility of the facet panel on load. Currently the only supporting `open` and `closed`. This property expects an array of
- contexts and subcontexts associated with `compact` displays. `*` may be used but will be treated the same as `compact`. If a context is present in both open and closed, open will take priority. If the current context is not mentioned in either `open` or `closed`, it will try to inherit its value from a parent context. Defining only one array, `open` or `closed`, will assume the other undefined property is equal to `[]`.
+ Use this property to change the visibility of the facet panel on load. Currently the supported properties are `open` and `closed`. Both properties expect an array of
+ contexts and subcontexts associated with `compact` displays. `*` may be used but will be treated the same as `compact`. If a context is present in both open and closed, open will take priority. If the current context is not mentioned in either `open` or `closed`, it will try to inherit its value from a parent context. Defining only one array, `open` or `closed`, will assume the other property is equal to `[]`.
    - Type: Object
    - Default behavior: The facet panel will be open in the `compact` display and closed in all others.
    - General syntax:
@@ -494,8 +494,7 @@ If a property appears in the same configuration twice, the property defined late
    - Sample syntax:
      ```
      facetPanelDisplay: {
-         open: ["compact", "compact/select/association"],
-         closed: ["compact/select"]
+         open: ["compact/select/association"]
      }
      ```
 

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -477,22 +477,25 @@ If a property appears in the same configuration twice, the property defined late
      ```
 
  #### facetPanelDisplay
- Use this property to change the visibility of the facet panel on load. Currently the only property supported is `open`. This property expects an array of
- contexts and subcontexts associated with `compact` displays.
+ Use this property to change the visibility of the facet panel on load. Currently the only supporting `open` and `closed`. This property expects an array of
+ contexts and subcontexts associated with `compact` displays. `*` may be used but will be treated the same as `compact`. If a context is present in both open and closed, open will take priority. If the current context is not mentioned in either `open` or `closed`, it will try to inherit its value from a parent context. Defining only one array, `open` or `closed`, will assume the other undefined property is equal to `[]`.
    - Type: Object
    - Default behavior: The facet panel will be open in the `compact` display and closed in all others.
    - General syntax:
      ```
      facetPanelDisplay: {
-         open: [_context_]
+         open: [_context_],
+         closed: [_context_]
      }
      ```
    - `facetPanelDisplay` attributes:
-     - `open`: An array of contexts that the facet panel should be open for on page load. NOTE: The only context supported is `compact/select/association`.
+     - `open`: An array of contexts that the facet panel should be open for on page load.
+     - `closed`: An array of contexts that the facet panel should be closed for on page load.
    - Sample syntax:
      ```
      facetPanelDisplay: {
-         open: ["compact/select/association"]
+         open: ["compact", "compact/select/association"],
+         closed: ["compact/select"]
      }
      ```
 

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -480,11 +480,11 @@
             params.parentReference = tableModel.parentReference;
             params.displayMode = recordsetDisplayModes.unlinkPureBinaryPopup;
 
-            params.reference = ref.hideFacets().contextualize.compactSelect; // column reference
+            params.reference = ref.hideFacets().contextualize.compactSelectAssociation; // column reference
             params.selectMode = modalBox.multiSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = false;
+            params.facetPanelOpen = chaiseConfig.facetPanelDisplay.open.indexOf("compact/select/association") > -1;;
 
             var stackElement = logService.getStackNode(
                 logService.logStackTypes.RELATED,

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -484,7 +484,7 @@
             params.selectMode = modalBox.multiSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = chaiseConfig.facetPanelDisplay.open.indexOf("compact/select/association") > -1;
+            params.facetPanelOpen = params.reference.display.facetPanelOpen;
 
             var stackElement = logService.getStackNode(
                 logService.logStackTypes.RELATED,

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -480,11 +480,10 @@
             params.parentReference = tableModel.parentReference;
             params.displayMode = recordsetDisplayModes.unlinkPureBinaryPopup;
 
-            params.reference = ref.hideFacets().contextualize.compactSelectAssociation; // column reference
+            params.reference = ref.hideFacets().contextualize.compactSelectAssociationUnlink; // column reference
             params.selectMode = modalBox.multiSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = params.reference.display.facetPanelOpen;
 
             var stackElement = logService.getStackNode(
                 logService.logStackTypes.RELATED,

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -484,7 +484,7 @@
             params.selectMode = modalBox.multiSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
-            params.facetPanelOpen = chaiseConfig.facetPanelDisplay.open.indexOf("compact/select/association") > -1;;
+            params.facetPanelOpen = chaiseConfig.facetPanelDisplay.open.indexOf("compact/select/association") > -1;
 
             var stackElement = logService.getStackNode(
                 logService.logStackTypes.RELATED,

--- a/record/record.controller.js
+++ b/record/record.controller.js
@@ -484,6 +484,7 @@
             params.selectMode = modalBox.multiSelectMode;
             params.selectedRows = [];
             params.showFaceting = true;
+            params.facetPanelOpen =  params.reference.display.facetPanelOpen !== null ? params.reference.display.facetPanelOpen : false;
 
             var stackElement = logService.getStackNode(
                 logService.logStackTypes.RELATED,

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -324,12 +324,11 @@
             });
 
             // add not null filters for key information
-            params.reference = column.filteredRef(submissionRow, vm.recordEditModel.foreignKeyData[rowIndex]).addFacets(andFilters).contextualize.compactSelect;
+            params.reference = column.filteredRef(submissionRow, vm.recordEditModel.foreignKeyData[rowIndex]).addFacets(andFilters).contextualize.compactSelectForeignKey;
 
             params.selectedRows = [];
             params.selectMode = modalBox.singleSelectMode;
             params.showFaceting = true;
-            params.facetPanelOpen = false;
 
             var columnModel = vm.recordEditModel.columnModels[columnIndex];
             params.logStack = recordCreate.getColumnModelLogStack(columnModel);

--- a/recordedit/form.controller.js
+++ b/recordedit/form.controller.js
@@ -329,6 +329,7 @@
             params.selectedRows = [];
             params.selectMode = modalBox.singleSelectMode;
             params.showFaceting = true;
+            params.facetPanelOpen =  params.reference.display.facetPanelOpen !== null ? params.reference.display.facetPanelOpen : false;
 
             var columnModel = vm.recordEditModel.columnModels[columnIndex];
             params.logStack = recordCreate.getColumnModelLogStack(columnModel);

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -146,7 +146,8 @@
                     context.tableName = reference.table.name;
 
                     recordsetModel.reference = reference.contextualize.compact;
-                    recordsetModel.config.facetPanelOpen = showFaceting && recordsetModel.reference.display.facetPanelOpen;
+                    // if display.facetPanelOpen is null, don't change the value since it was set prior based on showFaceting
+                    if (showFaceting && params.reference.display.facetPanelOpen !== null) recordsetModel.config.facetPanelOpen = params.reference.display.facetPanelOpen;
 
                     // if there's something wrong with the facet or filters in the url,
                     // this getter will complain. We want to catch these errors here,

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -147,7 +147,7 @@
 
                     recordsetModel.reference = reference.contextualize.compact;
                     // if display.facetPanelOpen is null, don't change the value since it was set prior based on showFaceting
-                    if (showFaceting && params.reference.display.facetPanelOpen !== null) recordsetModel.config.facetPanelOpen = params.reference.display.facetPanelOpen;
+                    if (showFaceting && recordsetModel.reference.display.facetPanelOpen !== null) recordsetModel.config.facetPanelOpen = recordsetModel.reference.display.facetPanelOpen;
 
                     // if there's something wrong with the facet or filters in the url,
                     // this getter will complain. We want to catch these errors here,

--- a/recordset/recordset.app.js
+++ b/recordset/recordset.app.js
@@ -145,8 +145,8 @@
                     context.catalogID = reference.table.schema.catalog.id;
                     context.tableName = reference.table.name;
 
-
                     recordsetModel.reference = reference.contextualize.compact;
+                    recordsetModel.config.facetPanelOpen = showFaceting && recordsetModel.reference.display.facetPanelOpen;
 
                     // if there's something wrong with the facet or filters in the url,
                     // this getter will complain. We want to catch these errors here,

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -18,8 +18,7 @@ var chaiseConfig = {
     showWriterEmptyRelatedOnLoad: false,
     showFaceting: true,
     facetPanelDisplay: {
-        open: ["compact", "compact/select/association"],
-        closed: ["compact/select"]
+        open: ["compact/select/association"]
     },
     logClientActions: false,
     navbarMenu: {

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -18,7 +18,8 @@ var chaiseConfig = {
     showWriterEmptyRelatedOnLoad: false,
     showFaceting: true,
     facetPanelDisplay: {
-        open: ["compact/select/association"]
+        open: ["compact", "compact/select/association"],
+        closed: ["compact/select"]
     },
     logClientActions: false,
     navbarMenu: {

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -16,6 +16,10 @@ var chaiseConfig = {
     disableDefaultExport: true,
     disableExternalLinkModal: true,
     showWriterEmptyRelatedOnLoad: false,
+    showFaceting: true,
+    facetPanelDisplay: {
+        open: ["compact/select/association"]
+    },
     logClientActions: false,
     navbarMenu: {
         children: [

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -1028,6 +1028,9 @@ exports.testAddAssociationTable = function (params, isInline, pageReadyCondition
                 var totalCountText = chaisePage.recordsetPage.getTotalCount().getText();
                 expect(totalCountText).toBe("Displaying\nall " + params.totalCount +"\nof " + params.totalCount + " records", "association count display missmatch.");
 
+                // check the state of the facet panel
+                expect(chaisePage.recordPage.getModalSidePanel().isDisplayed()).toBeTruthy("Side panel is not visible on load");
+
                 done();
             }).catch(function(error) {
                 console.log(error);
@@ -1157,6 +1160,9 @@ exports.testBatchUnlinkAssociationTable = function (params, isInline, pageReadyC
 
                 var totalCountText = chaisePage.recordsetPage.getTotalCount().getText();
                 expect(totalCountText).toBe("Displaying\nall " + params.totalCount +"\nof " + params.totalCount + " records", "association count display missmatch.");
+
+                // check the state of the facet panel
+                expect(chaisePage.recordPage.getModalSidePanel().isDisplayed()).toBeTruthy("Side panel is not visible on load");
 
                 done();
             }).catch(function(error) {


### PR DESCRIPTION
This PR adds a chaise config property to allow for control over the initial display of the facet panel in search popups on modal load. The property includes 2 arrays, open and closed, of contexts related to compact and its sub-contexts.

To determine the state of the facet panel, chaise will get the value from ermrestJS which calculates the value based on the context of the reference and the defined `facetPanelDisplay` value.

Other changes include using more specific "contexts" when contextualizing a reference in places in chaise. The only reference that hasn't been changed was the reference used for the `Show More` popup in faceting.