### PR TITLE
Faceting > HTML structure > panel header

### DIFF
--- a/src/assets/scss/_faceting.scss
+++ b/src/assets/scss/_faceting.scss
@@ -51,10 +51,12 @@
           font-family: "Font Awesome 6 Free";
           font-weight: 900;
           transform: unset;
+          font-size: 18px;
+          height: unset;
         }
 
         &:not(.collapsed)::after {
-          content: '\f107'; // fa-solid fa-chevron-down
+          content: '\f078'; // fa-solid fa-chevron-down
         }
 
         &:focus {

--- a/src/assets/scss/_faceting.scss
+++ b/src/assets/scss/_faceting.scss
@@ -51,7 +51,7 @@
           font-family: "Font Awesome 6 Free";
           font-weight: 900;
           transform: unset;
-          font-size: 18px;
+          font-size: 1.25rem;
           height: unset;
         }
 

--- a/src/assets/scss/_faceting.scss
+++ b/src/assets/scss/_faceting.scss
@@ -36,9 +36,22 @@
         padding: 10px 5px;
         text-transform: none;
         position: relative;
+        // Overriding accordian-button css to align right angle bracket icon to left
+        flex-direction: row-reverse;
+        justify-content: flex-end;
 
         background-color: $table-header-background-color;
         color: $black-color;
+
+        // Overriding accordian-button css to align right angle bracket icon to left
+        &::after {
+          margin: 0px 8px;
+          transform: rotate(-90deg);
+        }
+
+        &:not(.collapsed)::after {
+          transform: rotate(0deg);
+        }
 
         &:focus {
           box-shadow: none;
@@ -65,6 +78,16 @@
       .accordion-body {
         padding: 10px;
       }
+    }
+
+    .facet-header-text {
+      font-size: 1.25rem;
+    }
+
+    .align-center-icon {
+      line-height: 20px;
+      vertical-align: middle;
+      margin: 4px;
     }
   }
 }

--- a/src/assets/scss/_faceting.scss
+++ b/src/assets/scss/_faceting.scss
@@ -46,11 +46,15 @@
         // Overriding accordian-button css to align right angle bracket icon to left
         &::after {
           margin: 0px 8px;
-          transform: rotate(-90deg);
+          background-image: none;
+          content: '\f054'; // fa-solid fa-chevron-right
+          font-family: "Font Awesome 6 Free";
+          font-weight: 900;
+          transform: unset;
         }
 
         &:not(.collapsed)::after {
-          transform: rotate(0deg);
+          content: '\f107'; // fa-solid fa-chevron-down
         }
 
         &:focus {

--- a/src/components/FacetHeader.tsx
+++ b/src/components/FacetHeader.tsx
@@ -1,0 +1,89 @@
+import '@isrd-isi-edu/chaise/src/assets/scss/_faceting.scss';
+
+import { useRef, useState } from 'react';
+
+// Components
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+
+type FacetHeaderProps = {
+  key: string;
+  headerText: any;
+  showTooltipIcon: any;
+  tooltipContent: any;
+};
+
+/**
+ * @param key key prop to uniquely identify panel header item
+ * @param headerText headerText prop that holds content to show as header
+ * @param showTooltipIcon prop to enable tooltip for header text
+ * @param tooltipContent text to be shown on hover of header text
+ * @returns FacetHeader Component
+ */
+const FacetHeader = ({
+  key,
+  headerText,
+  showTooltipIcon,
+  tooltipContent,
+}: FacetHeaderProps) => {
+  /**
+   * @contentRef variable to store ref of facet header text
+   * @show state variable to control whether to show tooltip or not
+   */
+  const contentRef = useRef(null);
+  const [show, setShow] = useState(false);
+
+  // Function to check the text overflow.
+  const isTextOverflow = (element) => {
+    if (element) {
+      return element.offsetWidth < element.scrollWidth;
+    }
+    return false;
+  };
+
+  return (
+    <OverlayTrigger
+      trigger='hover'
+      placement='right'
+      overlay={
+        <Tooltip style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}>
+          {contentRef &&
+          contentRef.current &&
+          isTextOverflow(contentRef.current) ? (
+            <>
+              <DisplayValue value={headerText} />: {tooltipContent}
+            </>
+          ) : tooltipContent ? (
+            tooltipContent
+          ) : (
+            <DisplayValue value={headerText} />
+          )}
+        </Tooltip>
+      }
+      onToggle={(nextshow: boolean) => {
+        // Bootstrap onToggle prop to make tooltip visible or hidden
+        if (contentRef && contentRef.current) {
+          const isOverflow = isTextOverflow(contentRef.current);
+
+          // If either text overflow or showtooltip is true, show tooltip to right of the content
+          setShow((isOverflow || showTooltipIcon) && nextshow);
+        }
+      }}
+      show={show}
+    >
+      <div className='accordion-toggle ellipsis' id={key}>
+        <div ref={contentRef} className='facet-header-text ellipsis'>
+          <DisplayValue value={headerText} />
+          {/* Condition to show tooltip icon */}
+          {showTooltipIcon && (
+            <span className='chaise-icon-for-tooltip align-center-icon'></span>
+          )}
+        </div>
+        <span className='facet-header-icon'></span>
+      </div>
+    </OverlayTrigger>
+  );
+};
+
+export default FacetHeader;

--- a/src/components/facet-header.tsx
+++ b/src/components/facet-header.tsx
@@ -8,33 +8,42 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 
-/**
- * @displayname content to be displayed as panel header
- * @showTooltipIcon Optional prop to enable tooltip for displayname
- * @comment Optional text to be shown on hover of displayname
- */
 type FacetHeaderProps = {
+  /**
+   * content to be displayed as panel header
+   */
   displayname: Displayname;
+  /**
+   * Optional prop to enable tooltip for displayname
+   */
   showTooltipIcon?: boolean;
+  /**
+   * Optional text to be shown on hover of displayname
+   */
   comment?: string;
 };
 
 /**
- * @returns {FacetHeader} Component that renders custom text (displayname) on facet header. 
+ * @returns {Component} FacetHeader Component that renders custom text (displayname) on facet header. 
  */
 const FacetHeader = ({
   displayname,
   showTooltipIcon=false,
   comment,
 }: FacetHeaderProps) => {
+
   /**
-   * @contentRef variable to store ref of facet header text
-   * @show state variable to control whether to show tooltip or not
+   * variable to store ref of facet header text
    */
   const contentRef = useRef(null);
+  /**
+   * state variable to control whether to show tooltip or not
+   */
   const [show, setShow] = useState(false);
 
-  // Function to check the text overflow.
+  /**
+   * Function to check the text overflow.
+   */
   const isTextOverflow = (element: HTMLElement) => {
     if (element) {
       return element.offsetWidth < element.scrollWidth;

--- a/src/components/facet-header.tsx
+++ b/src/components/facet-header.tsx
@@ -35,7 +35,7 @@ const FacetHeader = ({
   const [show, setShow] = useState(false);
 
   // Function to check the text overflow.
-  const isTextOverflow = (element) => {
+  const isTextOverflow = (element: HTMLElement) => {
     if (element) {
       return element.offsetWidth < element.scrollWidth;
     }
@@ -44,7 +44,6 @@ const FacetHeader = ({
 
   return (
     <OverlayTrigger
-      trigger='hover'
       placement='right'
       overlay={
         <Tooltip style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}>

--- a/src/components/facet-header.tsx
+++ b/src/components/facet-header.tsx
@@ -8,14 +8,19 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 
+/**
+ * @displayname content to be displayed as panel header
+ * @showTooltipIcon Optional prop to enable tooltip for displayname
+ * @comment Optional text to be shown on hover of displayname
+ */
 type FacetHeaderProps = {
-  displayname: Displayname; // content to be displayed as panel header
-  showTooltipIcon?: boolean; // prop to enable tooltip for displayname
-  comment?: string; // Optional text to be shown on hover of displayname
+  displayname: Displayname;
+  showTooltipIcon?: boolean;
+  comment?: string;
 };
 
 /**
- * @returns FacetHeader Component
+ * @returns {FacetHeader} Component that renders custom text (displayname) on facet header. 
  */
 const FacetHeader = ({
   displayname,

--- a/src/components/facet-header.tsx
+++ b/src/components/facet-header.tsx
@@ -6,26 +6,21 @@ import { useRef, useState } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 type FacetHeaderProps = {
-  key: string;
-  headerText: any;
-  showTooltipIcon: any;
-  tooltipContent: any;
+  displayname: Displayname; // content to be displayed as panel header
+  showTooltipIcon?: boolean; // prop to enable tooltip for displayname
+  comment?: string; // Optional text to be shown on hover of displayname
 };
 
 /**
- * @param key key prop to uniquely identify panel header item
- * @param headerText headerText prop that holds content to show as header
- * @param showTooltipIcon prop to enable tooltip for header text
- * @param tooltipContent text to be shown on hover of header text
  * @returns FacetHeader Component
  */
 const FacetHeader = ({
-  key,
-  headerText,
-  showTooltipIcon,
-  tooltipContent,
+  displayname,
+  showTooltipIcon=false,
+  comment,
 }: FacetHeaderProps) => {
   /**
    * @contentRef variable to store ref of facet header text
@@ -42,22 +37,22 @@ const FacetHeader = ({
     return false;
   };
 
+  const renderTooltipContent = () => {
+    if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && comment) {
+      return <><DisplayValue value={displayname} />: {comment}</>;
+    } else if (comment) {
+      return comment;
+    } else {
+      return <DisplayValue value={displayname} />;
+    }
+  }
+
   return (
     <OverlayTrigger
       placement='right'
       overlay={
         <Tooltip style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}>
-          {contentRef &&
-          contentRef.current &&
-          isTextOverflow(contentRef.current) ? (
-            <>
-              <DisplayValue value={headerText} />: {tooltipContent}
-            </>
-          ) : tooltipContent ? (
-            tooltipContent
-          ) : (
-            <DisplayValue value={headerText} />
-          )}
+          {renderTooltipContent()}
         </Tooltip>
       }
       onToggle={(nextshow: boolean) => {
@@ -71,9 +66,9 @@ const FacetHeader = ({
       }}
       show={show}
     >
-      <div className='accordion-toggle ellipsis' id={key}>
+      <div className='accordion-toggle ellipsis'>
         <div ref={contentRef} className='facet-header-text ellipsis'>
-          <DisplayValue value={headerText} />
+          <DisplayValue value={displayname} />
           {/* Condition to show tooltip icon */}
           {showTooltipIcon && (
             <span className='chaise-icon-for-tooltip align-center-icon'></span>

--- a/src/components/facet-header.tsx
+++ b/src/components/facet-header.tsx
@@ -37,6 +37,11 @@ const FacetHeader = ({
     return false;
   };
 
+  /**
+   * If header text overflowed, display tooltip on hover of header.
+   * If comment is present and header text overflowed, then display tooltip in <header text>: <comment> format
+   * @returns tooltip content that needs to be displayed on hover of panel header text
+   */
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && comment) {
       return <><DisplayValue value={displayname} />: {comment}</>;

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import Accordion from 'react-bootstrap/Accordion';
 import FacetChoicePicker from '@isrd-isi-edu/chaise/src/components/facet-choice-picker';
 import FacetRangePicker from '@isrd-isi-edu/chaise/src/components/facet-range-picker';
-import FacetHeader from '@isrd-isi-edu/chaise/src/components/FacetHeader';
+import FacetHeader from '@isrd-isi-edu/chaise/src/components/facet-header';
 
 // TODO subject to change
 type FacetingProps = {

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -15,6 +15,13 @@ type FacetingProps = {
   reference: any
 }
 
+type FacetHeaderProps = {
+  key: string,
+  headerText: any,
+  showTooltipIcon: any,
+  tooltipContent: any
+}
+
 const Faceting = ({
   reference
 }: FacetingProps) => {
@@ -37,7 +44,7 @@ const Faceting = ({
    * @param tooltipContent text to be shown on hover of header text
    * @returns FacetHeader Component
    */
-  const FacetHeader = ({ key, headerText, showTooltipIcon, tooltipContent }) => {
+  const FacetHeader = ({ key, headerText, showTooltipIcon, tooltipContent }: FacetHeaderProps) => {
     /**
      * @contentRef variable to store ref of facet header text
      * @show state variable to control whether to show tooltip or not

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -1,9 +1,11 @@
 import '@isrd-isi-edu/chaise/src/assets/scss/_faceting.scss';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Components
 import Accordion from 'react-bootstrap/Accordion';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import FacetChoicePicker from '@isrd-isi-edu/chaise/src/components/facet-choice-picker';
 import FacetRangePicker from '@isrd-isi-edu/chaise/src/components/facet-range-picker';
@@ -28,15 +30,66 @@ const Faceting = ({
     }
   };
 
+  /**
+   * 
+   * @param param0 prop that holds content to show as header
+   * @param param1 showTooltip prop to enable tooltip for header text
+   * @returns FacetHeader Component
+   */
+  const FacetHeader = ({ key, content, showTooltip, tooltipContent }) => {
+    /**
+     * @contentRef variable to store ref of facet header text
+     * @show state variable to control whether to show tooltip or not
+     */
+    const contentRef = useRef(null);
+    const [show, setShow] = useState(false);
+
+    // Function to check the text overflow.
+    const isTextOverflow = (element) => {
+      if (element) {
+        return (element.offsetWidth < element.scrollWidth);
+      }
+      return false; 
+    }
+    
+    return (
+      <OverlayTrigger
+        placement='right'
+        overlay={<Tooltip><DisplayValue value={tooltipContent} /></Tooltip>}
+        onToggle={(nextshow: boolean) => {
+          if (contentRef && contentRef.current) {
+            const isOverflow = isTextOverflow(contentRef.current);
+            // If either text overflow or showtooltip is true, show tooltip to right of the content
+            setShow((isOverflow || showTooltip) && nextshow);
+          }
+        }}
+        onExiting={() => {
+          setShow(false);
+        }}
+        show={show}
+      >
+        <div className='accordion-toggle ellipsis' id={key}>
+          <div ref={contentRef} className='facet-header-text ellipsis'>
+            <DisplayValue value={content} />
+            <span className='chaise-icon-for-tooltip align-center-icon'></span>
+          </div>
+          <span className='facet-header-icon'></span>
+        </div>
+      </OverlayTrigger>
+    );
+  };
+
   const renderFacets = () => {
     return reference.facetColumns.map((fc: any, index: number) => {
       return (
         <Accordion.Item eventKey={index + ''} key={index} className='facet-panel'>
           <Accordion.Header>
-            <div className='accordion-toggle ellipsis' id={'fc-heading-' + index}>
-              <span className='facet-header-text'><DisplayValue value={fc.displayname} /></span>
-              <span className='facet-header-icon'></span>
-            </div>
+              <FacetHeader 
+                key={`fc-heading-${index}`}
+                content={fc.displayname} 
+                showTooltip={true} 
+                tooltipContent={fc.displayname}
+              />
           </Accordion.Header>
           <Accordion.Body>
             {renderFacet(fc, index)}

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -1,25 +1,15 @@
 import '@isrd-isi-edu/chaise/src/assets/scss/_faceting.scss';
 
-import { useEffect, useRef, useState } from 'react';
-
+import { useEffect, useState } from 'react';
 // Components
 import Accordion from 'react-bootstrap/Accordion';
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import Tooltip from 'react-bootstrap/Tooltip';
-import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import FacetChoicePicker from '@isrd-isi-edu/chaise/src/components/facet-choice-picker';
 import FacetRangePicker from '@isrd-isi-edu/chaise/src/components/facet-range-picker';
+import FacetHeader from '@isrd-isi-edu/chaise/src/components/FacetHeader';
 
 // TODO subject to change
 type FacetingProps = {
   reference: any
-}
-
-type FacetHeaderProps = {
-  key: string,
-  headerText: any,
-  showTooltipIcon: any,
-  tooltipContent: any
 }
 
 const Faceting = ({
@@ -35,72 +25,6 @@ const Faceting = ({
       default:
         return <FacetChoicePicker facetColumn={fc} index={index}></FacetChoicePicker>
     }
-  };
-
-  /**
-   * @param key key prop to uniquely identify panel header item 
-   * @param headerText headerText prop that holds content to show as header
-   * @param showTooltipIcon prop to enable tooltip for header text
-   * @param tooltipContent text to be shown on hover of header text
-   * @returns FacetHeader Component
-   */
-  const FacetHeader = ({ key, headerText, showTooltipIcon, tooltipContent }: FacetHeaderProps) => {
-    /**
-     * @contentRef variable to store ref of facet header text
-     * @show state variable to control whether to show tooltip or not
-     */
-    const contentRef = useRef(null);
-    const [show, setShow] = useState(false);
-
-    // Function to check the text overflow.
-    const isTextOverflow = (element) => {
-      if (element) {
-        return (element.offsetWidth < element.scrollWidth);
-      }
-      return false; 
-    }
-
-    return (
-      <OverlayTrigger
-        trigger='hover'
-        placement='right'
-        overlay={
-          <Tooltip
-            style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}
-          >
-            {contentRef && contentRef.current && isTextOverflow(contentRef.current) ? (
-              <>
-                <DisplayValue value={headerText}/>
-                <br/>
-                {tooltipContent}
-              </>
-            ) : (tooltipContent ? tooltipContent : <DisplayValue value={headerText}/>)}
-          </Tooltip>
-        }
-        onToggle={(nextshow: boolean) => { 
-          
-          // Bootstrap onToggle prop to make tooltip visible or hidden
-          if (contentRef && contentRef.current) {
-            const isOverflow = isTextOverflow(contentRef.current);
-
-            // If either text overflow or showtooltip is true, show tooltip to right of the content
-            setShow((isOverflow || showTooltipIcon) && nextshow);
-          }
-        }}
-        show={show}
-      >
-        <div className='accordion-toggle ellipsis' id={key}>
-          <div ref={contentRef} className='facet-header-text ellipsis'>
-            <DisplayValue value={headerText} />
-            {/* Condition to show tooltip icon */}
-            {showTooltipIcon && (
-              <span className='chaise-icon-for-tooltip align-center-icon'></span>
-            )}
-          </div>
-          <span className='facet-header-icon'></span>
-        </div>
-      </OverlayTrigger>
-    );
   };
 
   const renderFacets = () => {

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -34,12 +34,11 @@ const Faceting = ({
           {/* TODO: On Click of header text in facet panel, because of the overlay 
             it wont trigger accordion to open. Aref is handling that part (handling accordion 
             open and close manually) */}
-          <Accordion.Header>
+          <Accordion.Header id={`fc-heading-${index}`}>
             <FacetHeader 
-              key={`fc-heading-${index}`}
-              headerText={fc.displayname} 
+              displayname={fc.displayname} 
               showTooltipIcon={fc.comment ? true : false} 
-              tooltipContent={fc.comment}
+              comment={fc.comment}
             />
           </Accordion.Header>
           <Accordion.Body>

--- a/src/components/faceting.tsx
+++ b/src/components/faceting.tsx
@@ -31,12 +31,13 @@ const Faceting = ({
   };
 
   /**
-   * 
-   * @param param0 prop that holds content to show as header
-   * @param param1 showTooltip prop to enable tooltip for header text
+   * @param key key prop to uniquely identify panel header item 
+   * @param headerText headerText prop that holds content to show as header
+   * @param showTooltipIcon prop to enable tooltip for header text
+   * @param tooltipContent text to be shown on hover of header text
    * @returns FacetHeader Component
    */
-  const FacetHeader = ({ key, content, showTooltip, tooltipContent }) => {
+  const FacetHeader = ({ key, headerText, showTooltipIcon, tooltipContent }) => {
     /**
      * @contentRef variable to store ref of facet header text
      * @show state variable to control whether to show tooltip or not
@@ -51,27 +52,43 @@ const Faceting = ({
       }
       return false; 
     }
-    
+
     return (
       <OverlayTrigger
+        trigger='hover'
         placement='right'
-        overlay={<Tooltip><DisplayValue value={tooltipContent} /></Tooltip>}
-        onToggle={(nextshow: boolean) => {
+        overlay={
+          <Tooltip
+            style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}
+          >
+            {contentRef && contentRef.current && isTextOverflow(contentRef.current) ? (
+              <>
+                <DisplayValue value={headerText}/>
+                <br/>
+                {tooltipContent}
+              </>
+            ) : (tooltipContent ? tooltipContent : <DisplayValue value={headerText}/>)}
+          </Tooltip>
+        }
+        onToggle={(nextshow: boolean) => { 
+          
+          // Bootstrap onToggle prop to make tooltip visible or hidden
           if (contentRef && contentRef.current) {
             const isOverflow = isTextOverflow(contentRef.current);
+
             // If either text overflow or showtooltip is true, show tooltip to right of the content
-            setShow((isOverflow || showTooltip) && nextshow);
+            setShow((isOverflow || showTooltipIcon) && nextshow);
           }
-        }}
-        onExiting={() => {
-          setShow(false);
         }}
         show={show}
       >
         <div className='accordion-toggle ellipsis' id={key}>
           <div ref={contentRef} className='facet-header-text ellipsis'>
-            <DisplayValue value={content} />
-            <span className='chaise-icon-for-tooltip align-center-icon'></span>
+            <DisplayValue value={headerText} />
+            {/* Condition to show tooltip icon */}
+            {showTooltipIcon && (
+              <span className='chaise-icon-for-tooltip align-center-icon'></span>
+            )}
           </div>
           <span className='facet-header-icon'></span>
         </div>
@@ -83,13 +100,16 @@ const Faceting = ({
     return reference.facetColumns.map((fc: any, index: number) => {
       return (
         <Accordion.Item eventKey={index + ''} key={index} className='facet-panel'>
+          {/* TODO: On Click of header text in facet panel, because of the overlay 
+            it wont trigger accordion to open. Aref is handling that part (handling accordion 
+            open and close manually) */}
           <Accordion.Header>
-              <FacetHeader 
-                key={`fc-heading-${index}`}
-                content={fc.displayname} 
-                showTooltip={true} 
-                tooltipContent={fc.displayname}
-              />
+            <FacetHeader 
+              key={`fc-heading-${index}`}
+              headerText={fc.displayname} 
+              showTooltipIcon={fc.comment ? true : false} 
+              tooltipContent={fc.comment}
+            />
           </Accordion.Header>
           <Accordion.Body>
             {renderFacet(fc, index)}


### PR DESCRIPTION
Changes pushed to panel-header branch are:
 Made sure the header looks the same as master (Old Angular).
 Made sure the header height and font is the same
 Made sure the "chevron" looks the same
 Conditionally added the class when the header has a comment (just like the columns in recordset-table.tsx)
 Made sure ellipsis should work properly:
     -- If the header has comment, always show the comment.
     -- Otherwise, if the ellipsis is displayed, the tooltip should show the header name.