### PR TITLE
Change how pseudoColor is used and stored

### DIFF
--- a/viewer/viewer.utils.js
+++ b/viewer/viewer.utils.js
@@ -1110,7 +1110,7 @@
         }
 
         /**
-         * The expected input format: [{channelNumber: , settings: }]]
+         * The expected input format: [{channelNumber: , channelConfig: , pseudoColor}]]
          * TODO this function is not using ermrestjs and directly sending a request
          * to ermrest. This is because we cannot assume the config column is visible,
          * while the Reference.update only allows updating of the visible columns.
@@ -1125,13 +1125,17 @@
             url += UriUtils.fixedEncodeURIComponent(channelConfig.table_name) + "/";
             url += UriUtils.fixedEncodeURIComponent(channelConfig.reference_image_column_name) + ",";
             url += UriUtils.fixedEncodeURIComponent(channelConfig.channel_number_column_name) + ";";
-            url += UriUtils.fixedEncodeURIComponent(channelConfig.channel_config_column_name);
+            url += UriUtils.fixedEncodeURIComponent(channelConfig.channel_config_column_name) + ",";
+            url += UriUtils.fixedEncodeURIComponent(channelConfig.pseudo_color_column_name);
 
             var ch = osdConstant.CHANNEL_CONFIG;
             data.forEach(function (d) {
                 var saved = {};
                 saved[channelConfig.reference_image_column_name] = context.imageID;
                 saved[channelConfig.channel_number_column_name] = d.channelNumber;
+                if (d.pseudoColor) {
+                    saved[channelConfig.pseudo_color_column_name] = d.pseudoColor;
+                }
                 var config = {};
                 config[ch.NAME_ATTR] = ch.FORMAT_NAME;
                 config[ch.VERSION_ATTR] = channelConfigFormatVersion;
@@ -1224,4 +1228,4 @@
 
     }]);
 
-  })();
+})();


### PR DESCRIPTION
This PR addresses #2124 issue. In terms of code change in this PR, I only modified the `updateChannelConfig` function to send the value of `pseudoColor` sent from osd-viewer alongside the `ChannelConfig`. The rest of the changes can be found in [osd-viewer#96 PR](https://github.com/informatics-isi-edu/openseadragon-viewer/pull/96). I'll explain why we decided to make these changes in the following.

As part of the image processing pipeline, We store a `pseudoColor` with the greyscale images. This value was used in the viewer app to populate the "Hue" control.  When we modified the channel controls to make them persistent in the database, we introduced a `ChannelConfig` JSON column with a `hue` property. And therefore, I modified the code to use this `hue` if `ChannelConfig` is defined (and ignore `pseudoColor`). 

While this works properly in the viewer app, it's causing some confusing behavior in other Chaise apps. The `ChannelConfig` is hidden, while `pseudoColor` is still visible and users can modify it. But as long as `ChannelConfig` is defined, the `pseudoColor` is completely ignored .

That's why we decided to change osd-viewer and,
- Use the `pseudoColor` if defined for the hue control (give it more priority over `ChannelConfig.hue`).
- When users click on save, change the `pseudoColor` alongside the `ChannelConfig`.

This will ensure what's displayed in other Chaise apps is consistent with the viewer app. Although by doing this, the value of `ChannelConfig.hue` is redundant now. And if users change the `pseudoColor` in the recordedit page, these two values will stay out of sync until the user navigates to the viewer page and saves all the settings.

We had a conversation about this, and while the new solution is not perfect, we decided to push this for now. I'll create a new issue with more information to summarize what we think we should do next


