### PR TITLE
Float and timestamp precision improvements for range picker

### DIFF
--- a/common/faceting.js
+++ b/common/faceting.js
@@ -736,8 +736,8 @@
                             maxEps = (Math.abs(max) > 0) ? Math.max( tiny, Math.pow(2, expbase + Math.log2(Math.abs(max))) ) : tiny;
 
                             // adjust by epsilon
-                            scope.rangeOptions.absMin = (min-minEps);
-                            scope.rangeOptions.absMax = formatFloatMax(max+maxEps);
+                            scope.rangeOptions.absMin = min ? (min-minEps) : null;
+                            scope.rangeOptions.absMax = max ? formatFloatMax(max+maxEps) : null;
                         } else {
                             scope.rangeOptions.absMin = min;
                             scope.rangeOptions.absMax = max;

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -736,8 +736,8 @@
                             maxEps = (Math.abs(max) > 0) ? Math.max( tiny, Math.pow(2, expbase + Math.log2(Math.abs(max))) ) : tiny;
 
                             // adjust by epsilon
-                            scope.rangeOptions.absMin = min ? (min-minEps) : null;
-                            scope.rangeOptions.absMax = max ? formatFloatMax(max+maxEps) : null;
+                            scope.rangeOptions.absMin = (min !== null && min !== undefined) ? (min-minEps) : null;
+                            scope.rangeOptions.absMax = (max !== null && max !== undefined) ? formatFloatMax(max+maxEps) : null;
                         } else {
                             scope.rangeOptions.absMin = min;
                             scope.rangeOptions.absMax = max;

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -732,10 +732,11 @@
                             }
 
                             // max(tiny, pow(2, expbase + log2(abs(x))))
+                            // use tiny if abs(x) is 0 or negative
                             minEps = (Math.abs(min) > 0) ? Math.max( tiny, Math.pow(2, expbase + Math.log2(Math.abs(min))) ) : tiny;
                             maxEps = (Math.abs(max) > 0) ? Math.max( tiny, Math.pow(2, expbase + Math.log2(Math.abs(max))) ) : tiny;
 
-                            // adjust by epsilon
+                            // adjust by epsilon if value is defined and non null
                             scope.rangeOptions.absMin = (min !== null && min !== undefined) ? formatFloatMin(min-minEps) : null;
                             scope.rangeOptions.absMax = (max !== null && max !== undefined) ? formatFloatMax(max+maxEps) : null;
                         } else {
@@ -752,7 +753,7 @@
                             scope.rangeOptions.absMin = timestampToDateTime(min);
                             scope.rangeOptions.absMax = timestampToDateTime(max);
                         } else if (isColumnOfType('float')) {
-                            scope.rangeOptions.absMin = (min);
+                            scope.rangeOptions.absMin = formatFloatMin(min);
                             scope.rangeOptions.absMax = formatFloatMax(max);
                         } else {
                             scope.rangeOptions.absMin = min;

--- a/common/faceting.js
+++ b/common/faceting.js
@@ -736,7 +736,7 @@
                             maxEps = (Math.abs(max) > 0) ? Math.max( tiny, Math.pow(2, expbase + Math.log2(Math.abs(max))) ) : tiny;
 
                             // adjust by epsilon
-                            scope.rangeOptions.absMin = (min !== null && min !== undefined) ? (min-minEps) : null;
+                            scope.rangeOptions.absMin = (min !== null && min !== undefined) ? formatFloatMin(min-minEps) : null;
                             scope.rangeOptions.absMax = (max !== null && max !== undefined) ? formatFloatMax(max+maxEps) : null;
                         } else {
                             scope.rangeOptions.absMin = min;

--- a/test/e2e/specs/delete-prohibited/recordset/histogram-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/histogram-facet.spec.js
@@ -33,19 +33,19 @@ var testParams = {
         }, {
             name: "timestamp_col",
             absMin: { date: "2007-04-06", time: "01:01:01" },
-            absMax: { date: "2007-09-30", time: "06:30:30" },
+            absMax: { date: "2007-09-30", time: "06:30:31" },
             zoom1: {
-                min: {date: "2007-05-11", time: "11:42:54"},
-                max: {date: "2007-08-25", time: "19:48:36"}
+                min: {date: "2007-05-11", time: "11:42:55"},
+                max: {date: "2007-08-25", time: "19:48:37"}
             },
             zoom2: {
-                min: {date: "2007-06-01", time: "18:08:02"},
-                max: {date: "2007-08-04", time: "13:23:27"}
+                min: {date: "2007-06-01", time: "18:08:03"},
+                max: {date: "2007-08-04", time: "13:23:28"}
             },
             allRecords: "Displaying\nfirst 25\nof 155 matching results",
             zoom3: {
-                min: {date: "2007-06-14", time: "12:23:07"},
-                max: {date: "2007-07-22", time: "19:08:22"}
+                min: {date: "2007-06-14", time: "12:23:08"},
+                max: {date: "2007-07-22", time: "19:08:23"}
             }
         }
     ]
@@ -86,7 +86,7 @@ describe("Viewing Recordset with Faceting,", function() {
         it("should have " + testParams.totalNumFacets + " facets", function () {
             expect(chaisePage.recordsetPage.getFacetTitles()).toEqual(testParams.facetNames, "Displayed list of facets is incorrect");
         });
-        
+
         if (!process.env.CI) {
             console.log("histogram test cases only work on CI environments.");
             return;


### PR DESCRIPTION
This PR changes how the min and max is done for timestamp and float type facets. Both will have an epsilon adjusted value used for the min and max to make sure fractional seconds and floating point precision is handled. Float precision is consistent from user input to display to server request

Opening this PR to run test cases in CI (specifically `histogram-facet.spec.js`).