### PR TITLE
show the versioned link in share popup only if table supports it

### DIFF
--- a/common/templates/shareCitation.modal.html
+++ b/common/templates/shareCitation.modal.html
@@ -25,12 +25,12 @@
         </div>
         <li id="share-link">
             <h2 ng-show="!ctrl.params.hideHeader">Share Link</h2>
-            <h3 class="share-item-header">
+            <h3 class="share-item-header" ng-if="ctrl.params.showVersionLink">
                 Versioned Link
                 <small tooltip-placement="bottom" ng-attr-uib-tooltip="{{!ctrl.moreThanWeek() ? 'Data snapshotted at ' + ctrl.params.versionDate : undefined}}">({{ctrl.params.versionDateRelative}})</small>
                 <span class="glyphicon glyphicon-copy chaise-copy-btn" ng-click="::ctrl.copyToClipboard(ctrl.params.versionLink, ctrl.logActions.SHARE_VERSIONED_LINK_COPY)" uib-tooltip="Copy link URL to clipboard." tooltip-placement="bottom"></span>
             </h3>
-            <a class="share-item-value" id="version" ng-href="{{::ctrl.params.versionLink}}">{{::ctrl.params.versionLink}}</a>
+            <a class="share-item-value" id="version" ng-href="{{::ctrl.params.versionLink}}" ng-if="ctrl.params.showVersionLink">{{::ctrl.params.versionLink}}</a>
             <h3 class="share-item-header">
                 Live Link
                 <span class="glyphicon glyphicon-copy chaise-copy-btn" ng-click="::ctrl.copyToClipboard(ctrl.params.permalink, ctrl.logActions.SHARE_LIVE_LINK_COPY)"  uib-tooltip="Copy link URL to clipboard." tooltip-placement="bottom"></span>

--- a/test/e2e/data_setup/schema/record/editable-id.json
+++ b/test/e2e/data_setup/schema/record/editable-id.json
@@ -144,7 +144,8 @@
                         "collapse_toc_panel": true,
                         "hide_column_header": true
                     }
-                }
+                },
+                "tag:isrd.isi.edu:2020,history-capture": true
             }
         },
         "fk-table": {

--- a/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
+++ b/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
@@ -389,6 +389,7 @@
                 }
             ],
             "annotations": {
+                "tag:isrd.isi.edu:2020,history-capture": false,
                 "comment": [
                     "default"
                 ],

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -92,8 +92,10 @@ var testParams = {
       tableToShow: 'Categories_5',
       sidePanelTableOrder:[ 'Summary', 'Categories_collection (5)',  'media (1)', 'Categories_collection_2 (5)',  'Categories_3 (5)',  'Categories_4 (5)',  'Categories_5 (5)',  'Categories_6 (5)']
     },
-    citationParams: {
+    sharePopupParams: {
         permalink: browser.params.origin+"/id/"+browser.params.catalogId+"/"+chaisePage.getEntityRow("product-record", "accommodation", [{column: "id",value: "2002"}]).RID,
+        // the table has history-capture: true
+        hasVersionedLink: true,
         verifyVersionedLink: true,
         citation: "accommodation_inbound1 one, accommodation_inbound1 three, accommodation_inbound1 five(3) Sherathon Hotel, accommodation_outbound1_outbound3 one http://www.starwoodhotels.com/sheraton/index.html (" + moment().format("YYYY") + ").",
         bibtextFile: "accommodation_"+chaisePage.getEntityRow("product-record", "accommodation", [{column: "id",value: "2002"}]).RID+".bib",

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -100,9 +100,11 @@ describe('View existing record,', function() {
         });
 
         // test that no citation appears in share modal when no citation is defined on table
+        // and also version link is not displayed when the table doesn't support history
         recordHelpers.testSharePopup({
             permalink: testParams.html_table_name_record_url,
-            verifyVersionedLink: false,
+
+            hasVersionedLink: true,
             citation: null,
             bibtextFile: null,
             title: "Share"

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -83,6 +83,8 @@ describe ("Viewing exisiting record with related entities, ", function () {
         keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
         recordHelpers.testSharePopup({
             permalink: RIDLink,
+            // the table has history-capture: false
+            hasVersionedLink: false,
             verifyVersionedLink: false,
             citation: "Super 8 North Hollywood Motel, accommodation_outbound1_outbound1 two https://www.kayak.com/hotels/Super-8-North-Hollywood-c31809-h40498/2016-06-09/2016-06-10/2guests (" + moment().format("YYYY") + ").",
             bibtextFile: false, // we don't need to test this here as well (it has been tested in record presentation)


### PR DESCRIPTION
In [this ermrestjs commit](https://github.com/informatics-isi-edu/ermrestjs/commit/20e0fa747533ad8f42938ed057eb6c8655ec0fb0), I added a new `Table.supportHistory` API. This PR will make sure chaise is using this API to conditionally add the version link in the share and cite popup.

The main purpose of this PR is to run test cases on Github Actions before merging with master.

related issue: #2002