### PR TITLE
Edit delete

### DIFF
--- a/src/components/delete-confirmation-modal.tsx
+++ b/src/components/delete-confirmation-modal.tsx
@@ -15,19 +15,23 @@ type DeleteConfirmationModalProps = {
    * prop to trigger on cancel
    */
   onCancel: () => void;
+  /**
+   * children passed to the component
+   */
+  children: any
 };
 
 /**
  * returns Modal Component - Component that renders delete comfirmation dialog
  */
-const DeleteConfirmationModal = ({ show, onDeleteConfirmation, onCancel, ...props }: DeleteConfirmationModalProps) => {
+const DeleteConfirmationModal = ({ show, onDeleteConfirmation, onCancel, children }: DeleteConfirmationModalProps) => {
   return (
     <Modal show={show} onHide={onCancel} keyboard={false}>
       <Modal.Header>
         <Modal.Title>Confirm Delete</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <div className='modal-text'>{props && props.children}</div>
+        <div className='modal-text'>{children}</div>
       </Modal.Body>
       <Modal.Footer>
         <Button

--- a/src/components/delete-confirmation-modal.tsx
+++ b/src/components/delete-confirmation-modal.tsx
@@ -1,0 +1,52 @@
+import '@isrd-isi-edu/chaise/src/assets/scss/_export.scss';
+
+import { Button, Modal } from 'react-bootstrap';
+
+type DeleteConfirmationModalProps = {
+  /**
+   * prop to show modal
+   */
+  show: boolean;
+  /**
+   * prop to trigger on delete confirmation
+   */
+  onDeleteConfirmation: () => void;
+  /**
+   * prop to trigger on cancel
+   */
+  onCancel: () => void;
+};
+
+/**
+ * returns Modal Component - Component that renders delete comfirmation dialog
+ */
+const DeleteConfirmationModal = ({ show, onDeleteConfirmation, onCancel, ...props }: DeleteConfirmationModalProps) => {
+  return (
+    <Modal show={show} onHide={onCancel} keyboard={false}>
+      <Modal.Header>
+        <Modal.Title>Confirm Delete</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='modal-text'>{props && props.children}</div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          className='chaise-btn chaise-btn-danger'
+          variant='outline-primary'
+          onClick={onDeleteConfirmation}
+        >
+          Delete
+        </Button>
+        <Button
+          className='chaise-btn chaise-btn-secondary'
+          variant='outline-primary'
+          onClick={onCancel}
+        >
+          cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/src/components/table-row.tsx
+++ b/src/components/table-row.tsx
@@ -55,7 +55,10 @@ const TableRow = ({
    * state variable to open and close delete confirmation modal window
    */
   const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState<boolean>(false);
-
+  
+  /**
+   * state variable to hold logObj reference which will be used on Delete confirmation.
+   */
   const [logObj, setLogObj] = useState<any>(null);
 
   const rowContainer = useRef<any>(null);
@@ -125,17 +128,19 @@ const TableRow = ({
 
   const onDeleteConfirmation = () => {
     setShowDeleteConfirmationModal(false);
-    tuple.reference.delete(logObj).then(function deleteSuccess() {
-      // tell parent controller data updated
-      // scope.$emit('record-deleted', emmitedMessageArgs);
-      
-      // Later uncomment
-      // setShowDeleteConfirmationModal(false);
-    }).catch(function (error: any) {
-      // TODO: ask
-      // ErrorService.handleException(response, true);
-      onDeleteError(error);
-    });
+    if (logObj) {
+      tuple.reference.delete(logObj).then(function deleteSuccess() {
+        // tell parent controller data updated
+        // scope.$emit('record-deleted', emmitedMessageArgs);
+        
+        // Later uncomment
+        // setShowDeleteConfirmationModal(false);
+      }).catch(function (error: any) {
+        // TODO: ask
+        // ErrorService.handleException(response, true);
+        onDeleteError(error);
+      });
+    }
   }
 
   const onDeleteError = (error: any) => {
@@ -253,9 +258,6 @@ const TableRow = ({
       };
     }
   }
-  deleteCallback = function () {
-    deleteOrUnlink(tupleReference, isRelated);
-  };
 
   const readMore = () => {
     if (readMoreObj.hideContent) {

--- a/src/components/table-row.tsx
+++ b/src/components/table-row.tsx
@@ -6,7 +6,7 @@ import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 
 // models
 import { RecordsetConfig, RecordsetDisplayMode, RecordsetSelectMode } from '@isrd-isi-edu/chaise/src/models/recordset';
-import { LogParentActions } from '@isrd-isi-edu/chaise/src/models/log';
+import { LogActions, LogParentActions } from '@isrd-isi-edu/chaise/src/models/log';
 
 // services
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
@@ -14,6 +14,9 @@ import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utils
 import { addQueryParamsToURL } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
+import { windowRef } from '@isrd-isi-edu/chaise/src//utils/window-ref';
+import useRecordset from '@isrd-isi-edu/chaise/src//hooks/recordset';
+import { getRandomInt } from '@isrd-isi-edu/chaise/src//utils/math-utils';
 
 type TableRowProps = {
   config: RecordsetConfig,
@@ -47,6 +50,7 @@ const TableRow = ({
   })
 
   const rowContainer = useRef<any>(null);
+  const { logRecordsetClientAction } = useRecordset();
 
   const initializeOverflows = () => {
     // Iterate over each <td> in the <tr>
@@ -132,25 +136,21 @@ const TableRow = ({
   if (config.editable && tuple.canUpdate) {
     editCallback = function () {
       $log.debug('edit clicked!');
-      // TODO edit functionality
-      // var id = MathUtils.getRandomInt(0, Number.MAX_SAFE_INTEGER);
+      
+      const referrer_id = 'recordset-' + getRandomInt(0, Number.MAX_SAFE_INTEGER);
+      const newRef = tupleReference.contextualize?.entryEdit;
 
-      // var editLink = editLink = tupleReference.contextualize.entryEdit.appLink;
-      // var qCharacter = editLink.indexOf("?") !== -1 ? "&" : "?";
-      // $window.open(editLink + qCharacter + 'invalidate=' + UriUtils.fixedEncodeURIComponent(id), '_blank');
+      if (newRef) {
+        const editLink = addQueryParamsToURL(newRef.appLink, {
+          invalidate: referrer_id
+        });
 
-      // var args = {};
-      // if (isRelated) {
-      //   args = containerDetails(scope);
-      // }
-      // args.id = id;
-      // scope.$emit("edit-request", args);
+        windowRef.open(editLink, '_blank');
 
-      // TODO log support (can be ignored for now)
-      // logService.logClientAction({
-      //   action: getLogAction(scope, logService.logActions.EDIT_INTEND),
-      //   stack: scope.logStack
-      // }, tupleReference.defaultLogInfo);
+        logRecordsetClientAction(LogActions.EDIT_INTEND);
+      } else {
+        $log.debug('Error: reference is undefined or null');
+      }
     };
   }
 

--- a/src/utils/math-utils.ts
+++ b/src/utils/math-utils.ts
@@ -20,3 +20,15 @@ export function generateUUID(): string {
 function uuidS4() {
   return Math.floor((1 + Math.random()) * 0x10000).toString(36);
 }
+
+/**
+ * 
+ * @param min minimum number 
+ * @param max maximum number
+ * @returns random number generated
+ */
+ export function getRandomInt(min: number, max: number) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min)) + min;
+}


### PR DESCRIPTION
This PR has changes:

Related to "edit":
-       Clicking on edit should open the recordedit page with the proper query parameter.
-       For now, you don't need to worry about updating the recordset after the edit is done. I need to think more about it.

Related to "delete":
-  Depending on the confirmDelete chaise-config property, clicking the "delete" button should either send the request or show a confirmation modal.
- The confirmation modal should Specify the tuple.displayname of what the user is attempting to delete.
- Have a Cancel and close button like the master. There should be a callback for this function where we can later log the action.
- Have a delete button that will trigger the delete.

**PENDING:**
- For now, you don't need to worry about updating the recordset after the delete is done. I need to think more about it.
- Setting logStack property [here](https://github.com/informatics-isi-edu/chaise/blob/6ab7ac42abf0845645d7e2b2c4ccc8a335f4c64c/src/components/table-row.tsx#L148,L152)