### PR TITLE
mailto links prepended with unsafe

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -2496,7 +2496,7 @@
             // angular configurations
             // allows unsafe prefixes to be downloaded
             // full regex: "/^\s*(https?|ftp|mailto|tel|file|blob):/"
-            compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|blob):/);
+            compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|blob|mailto):/);
             cookiesProvider.defaults.path = '/';
             logProvider.debugEnabled(getConfigJSON().debug === true);
             // Configure all tooltips to be attached to the body by default. To attach a

--- a/test/e2e/specs/all-features/chaise-config.js
+++ b/test/e2e/specs/all-features/chaise-config.js
@@ -96,6 +96,11 @@ var chaiseConfig = {
                         ]
                     },
                     {
+                        name: "Help with Editing",
+                        url: "mailto:support@isrd.isi.edu.test",
+                        newTab: true
+                    },
+                    {
                         name: "No Show",
                         url: "/chaise/record/#1/isa:dataset/id=404",
                         newTab: false,

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -46,9 +46,9 @@ describe('Navbar ', function() {
     it('for the menu, should generate the correct # of list items based on acls to show/hide specific options', function() {
         var nodesInDOM = menu.all(by.tagName('li'));
         // Count the number of nodes that are being shown (top level and submenus)
-        //   - Local: config has 13 but 1 is hidden by ACLs
-        //   - CI: config has 13 but 7 are hidden based on ACLs
-        var counter = (!process.env.CI ? 12 : 6); // counted from chaise config doc rather than having code count
+        //   - Local: config has 14 but 1 is hidden by ACLs
+        //   - CI: config has 14 but 7 are hidden based on ACLs
+        var counter = (!process.env.CI ? 13 : 7); // counted from chaise config doc rather than having code count
 
         nodesInDOM.count().then(function(count) {
             expect(count).toEqual(counter, "number of nodes present does not match what's defined in chaise-config");
@@ -70,7 +70,7 @@ describe('Navbar ', function() {
     });
 
     if (!process.env.CI) {
-        var menuDropdowns, disabledSubMenuOptions;
+        var menuDropdowns, disabledSubMenuOptions, editMenu;
         it('should have a disabled "Records" link.', function () {
             menuDropdowns = element.all(by.css('#navbar-menu > li.dropdown'));
 
@@ -80,7 +80,7 @@ describe('Navbar ', function() {
         });
 
         it('should have a header and a disabled "Edit Existing Record" submenu link (no children).', function () {
-            var editMenu = menuDropdowns.get(3);
+            editMenu = menuDropdowns.get(3);
             // need to open menu so it renders and has a value
             editMenu.click().then(function () {
                 subMenuHeader = editMenu.all(by.css("span.chaise-dropdown-header"));
@@ -98,6 +98,14 @@ describe('Navbar ', function() {
         it('should have disabled "Edit Records" submenu link (has children)', function () {
             //menu should still be open from previous test case
             expect(disabledSubMenuOptions[1].getText()).toBe("Edit Records", "the wrong link is disabled or caret is still visible");
+        });
+
+        it('should have a "mailto:" link displayed properly', function () {
+            editMenu.all(by.css('a')).then(function (options) {
+                expect(options.length).toBe(7, 'some options are not shown properly');
+                expect(options[6].getText()).toBe('Help with Editing', 'Help link title is incorrect');
+                expect(chaisePage.navbar.getHrefValue(options[6])).toBe('mailto:support@isrd.isi.edu.test', 'mailto: link was incorrect')
+            });
         });
     }
 

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1291,6 +1291,10 @@ var navbar = function () {
         var banner = this.getBanner(key);
         return banner.element(by.css(".close"));
     }
+
+    this.getHrefValue = function(element) {
+        return browser.executeScript("return arguments[0].getAttribute('href');", element);
+    };
 }
 
 // Makes a string safe and valid for use in an HTML element's id attribute.


### PR DESCRIPTION
We decided to only enable `mailto` in our list of "sanitized" hrefs in angularJS. After closing this PR, the corresponding issue should remain open until this is implemented in react branch.

Linking issue #2202 here so it isn't automatically closed by attaching it to the "Development" option.