### PR TITLE
Handle empty input for colors like any other input

### DIFF
--- a/common/inputs.js
+++ b/common/inputs.js
@@ -317,7 +317,6 @@
             require: '?ngModel',
             scope: {
                 toggleCallback: "=?",
-                isRequired: "="
             },
             link: function (scope, elem, attrs, ngModel) {
                 if (!ngModel) return;
@@ -329,7 +328,9 @@
                     showPalette: false,
                     showInitial: true,
                     showInput: true,
-                    allowEmpty: (scope.isRequired !== true)
+                    // we allow empty values  even if it's required (just like any other input)
+                    // chaise will then properly complain if users didn't select any values
+                    allowEmpty: true
                 });
 
                 // when the model changed, change the input

--- a/recordedit/index.html.in
+++ b/recordedit/index.html.in
@@ -235,7 +235,7 @@
                                                             <!-- color input -->
                                                             <div ng-switch-when="color" class="chaise-input-group">
                                                                 <div class="chaise-input-control chaise-color-picker">
-                                                                    <input color-picker toggle-callback="form.toggleColorPickerCallbacks[rowIndex][columnIndex]" is-required="form.isRequired(columnIndex)" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="text" empty-to-null>
+                                                                    <input color-picker toggle-callback="form.toggleColorPickerCallbacks[rowIndex][columnIndex]" ng-required="form.isRequired(columnIndex)" id="form-{{rowIndex}}-{{::form.makeSafeIdAttr(column.displayname.value)}}-input" ng-model="form.recordEditModel.rows[rowIndex][column.name]" name="{{::column.name}}" type="text" empty-to-null>
                                                                     <chaise-clear-input btn-class="text-remove" click-callback="form.clearInput(rowIndex, column.name)" show="form.showRemove(rowIndex, column.name)"></chaise-clear-input>
                                                                 </div>
                                                                 <span class="chaise-input-group-append">

--- a/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.js
@@ -696,7 +696,6 @@ describe("Other facet features, ", function() {
         });
     });
 
-    return;
     describe("regarding UnsupportedFilters handling, ", function () {
         var uriPrefix = browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + testParams.schema_name + ":" + testParams.table_name;
         var currParams = testParams.unsupported_filters_error;

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -372,6 +372,10 @@ var recordEditPage = function() {
         return browser.executeScript("return $(arguments[0]).parents('div[ng-switch-when=\"file\"]').siblings('.text-danger.ng-active').find('div[ng-message=\"" + type + "\"]')[0];", el);
     };
 
+    this.getColorInputErrorMessage = function(el, type) {
+        return browser.executeScript("return $(arguments[0]).parents('div[ng-switch-when=\"color\"]').siblings('.text-danger.ng-active').find('div[ng-message=\"" + type + "\"]')[0];", el);
+    };
+
     this.clearInput = function(el) {
         return el.getAttribute('value').then(function(value) {
             el.sendKeys(Array(value.length + 1).join(protractor.Key.BACK_SPACE));

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -1561,15 +1561,12 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                 // clear the value
                                 return chaisePage.recordEditPage.clearInput(colorInput);
                             }).then(function () {
+                                // the input won't validate until we press enter or change focus
                                 return browser.actions().sendKeys(protractor.Key.ENTER).perform();
                             }).then(function () {
-                                // if required, it will use the previous value
-                                if (c.nullok == false) {
-                                    expect(colorInput.getAttribute('value')).toBeTruthy(colError(c.name, "Was able to clear the input."));
-                                }
-
                                 return colorInput.sendKeys(invalidValue);
                             }).then (function () {
+                                // the input won't validate until we press enter or change focus
                                 return browser.actions().sendKeys(protractor.Key.ENTER).perform();
                             }).then (function () {
                                 expect(colorInput.getAttribute('value')).not.toBe(invalidValue);
@@ -1608,9 +1605,9 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                                 // make sure popup is displayed
                                 chaisePage.waitForElement(popup);
 
-                                // make sure nullok is offered or not
+                                // make sure clear btn is offered regardless of null/not-null (just like any other  input)
                                 var clearBtn = chaisePage.recordEditPage.getColorInputPopupClearBtn();
-                                expect(clearBtn.isDisplayed()).toEqual(c.nullok != false, colError(c.name, "color popup: clear btn invalid state"));
+                                expect(clearBtn.isDisplayed()).toEqual(true, colError(c.name, "color popup: clear btn invalid state"));
 
                                 // write a color and submit
                                 popupInput = chaisePage.recordEditPage.getColorInputPopupInput();
@@ -1650,6 +1647,7 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
                             chaisePage.recordEditPage.clearInput(colorInput).then(function () {
                                 return colorInput.sendKeys(text);
                             }).then(function () {
+                                // the input won't validate until we press enter or change focus
                                 return browser.actions().sendKeys(protractor.Key.ENTER).perform();
                             }).then(function () {
 


### PR DESCRIPTION
Whether the input value is required or not (based on the `nullok` flag in the model), Chaise allows users to "clear" the input. And the "required" check is only done when users attempt to submit the form.

This was not the case for the color inputs. If a color typed column had `nullok=false`, Chaise wouldn't allow users to clear the input. As a result, the input would show the "black color" on load, while the actual saved value is still `null`. This would lead to a confusing UX, as it is described in [#2061](https://github.com/informatics-isi-edu/chaise/issues/2061). 

So in this PR, I just made sure to allow empty values in the color input and then let Angular handle the "required" check.