### PR TITLE
Remove makefile install target and introduce deploy

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,13 +104,15 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          sudo make install
+          make dist
+          sudo make deploy
       - name: Install chaise
         run: |
           sudo mkdir -p /var/www/html/chaise
           cd chaise
-          sudo make deps-test
-          sudo make install-wo-deps
+          make deps-test
+          make dist-wo-deps
+          sudo make deploy
       - name: Add tests users
         run: |
           sudo -H -u webauthn webauthn2-manage adduser test1

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@
 # Disable built-in rules
 .SUFFIXES:
 
-# set the default target to install
-.DEFAULT_GOAL:=install
 
-# env variables needed for installation
+# env variables
 WEB_URL_ROOT?=/
 WEB_INSTALL_ROOT?=/var/www/html/
 ERMRESTJS_REL_PATH?=ermrestjs/
@@ -16,7 +14,7 @@ OSD_VIEWER_REL_PATH?=openseadragon-viewer/
 # version number added to all the assets
 BUILD_VERSION:=$(shell date +%Y%m%d%H%M%S)
 
-# where chaise will be installed
+# where chaise will be deployed
 CHAISEDIR:=$(WEB_INSTALL_ROOT)$(CHAISE_REL_PATH)
 
 #chaise and ermrsetjs paths
@@ -602,10 +600,7 @@ define bundle_js_files
 	@$(BIN)/uglifyjs $(2) -o $(DIST)/$(1) --compress --source-map "url='$(1).map',root='$(CHAISE_BASE_PATH)'"
 endef
 
-# Rule to create the package.
-$(DIST): print-variables $(SASS) $(MIN) $(HTML) gitversion
-
-# build version will change everytime make all or install is called
+# build version will change everytime it's called
 $(BUILD_VERSION):
 
 # make sure the latest webdriver is installed
@@ -648,28 +643,27 @@ clean:
 
 # Rule to clean the dependencies too
 .PHONY: distclean
-distclean: clean
+clean-deps: clean
 	rm -rf $(MODULES) || true
 
-# Rule to build chaise
-.PHONY: all
-all: $(DIST)
+# Rule to create the package.
+.PHONY: dist-wo-deps
+dist-wo-deps: print-variables $(SASS) $(MIN) $(HTML) gitversion
 
-# Rule for installing for normal deployment (build chaise and deploy)
-.PHONY: install dont_install_in_root
-install: deps $(DIST) dont_install_in_root rsync-chaise
+# Rule to install the dependencies and create the pacakge
+$(DIST): deps dist-wo-deps
 
-# Rule for installing without installing dependencies
-.PHONY: install-wo-deps dont_install_in_root
-install-wo-deps: $(DIST) dont_install_in_root rsync-chaise
+# deploy chaise to the location
+.PHONY: deploy
+deploy: dont_deploy_in_root
+	$(info - deploying the package)
+	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' --exclude='$(JS_CONFIG)' --exclude='$(VIEWER_CONFIG)' . $(CHAISEDIR)
 
-# Rule for installing during testing (build chaise and deploy with the chaise-config)
-.PHONY: install-w-config dont_install_in_root
-install-w-config: deps $(DIST) dont_install_in_root $(JS_CONFIG) $(VIEWER_CONFIG) rsync-chaise-w-config
-
-# Rule for installing during testing without updating dependencies (build chaise and deploy with the chaise-config)
-.PHONY: install-w-config dont_install_in_root
-install-wo-deps-w-config: $(DIST) dont_install_in_root $(JS_CONFIG) $(VIEWER_CONFIG) rsync-chaise-w-config
+# rsync the build and config files to the location
+.PHONY: deploy-w-config
+deploy-w-config: dont_deploy_in_root $(JS_CONFIG) $(VIEWER_CONFIG)
+	$(info - deploying the package with the existing default config files)
+	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' . $(CHAISEDIR)
 
 # Rule to create version.txt
 .PHONY: gitversion
@@ -677,18 +671,8 @@ gitversion:
 	$(info - creating version.txt)
 	@sh ./git_version_info.sh
 
-dont_install_in_root:
+dont_deploy_in_root:
 	@echo "$(CHAISEDIR)" | egrep -vq "^/$$|.*:/$$"
-
-# rsync the build files to the location
-rsync-chaise:
-	$(info - deploying the package)
-	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' --exclude='$(JS_CONFIG)' --exclude='$(VIEWER_CONFIG)' . $(CHAISEDIR)
-
-# rsync the build and config files to the location
-rsync-chaise-w-config:
-	$(info - deploying the package with the existing default config files)
-	@rsync -avz --exclude='.*' --exclude='docs' --exclude='test' --exclude='$(MODULES)' . $(CHAISEDIR)
 
 print-variables:
 	@mkdir -p $(DIST)
@@ -696,8 +680,8 @@ print-variables:
 	$(info BUILD_VERSION=$(BUILD_VERSION))
 	$(info building and deploying to: $(CHAISEDIR))
 	$(info Chaise will be accessed using: $(CHAISE_BASE_PATH))
-	$(info ERMrestJS must already be installed and accesible using: $(ERMRESTJS_BASE_PATH))
-	$(info If using viewer, OSD viewer must already be installed and accesible using: $(OSD_VIEWER_BASE_PATH))
+	$(info ERMrestJS must already be deployed and accesible using: $(ERMRESTJS_BASE_PATH))
+	$(info If using viewer, OSD viewer must already be deployed and accesible using: $(OSD_VIEWER_BASE_PATH))
 	$(info =================)
 
 # Rules for help/usage
@@ -706,21 +690,20 @@ help: usage
 usage:
 	@echo "Usage: make [target]"
 	@echo "Available targets:"
-	@echo "  install                    local install of node dependencies, build and install the client"
-	@echo "  install-w-config           local install of node dependencies, build and install the client with chaise-config.js file"
-	@echo "  install-wo-deps            build and install the client"
-	@echo "  install-wo-deps-w-config   build and install the client with chaise-config.js file"
-	@echo "  all                        build the client"
-	@echo "  clean                      clean the files and folders created during build"
-	@echo "  distclean                  clean the files and folders created during build and npm dependencies"
-	@echo "  deps                       local install of node dependencies"
-	@echo "  updeps                     local update  of node dependencies"
-	@echo "  update-webdriver           update the protractor's webdriver"
-	@echo "  deps-test                  install dev node dependencies and update protractor's webdriver"
-	@echo "  test                       run e2e tests"
-	@echo "  testrecordadd              run data entry app add e2e tests"
-	@echo "  testrecordedit             run data entry app edit e2e tests"
-	@echo "  testrecord                 run record app e2e tests"
-	@echo "  testrecordset              run recordset app e2e tests"
-	@echo "  testviewer                 run viewer app e2e tests"
-	@echo "  testnavbar                 run navbar e2e tests"
+	@echo "  dist                           local install of node dependencies, build the chaise bundles"
+	@echo "  dist-wo-deps                   build the chaise bundles"
+	@echo "  deploy                         deploy chaise to the given location"
+	@echo "  deploy-w-config                deploy chaise to the given location with config files"
+	@echo "  clean                          clean the files and folders created during build"
+	@echo "  clean-deps                     clean npm dependencies"
+	@echo "  deps                           local install of node dependencies"
+	@echo "  updeps                         local update  of node dependencies"
+	@echo "  update-webdriver               update the protractor's webdriver"
+	@echo "  deps-test                      local install of dev node dependencies and update protractor's webdriver"
+	@echo "  test                           run e2e tests"
+	@echo "  testrecordadd                  run data entry app add e2e tests"
+	@echo "  testrecordedit                 run data entry app edit e2e tests"
+	@echo "  testrecord                     run record app e2e tests"
+	@echo "  testrecordset                  run recordset app e2e tests"
+	@echo "  testviewer                     run viewer app e2e tests"
+	@echo "  testnavbar                     run navbar e2e tests"

--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ clean:
 
 # Rule to clean the dependencies too
 .PHONY: distclean
-clean-deps: clean
+distclean: clean
 	rm -rf $(MODULES) || true
 
 # Rule to create the package.
@@ -694,8 +694,8 @@ usage:
 	@echo "  dist-wo-deps                   build the chaise bundles"
 	@echo "  deploy                         deploy chaise to the given location"
 	@echo "  deploy-w-config                deploy chaise to the given location with config files"
-	@echo "  clean                          clean the files and folders created during build"
-	@echo "  clean-deps                     clean npm dependencies"
+	@echo "  clean                          remove the files and folders created during build"
+	@echo "  distclean                      the same as clean, and also removes npm dependencies"
 	@echo "  deps                           local install of node dependencies"
 	@echo "  updeps                         local update  of node dependencies"
 	@echo "  update-webdriver               update the protractor's webdriver"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When developing new code for Chaise, please make sure you're following these ste
 1. create a new branch and make your updates to the code in the branch (avoid changing master branch directly);
 2. do your own quality assurance;
 4. update the e2e tests (if applicable);
-6. make sure you can deploy your code without any issues (`make install` should not fail);
+6. make sure you can deploy your code without any issues (`make dist && make deploy` should not fail);
 7. make sure that all tests are passing before submitting the pull request (`make test` should be free of errors);
 8. make your pull request, assign it to yourself, and ask someone to review your code.
   - Try to provide as much information as you can on your PR. Explain the issues that the PR is fixing, and the changes that you've done in the PR.

--- a/docs/dev-docs/e2e-test.md
+++ b/docs/dev-docs/e2e-test.md
@@ -56,7 +56,7 @@ You can get your cookie by querying the database, or using the following simple 
 2. Make sure all the dependencies are installed by running the following command:
 
     ```sh
-    $ make deps-test
+    make deps-test
     ```
 
     This will install all the npm dependencies that are needed and will also make sure the Selenium's WebDriver that protractor uses is updated.
@@ -65,15 +65,18 @@ You can get your cookie by querying the database, or using the following simple 
     - If the version of Chrome that is installed on your machine is different from the ChromeDriver that Selenium uses, it will throw an error. So make sure both versions are always updated and compatible.
 
 
-3. Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository. (This will upload your local code to the remote server)
+3. Build Chaise without installing the dependencies again:
     ```sh
-    $ make install-wo-deps
+    make dist-wo-deps
     ```
+    As the name suggests this will not install dependencies. That's why you need to install all the dependencies in step 2.
 
-    - As the name suggests this will not install dependencies. That's why you need to install all the dependencies in step 2. The following are other available targets related to install:
-      - `install`: Will install production dependencies before installing (not advised for testing purposes and should be used for production)
-      - `install-w-config`: The same as `install` and will also copy the `chaise-config.js` file to the remote location.
-      - `install-wo-deps-w-config`: The same as `install-w-deps` and will also copy the `chaise-config.js` file to the remote location.
+4. Upload your code on the `https://dev.isrd.isi.edu/~<your-user-directory>` by the running the following command in your local chaise repository (This will upload your local code to the remote server):
+
+    ```sh
+    make deploy
+    ```
+    If you want to also deploy the existing config files in your local machine, you can use the `make deploy-w-config` command instead.
 
 
 ### Test cases

--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -41,7 +41,7 @@ ERMrestJS tests, which will also instruct you to get shared dependencies needed 
 
 1. First you need to setup some environment variables to tell Chaise where it should install the package. The following are the variables and their default values:
 
-    ```
+    ```sh
     WEB_URL_ROOT=/
     WEB_INSTALL_ROOT=/var/www/html/
     CHAISE_REL_PATH=chaise/
@@ -51,18 +51,28 @@ ERMrestJS tests, which will also instruct you to get shared dependencies needed 
     Notes:
     - All the variables MUST have a trailing `/`.
 
-    - If you're installing remotely, since we're using the `WEB_INSTALL_ROOT` in `rsync` command, you can use a remote location `username@host:public_html/` for this variable.
+    - If you're deploying remotely, since we're using the `WEB_INSTALL_ROOT` in `rsync` command, you can use a remote location `username@host:public_html/` for this variable.
 
-    - A very silly thing to do would be to set your deployment directory to root `/` and run `make install` with `sudo`. This would be very silly indeed, and would probably result in some corruption of your operating system. Surely, no one would ever do this. But, in the off chance that one might attempt such silliness, the `make install` rule specifies a `dont_install_in_root` prerequisite that attempts to put a stop to any such silliness before it goes too far.
+    - A very silly thing to do would be to set your deployment directory to root `/` and run `make deploy` with `sudo`. This would be very silly indeed, and would probably result in some corruption of your operating system. Surely, no one would ever do this. But, in the off chance that one might attempt such silliness, the `make deploy` rule specifies a `dont_deploy_in_root` prerequisite that attempts to put a stop to any such silliness before it goes too far.
 
-2. After making sure the variables are properly set, run the following command:
+2. Build the Chaise bundles by running the following command:
 
-    ```
-    $ make install
+    ```sh
+    make dist
     ```
 
     Notes:
-      - If the given directory does not exist, it will first create it. So you may need to run `make install` with _super user_ privileges depending on the installation directory you choose.
+    - Make sure to run this command with the owner of the current folder. If you attempt to run this with a different user, it will complain.
+
+
+3. To deploy the package, run the following:
+
+    ```sh
+    make deploy
+    ```
+
+    Notes:
+      - If the given directory does not exist, it will first create it. So you may need to run `make deploy` with _super user_ privileges depending on the deployment directory you choose (by default it's `/var/www/html/`).
 
 ## Configuration
 
@@ -76,26 +86,4 @@ Once deployed the apps can be found at `http://<hostname>/chaise/<app>`, where `
 
 ## Testing
 
-This section assumes you have already installed _and tested_ [ERMrestJS](https://github.com/informatics-isi-edu/ermrestjs). If you have not, stop here and do that first, then return this step.
-
-Before running the test cases you need to set `ERMREST_URL`, `CHAISE_BASE_URL`, `AUTH_COOKIE`, `RESTRICTED_AUTH_COOKIE`, and `REMOTE_CHAISE_DIR_PATH` environment variables. See [How to Get Your AUTH_COOKIE](../dev-docs/e2e-test.md#how-to-get-your-auth-cookie).
-
-The example here is based on the assumption that the tests are installed and executed against a deployment to a userdir.
-
-```sh
-export CHAISE_BASE_URL=https://HOST/~USERNAME/chaise
-export ERMREST_URL=https://HOST/ermrest
-export AUTH_COOKIE=YOUR_WEBAUTHN_COOKIE
-export RESTRICTED_AUTH_COOKIE=YOUR_SECOND_USER_ERMREST_COOKIE
-export REMOTE_CHAISE_DIR_PATH=USERNAME@HOST:public_html/chaise
-```
-
-Then run the tests (install, if you haven't already).
-
-```sh
-$ make install  # if not already installed
-$ npm install # if npm dependencies not already installed
-$ make test
-```
-
-For more information, see the [E2E tests guide](../dev-docs/e2e-test.md).
+Please refer to he [E2E tests guide](../dev-docs/e2e-test.md).

--- a/docs/user-docs/login-app.md
+++ b/docs/user-docs/login-app.md
@@ -43,11 +43,11 @@ Login app has more dependencies that, if not included, are fetched dynamically. 
 
 The position of where you're adding these include statements is very important. It HAS TO be BEFORE `login.app.js`.  Adding them after `login.app.js` defeats the purpose of prefetching and actually causes duplicated fetching.
 
-You should not copy the contents of `dist/chaise-dependencies.html` manually and this should be part of the automated process of building Chaise and your other apps (Since the list generation is controlled by Chaise, we might update the list and therefore you should make sure you're always getting the latest list of dependencies.)  
+You should not copy the contents of `dist/chaise-dependencies.html` manually and this should be part of the automated process of building Chaise and your other apps (Since the list generation is controlled by Chaise, we might update the list and therefore you should make sure you're always getting the latest list of dependencies.)
 
 If you're using [Jekyll](https://jekyllrb.com), the following are the steps on how you can achieve this:
 
-1. Make sure `make install` is done in Chaise.
+1. Make sure `make dist` and `make deploy` is done in Chaise.
     - This will create the `dist` folder in your specified build target (by default it's `/var/www/html/chaise`).
     - It will also generate the `dist/chaise-dependencies.html`.
 

--- a/docs/user-docs/navbar-app.md
+++ b/docs/user-docs/navbar-app.md
@@ -51,7 +51,7 @@ You should not copy the contents of `dist/chaise-dependencies.html` manually and
 
 If you're using [Jekyll](https://jekyllrb.com), the following are the steps on how you can achieve this:
 
-1. Make sure `make install` is done in Chaise.
+1. Make sure `make dist` and `make deploy` is done in Chaise.
     - This will create the `dist` folder in your specified build target (by default it's `/var/www/html/chaise`).
     - It will also generate the `dist/chaise-dependencies.html`.
 

--- a/docs/viewer/viewer-app.md
+++ b/docs/viewer/viewer-app.md
@@ -61,22 +61,17 @@ You need to deploy both Chaise and openseadragon-viewer to ensure the viewer app
 
     If that is not the case in your deployment, you should modify the variables accordingly.
 
+2. Make sure Chaise is deployed by following [its own guide](https://github.com/informatics-isi-edu/chaise/blob/master/docs/user-docs/installation.md#deploying).
 
-2. Clone the openseadragon-viewer repository,
+3. Clone the openseadragon-viewer repository,
     ```
     $ git clone git@github.com:informatics-isi-edu/openseadragon-viewer.git
     ```
 
-3. Run the following command in the openseadragon-viewer folder
+4. Run the following command in the openseadragon-viewer folder
    (make sure to run this in the openseadragon-viewer folder),
     ```
-    $ make install
-    ```
-
-3. Make sure Chaise is properly installed by calling the following command under Chaise
-  (make sure to run this in the Chaise folder),
-    ```
-    $ make install
+    $ make deploy
     ```
 
 ## How it works

--- a/package.json
+++ b/package.json
@@ -4,11 +4,6 @@
   "version": "0.0.0",
   "license": "Apache-2.0",
   "private": true,
-  "scripts": {
-    "build": "make install",
-    "pretest": "make install",
-    "test": "make test"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/informatics-isi-edu/chaise.git"


### PR DESCRIPTION
After reviewing how the `make install` command works, we realized that it's wrong and should be changed. This command is doing the following two steps:

Build the chaise bundles in the `dist` folder alongside the other chaise folders.
Deploy the built files to the given location (local or remote, depending on how the environment variables are defined).

In a multi-user environment (like the automated build process in our recipes), the first step should be performed by the owner of the folder. And the second step can only be performed by the user that has access to the `/var/www/html/` location. So we shouldn't have assumed that a single user can perform these two actions and should just separate them.

That's why in this PR, I removed the `install` target and introduced a new `deploy` target that goes alongside the existing `dist` target.


Notes:
- We found this issue because of how during build, we're calling `git log` to capture a "version". In the latest change to git, by default, only the owner of the `.git` file can run git commands. This was making the `git_version_info` fail.
- This pattern is repeated in all the front-end repositories. That's why I had to change all the other ones as well.
- Since I removed the install command, all the existing recipes are going to fail. So this PR can only be merged when the recipes are ready to use the new targets


@jrchudy:
- Please make sure I didn't miss anything. I tried to search for any usage of `install` to replace it with the new commands. 
- I haven't tested if the new change in `e2e.yml` works or not. I'd update this PR if the change failed. 
- I will apply these changes to the `react` branch when we've fully merged everything. 
- I didn't like how `distclean` is misleading now that we're announcing the `dist` target. So I changed it to `clean-deps`. Do you thin it's a good name?

