### PR TITLE
React unlink pure and binary + record test cases stabilized

### DIFF
--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -102,6 +102,16 @@
   }
 }
 
+.search-popup {
+  ~ .modal-error-backdrop {
+    z-index: 1061;
+  }
+
+  ~ .modal-error {
+    z-index: 1066;
+  }
+}
+
 .modal-footer .chaise-btn {
   margin-left: 5px;
 }

--- a/src/components/alerts.tsx
+++ b/src/components/alerts.tsx
@@ -33,6 +33,7 @@ export const Alerts = (): JSX.Element => {
         <a onClick={() => login()}>Log in</a>{' to continue your privileged access. '}
         <OverlayTrigger
           placement='bottom-start'
+          trigger='hover'
           overlay={<Tooltip>{tooltipText}</Tooltip>}
         >
           <i className='chaise-icon chaise-info'></i>

--- a/src/components/export.tsx
+++ b/src/components/export.tsx
@@ -183,10 +183,11 @@ const Export = ({
     addAlert('Export request has been canceled.', ChaiseAlertType.WARNING);
   };
 
+  // nextShow is true when the dropdown is open
   const onDropdownToggle = (nextShow: boolean) => {
     // toggle the tooltip based on dropdown's inverse state
     setUseTooltip(!nextShow);
-    setShowTooltip(!nextShow);
+    if (nextShow === true) setShowTooltip(false);
 
     // log the action
     if (nextShow) {

--- a/src/components/export.tsx
+++ b/src/components/export.tsx
@@ -203,6 +203,7 @@ const Export = ({
         <OverlayTrigger
           placement='bottom' overlay={<Tooltip>{MESSAGE_MAP.tooltip.export}</Tooltip>}
           show={showTooltip} onToggle={(show) => setShowTooltip(useTooltip && show)}
+          trigger='hover'
         >
           <Dropdown.Toggle
             disabled={disabled || !!selectedOption || options.length === 0}

--- a/src/components/faceting/facet-header.tsx
+++ b/src/components/faceting/facet-header.tsx
@@ -86,6 +86,7 @@ const FacetHeader = ({
     <>
       <OverlayTrigger
         placement='right'
+        trigger='hover'
         overlay={
           <Tooltip style={{ maxWidth: '50%', whiteSpace: 'nowrap' }}>
             {renderTooltipContent()}
@@ -121,6 +122,7 @@ const FacetHeader = ({
           (facetHasTimeoutError || noConstraints) &&
           <OverlayTrigger
             placement='right'
+            trigger='hover'
             overlay={
               <Tooltip>
                 {noConstraints && <span>showing facet values without any constraints applied.</span>}

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -935,6 +935,7 @@ const FacetRangePicker = ({
 
     return (<OverlayTrigger
       placement='bottom'
+      trigger='hover'
       overlay={<Tooltip>Zoom</Tooltip>}
     >
       {zoomInButton}
@@ -956,6 +957,7 @@ const FacetRangePicker = ({
 
     return (<OverlayTrigger
       placement='bottom'
+      trigger='hover'
       overlay={<Tooltip>Unzoom</Tooltip>}
     >
       {zoomOutButton}
@@ -969,6 +971,7 @@ const FacetRangePicker = ({
           <div className='chaise-btn-group' style={{ 'zIndex': 1 }}>
             <OverlayTrigger
               placement='right'
+              trigger='hover'
               overlay={
                 <Tooltip>
                   {renderHistogramHelpTooltip()}
@@ -980,7 +983,7 @@ const FacetRangePicker = ({
             </OverlayTrigger>
             {renderZoomInButton()}
             {renderZoomOutButton()}
-            <OverlayTrigger placement='bottom' overlay={<Tooltip>Reset</Tooltip>}>
+            <OverlayTrigger placement='bottom' trigger='hover' overlay={<Tooltip>Reset</Tooltip>}>
               <button type='button' className='reset-plotly-button chaise-btn chaise-btn-primary chaise-btn-sm' onClick={resetPlot}>
                 <span className='fas fa-undo'></span>
               </button>

--- a/src/components/modals/delete-confirmation-modal.tsx
+++ b/src/components/modals/delete-confirmation-modal.tsx
@@ -1,4 +1,4 @@
-import Modal from 'react-bootstrap/Modal';
+  import Modal from 'react-bootstrap/Modal';
 
 type DeleteConfirmationModalProps = {
   /**
@@ -14,25 +14,29 @@ type DeleteConfirmationModalProps = {
    */
   onCancel: () => void;
   /**
-   * The confimration message
+   * The confirmation message
    */
-   message?: JSX.Element;
+  message?: JSX.Element;
   /**
    * button label prop
    */
   buttonLabel: string;
+  /**
+   * The modal title
+   */
+  title?: string;
 };
 
 /**
  * returns Modal Component - Component that renders delete comfirmation dialog
  */
-const DeleteConfirmationModal = ({ show, onConfirm, onCancel, message, buttonLabel }: DeleteConfirmationModalProps) => {
+const DeleteConfirmationModal = ({ show, onConfirm, onCancel, message, buttonLabel, title }: DeleteConfirmationModalProps) => {
   const renderedMessage = message ? message : <>Are you sure you want to delete this record?</>;
 
   return (
     <Modal size='sm' show={show} onHide={onCancel}>
       <Modal.Header>
-        <Modal.Title>Confirm Delete</Modal.Title>
+        <Modal.Title>{title ? title : 'Confirm Delete'}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <div className='modal-text'>{renderedMessage}</div>

--- a/src/components/modals/delete-confirmation-modal.tsx
+++ b/src/components/modals/delete-confirmation-modal.tsx
@@ -34,7 +34,12 @@ const DeleteConfirmationModal = ({ show, onConfirm, onCancel, message, buttonLab
   const renderedMessage = message ? message : <>Are you sure you want to delete this record?</>;
 
   return (
-    <Modal size='sm' show={show} onHide={onCancel}>
+    <Modal 
+      className='confirm-delete-modal' 
+      size='sm' 
+      show={show} 
+      onHide={onCancel}
+    >
       <Modal.Header>
         <Modal.Title>{title ? title : 'Confirm Delete'}</Modal.Title>
       </Modal.Header>

--- a/src/components/modals/recordset-modal.tsx
+++ b/src/components/modals/recordset-modal.tsx
@@ -51,7 +51,7 @@ export type RecordestModalProps = {
    * Note: the modal won't close on submit and if that's the expected behavior,
    * you should do it in this callback.
    */
-  onSubmit: (selectedRows: SelectedRow[], setModalSubmittedRows?: any) => void,
+  onSubmit: (selectedRows: SelectedRow[]) => void,
   /**
    * Whether we should show the submit spinner or not
    */
@@ -165,7 +165,7 @@ const RecordsetModal = ({
   };
 
   const submit = () => {
-    onSubmit(submittedRows, setSubmittedRows);
+    onSubmit(submittedRows);
   };
 
   const onCancelClick = () => {

--- a/src/components/modals/recordset-modal.tsx
+++ b/src/components/modals/recordset-modal.tsx
@@ -270,7 +270,7 @@ const RecordsetModal = ({
             <span>Link </span>
             <Title reference={recordsetProps.initialReference} />
             <span> to </span>
-            <Title reference={recordsetProps.parentReference} /><span>:</span>
+            <Title reference={recordsetProps.parentReference} /><span>: </span>
             <Title displayname={recordsetProps.parentTuple?.displayname} />
           </div>
         );
@@ -280,7 +280,7 @@ const RecordsetModal = ({
             <span>Unlink </span>
             <Title reference={recordsetProps.initialReference} />
             <span> from </span>
-            <Title reference={recordsetProps.parentReference} /><span>:</span>
+            <Title reference={recordsetProps.parentReference} /><span>: </span>
             <Title displayname={recordsetProps.parentTuple?.displayname} />
           </div>
         );

--- a/src/components/modals/recordset-modal.tsx
+++ b/src/components/modals/recordset-modal.tsx
@@ -51,7 +51,7 @@ export type RecordestModalProps = {
    * Note: the modal won't close on submit and if that's the expected behavior,
    * you should do it in this callback.
    */
-  onSubmit: (selectedRows: SelectedRow[]) => void,
+  onSubmit: (selectedRows: SelectedRow[], setModalSubmittedRows?: any) => void,
   /**
    * Whether we should show the submit spinner or not
    */
@@ -165,7 +165,7 @@ const RecordsetModal = ({
   };
 
   const submit = () => {
-    onSubmit(submittedRows);
+    onSubmit(submittedRows, setSubmittedRows);
   };
 
   const onCancelClick = () => {

--- a/src/components/navbar/login.tsx
+++ b/src/components/navbar/login.tsx
@@ -189,6 +189,7 @@ const ChaiseLogin = (): JSX.Element => {
     if (enableUserTooltip && showUserTooltip) {
       return (<OverlayTrigger
         placement='bottom-end'
+        trigger='hover'
         overlay={<Tooltip>{userTooltip}</Tooltip>}
       >
         {dropdownToggleComponent}

--- a/src/components/record/record.tsx
+++ b/src/components/record/record.tsx
@@ -709,7 +709,7 @@ const RecordInner = ({
                   tooltip='Click to hide table of contents'
                 >
                   <button
-                    className='chaise-btn chaise-btn-tertiary'
+                    className='chaise-btn chaise-btn-tertiary hide-toc-btn'
                     onClick={hidePanel}
                   >
                     <span className='chaise-btn-icon chaise-icon chaise-sidebar-close'></span>

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -269,7 +269,7 @@ const RelatedTableActions = ({
 
     setAddPureBinaryModalProps({
       initialReference: modalReference,
-      initialPageLimit: RECORDSET_DEAFULT_PAGE_SIZE,
+      initialPageLimit: modalReference.display.defaultPageSize ? modalReference.display.defaultPageSize :  RECORDSET_DEAFULT_PAGE_SIZE,
       config: recordsetConfig,
       logInfo,
       getDisabledTuples,
@@ -313,7 +313,7 @@ const RelatedTableActions = ({
       deletable: false,
       sortable: true,
       selectMode: RecordsetSelectMode.MULTI_SELECT,
-      showFaceting: false,
+      showFaceting: true,
       disableFaceting: false,
       displayMode: RecordsetDisplayMode.PURE_BINARY_POPUP_UNLINK
     };
@@ -439,7 +439,7 @@ const RelatedTableActions = ({
         tooltip = <span>Display edit controls for {currentTable} related to this {mainTable}.</span>;
         label = 'Edit mode';
       } else {
-        tooltip = <span>Displayed related {currentTable} in tabular mode.</span>
+        tooltip = <span>Display related {currentTable} in tabular mode.</span>
         label = 'Table mode';
       }
     } else {
@@ -464,13 +464,13 @@ const RelatedTableActions = ({
   const renderCreateBtnTooltip = () => {
     if (relatedModel.canCreateDisabled) {
       const keyset = relatedModel.initialReference.origFKR.key.colset.columns;
-      let keysetString = '';
+      let keysetString: string | JSX.Element = '';
       keyset.forEach(function (col: any, idx: number) {
         keysetString += col.name;
         if (idx + 1 !== keyset.length) keysetString += ', ';
       });
 
-      keysetString = `<code>${keysetString}</code>`;
+      keysetString = <code>keysetString</code>;
       if (relatedModel.isPureBinary) {
         return <span>Unable to connect to {currentTable} records until {keysetString} in this {mainTable} is set.</span>;
       }

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -372,7 +372,14 @@ const RelatedTableActions = ({
 
             // TODO:
             // updateRecordPage(true, LogReloadCauses.RELATED_BATCH_UNLINK);
-            // recordTableUtils.update(searchPopupTableModel, true, true, true, false, logService.reloadCauses.BATCH_UNLINK);
+
+            // ask recordset to update the modal
+            if (!!container.current) {
+              fireCustomEvent(CUSTOM_EVENTS.FORCE_UPDATE_RECORDSET, container.current, {
+                cause: LogReloadCauses.ENTITY_BATCH_UNLINK,
+                pageStates: { updateResult: true, updateCount: true, updateFacets: true }
+              });
+            }
           }
 
           // TODO: - improve partial success and use TRS to check delete rights before giving a checkbox

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -63,6 +63,7 @@ const RelatedTableHeader = ({
     <div className='rt-section-header'>
       <OverlayTrigger
         placement='top'
+        trigger='hover'
         overlay={<Tooltip>{renderTooltipContent()}</Tooltip>}
         onToggle={(nextshow: boolean) => {
           // Bootstrap onToggle prop to make tooltip visible or hidden

--- a/src/components/recordset/filter-chiclet.tsx
+++ b/src/components/recordset/filter-chiclet.tsx
@@ -70,6 +70,7 @@ const FilterChiclet = ({
       {/* icon */}
       <OverlayTrigger
         placement='bottom-start'
+        trigger='hover'
         overlay={<Tooltip>{iconTooltip}</Tooltip>}
       >
         <IconTag
@@ -84,7 +85,7 @@ const FilterChiclet = ({
         <ConditionalWrapper
           condition={titleTooltip !== undefined}
           wrapper={children => (
-            <OverlayTrigger placement='bottom-start' overlay={<Tooltip>{titleTooltip}</Tooltip>}>
+            <OverlayTrigger placement='bottom-start' trigger='hover' overlay={<Tooltip>{titleTooltip}</Tooltip>}>
               {children}
             </OverlayTrigger>
           )}
@@ -100,6 +101,7 @@ const FilterChiclet = ({
       {/* value */}
       <OverlayTrigger
         placement='bottom-start'
+        trigger='hover'
         overlay={<Tooltip>{valueTooltip ? valueTooltip : usedValue}</Tooltip>}
       >
         <span className='filter-chiclet-value chaise-btn chaise-btn-secondary'>{usedValue}</span>

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -124,7 +124,8 @@ const RecordsetTable = ({
           res.push({
             displayname: tuple.displayname,
             uniqueId: tuple.uniqueId,
-            data: tuple.data
+            data: tuple.data,
+            tupleReference: tuple.reference
           });
         }
       });
@@ -159,7 +160,7 @@ const RecordsetTable = ({
       // if it's currently selected, then we should deselect (and vice versa)
       const isSelected = rowIndex !== -1;
       if (!isSelected) {
-        res.push({ displayname: tuple.displayname, uniqueId: tuple.uniqueId, data: tuple.data });
+        res.push({ displayname: tuple.displayname, uniqueId: tuple.uniqueId, data: tuple.data, tupleReference: tuple.reference });
       } else {
         res.splice(rowIndex, 1);
       }

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -288,10 +288,14 @@ const RecordsetInner = ({
     window.removeEventListener(CUSTOM_EVENTS.ADD_INTEND, onAddIntend);
     window.addEventListener(CUSTOM_EVENTS.ADD_INTEND, onAddIntend);
 
+    window.removeEventListener(CUSTOM_EVENTS.FORCE_UPDATE_RECORDSET, forceUpdate);
+    window.addEventListener(CUSTOM_EVENTS.FORCE_UPDATE_RECORDSET, forceUpdate);
+
     window.removeEventListener('focus', onFocus);
     window.addEventListener('focus', onFocus);
     return () => {
       window.removeEventListener(CUSTOM_EVENTS.ADD_INTEND, onAddIntend);
+      window.removeEventListener(CUSTOM_EVENTS.FORCE_UPDATE_RECORDSET, forceUpdate);
       window.removeEventListener('focus', onFocus);
     };
   }, [update]);
@@ -373,7 +377,18 @@ const RecordsetInner = ({
    */
   windowRef.updated = () => {
     editRequestIsDone.current = true;
-  }
+  };
+
+  /**
+   * call the update function
+   */
+  const forceUpdate = ((event: CustomEvent) => {
+    const cause = event.detail.cause;
+    const pageStates = event.detail.pageStates;
+    if (!!cause && !!pageStates) {
+      update(pageStates, null, { cause});
+    }
+  }) as EventListener;
 
   //------------------- UI related callbacks: --------------------//
 

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -385,7 +385,28 @@ const RecordsetInner = ({
   const forceUpdate = ((event: CustomEvent) => {
     const cause = event.detail.cause;
     const pageStates = event.detail.pageStates;
+    const unlinkResponse = event.detail.response;
     if (!!cause && !!pageStates) {
+      if (!!unlinkResponse) {
+        if (unlinkResponse.failedTupleData.length > 0) {
+          // iterate over the set of successful ids and find them in selected rows, then remove them
+          unlinkResponse.successTupleData.forEach((data: any) => {
+            // data is an object of key/value pairs for each piece of key information
+            // { keycol1: val, keycol2: val2, ... }
+            const idx = selectedRows.findIndex((tuple: any) => {
+              return Object.keys(data).every((key) => {
+                return tuple.data[key] == data[key]
+              });
+            });
+
+            selectedRows.splice(idx, 1);
+          });
+          setSelectedRows([...selectedRows]);
+        } else {
+          // if everything is successful, empty selected rows
+          setSelectedRows([]);
+        }
+      }
       update(pageStates, null, { cause});
     }
   }) as EventListener;

--- a/src/components/search-input.tsx
+++ b/src/components/search-input.tsx
@@ -186,6 +186,7 @@ const SearchInput = ({
       <div className='chaise-input-group-append'>
         <OverlayTrigger
           placement='bottom-start'
+          trigger='hover'
           overlay={
             <Tooltip>
               <p>Use space to separate between conjunctive terms, | (no spaces) to separate disjunctive terms and quotations for exact phrases.</p>

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -59,6 +59,7 @@ const Title = ({
     return (
       <OverlayTrigger
         placement='bottom-start'
+        trigger='hover'
         overlay={<Tooltip>{comment}</Tooltip>}
       >
         {renderLinkOrContainer()}

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -32,6 +32,7 @@ const ChaiseTooltip = ({
   return (
     <OverlayTrigger
       placement={placement}
+      trigger='hover'
       overlay={
         <Tooltip className={className}>
           {tooltip}

--- a/src/models/recordset.ts
+++ b/src/models/recordset.ts
@@ -141,6 +141,7 @@ export type SelectedRow = {
   displayname: Displayname;
   uniqueId: string | null;
   data?: any; // TODO
+  tupleReference: any; // TODO
   // the following can be added for plot app and might require change:
   // cannotBeRemoved?: boolean;
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -139,6 +139,7 @@ const LoginPopupApp = (): JSX.Element => {
         <div className='btn-container'>
           <OverlayTrigger
             placement='bottom-start'
+            trigger='hover'
             overlay={<Tooltip>Click to sign up for {cc.termsAndConditionsConfig.groupName}.</Tooltip>}
           >
             <a className='chaise-btn chaise-btn-primary'
@@ -149,6 +150,7 @@ const LoginPopupApp = (): JSX.Element => {
           </OverlayTrigger>
           <OverlayTrigger
             placement='bottom-start'
+            trigger='hover'
             overlay={<Tooltip>Click to proceed to the application after joining the group.</Tooltip>}
           >
             <button className='chaise-btn chaise-btn-secondary'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -141,8 +141,9 @@ export const DEFAULT_DISPLAYNAME = {
 export const CUSTOM_EVENTS = {
   ROW_EDIT_INTEND: 'row-edit-intend',
   ROW_DELETE_SUCCESS: 'row-delete-success',
-  ADD_INTEND: 'add-intend'
-}
+  ADD_INTEND: 'add-intend',
+  FORCE_UPDATE_RECORDSET: 'force-update-recordset-data',
+};
 
 const isIEOrEdge = /msie\s|trident\/|edge\//i.test(window.navigator.userAgent);
 export const URL_PATH_LENGTH_LIMIT = (isIEOrEdge) ? 2000 : 4000;

--- a/test/e2e/specs/all-features-confirmation/navbar/no-logo.spec.js
+++ b/test/e2e/specs/all-features-confirmation/navbar/no-logo.spec.js
@@ -263,7 +263,6 @@ describe('Navbar ', function() {
     xit('should display a "Log Out" link', function() {
         var logOutLink = element(by.id('logout-link'));
         browser.wait(EC.elementToBeClickable(logOutLink), browser.params.defaultTimeout).then(function() {
-            browser.ignoreSynchronization = true;
             expect(logOutLink.isDisplayed()).toBeTruthy();
         });
     }).pend("Pending until we handle tests logging in via Globus/other services");

--- a/test/e2e/specs/all-features-confirmation/record/create-btn.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/create-btn.spec.js
@@ -17,9 +17,8 @@ describe('View existing record,', function() {
         beforeAll(function() {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-create-btn:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             table = browser.params.defaultSchema.content.tables[testParams.table_name];
             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
         });

--- a/test/e2e/specs/all-features-confirmation/record/delete-btn.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/delete-btn.spec.js
@@ -17,9 +17,8 @@ describe('View existing record,', function() {
         beforeAll(function() {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-delete-btn:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             table = browser.params.defaultSchema.content.tables[testParams.table_name];
             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
         });

--- a/test/e2e/specs/all-features-confirmation/record/edit-btn.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/edit-btn.spec.js
@@ -17,9 +17,8 @@ describe('View existing record,', function() {
         beforeAll(function () {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-edit-btn:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             table = browser.params.defaultSchema.content.tables[testParams.table_name];
             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
         });

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -204,9 +204,8 @@ describe('View existing record,', function() {
         beforeAll(function() {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
         });
 
@@ -253,9 +252,8 @@ describe('View existing record,', function() {
         beforeAll(function() {
             var keys = [];
             keys.push(testParams.no_related_data.key.name + testParams.no_related_data.key.operator + testParams.no_related_data.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-record:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url)
             chaisePage.recordPageReady();
         });
 
@@ -289,8 +287,7 @@ describe('View existing record,', function() {
 
         beforeAll(function() {
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.sidePanelTest.schemaName + ":" + testParams.sidePanelTest.tableName +  "/id=" + testParams.sidePanelTest.id;
-            browser.ignoreSynchronization=true;
-            browser.get(url);
+            chaisePage.navigate(url);
             recSidePanelCat_5 = chaisePage.recordPage.getSidePanelItemById(5);
             hideTocBtn = chaisePage.recordPage.getHideTocBtn();
             chaisePage.waitForElement(hideTocBtn);

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -282,8 +282,7 @@ describe('View existing record,', function() {
         });
     });
 
-    // TODO test table of contents
-    xdescribe("For side panel table of contents in Record App", function() {
+    describe("For side panel table of contents in Record App", function() {
 
         beforeAll(function() {
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.sidePanelTest.schemaName + ":" + testParams.sidePanelTest.tableName +  "/id=" + testParams.sidePanelTest.id;
@@ -299,7 +298,7 @@ describe('View existing record,', function() {
         });
 
         it('On click of Related table name in TOC, page should move to the contents and open the table details', function(done){
-            var rtTableHeading = chaisePage.recordPage.getRelatedTableAccordion(testParams.sidePanelTest.tableToShow);
+            var rtTableHeading = chaisePage.recordPage.getRelatedTableAccordion(testParams.sidePanelTest.tableToShow).element(by.css('.accordion-collapse'));
 
             browser.wait(EC.elementToBeClickable(recSidePanelCat_5), browser.params.defaultTimeout);
             recSidePanelCat_5.click().then(function(className) {
@@ -307,7 +306,7 @@ describe('View existing record,', function() {
                 expect(rtTableHeading.isDisplayed()).toBeTruthy("Category_5 heading is not visible.");
                 return rtTableHeading.getAttribute("class");
             }).then (function(className) {
-                expect(className).toContain("panel-open", "Related table panel is not open when clicked through TOC.");
+                expect(className).toContain("show", "Related table panel is not open when clicked through TOC.");
                 done();
             }).catch( function(err) {
                 console.log(err);
@@ -317,12 +316,17 @@ describe('View existing record,', function() {
 
         it('Record count along with heading should match for the panel and related table content should be in correct order', function(done){
             chaisePage.recordPage.getSidePanelTableTitles().then(function(tableNames){
-                for (var i=0; i<tableNames.length; i++){
-                    tableNames[i] = tableNames[i].replace(/ +/g, " ");
-                }
-                expect(tableNames.length).toEqual(testParams.sidePanelTest.tocCount, "Count mismatch for number of related tables in the side panel");
-                expect(tableNames).toEqual(testParams.sidePanelTest.sidePanelTableOrder, "Order is not maintained for related tables in the side panel");
+                // for (var i=0; i<tableNames.length; i++){
+                //     tableNames[i] = tableNames[i].replace(/ +/g, " ");
+                // }
 
+                expect(tableNames.length).toEqual(testParams.sidePanelTest.tocCount, "Count mismatch for number of related tables in the side panel");
+                tableNames.forEach(function (tableName, idx) {
+                    tableName.getText().then(function (name) {
+                        expect(name.replace(/ +/g, " ")).toEqual(testParams.sidePanelTest.sidePanelTableOrder[idx], "Order is not maintained for related tables in the side panel");
+                    }); 
+                })
+                
                 done();
             }).catch( function(err) {
                 console.log(err);

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -268,11 +268,11 @@ describe('View recordset,', function () {
                 chaisePage.waitForAggregates();
             });
 
-            it ("should not show the total count if hide_row_count is true.", function () {
-                expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying all\n"+ activeListData.length + "\nrecords", "hide_row_count not honored");
+            it("should not show the total count if hide_row_count is true.", function () {
+                expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying all\n" + activeListData.length + "\nrecords", "hide_row_count not honored");
             });
 
-            it ("should show correct table rows.", function (done) {
+            it("should show correct table rows.", function (done) {
                 chaisePage.recordsetPage.getRows().then(function (rows) {
                     expect(rows.length).toBe(activeListData.length, "row length missmatch.");
                     rows.forEach(function (row, rowIndex) {
@@ -296,7 +296,7 @@ describe('View recordset,', function () {
                 }).catch(chaisePage.catchTestError(done));
             });
 
-            it ("going to a page with no results, the loader for columns should hide.", function (done) {
+            it("going to a page with no results, the loader for columns should hide.", function (done) {
                 chaisePage.navigate(browser.params.url + "/recordset/#" + browser.params.catalogId + "/" + activeListParams.schemaName + ":" + activeListParams.table_name + "/main_id=03");
                 chaisePage.recordsetPageReady()
                 chaisePage.waitForAggregates();
@@ -393,11 +393,11 @@ describe('View recordset,', function () {
                 });
             });
 
-            it("should show correct table rows", function() {
-                chaisePage.recordsetPage.getRows().then(function(rows) {
+            it("should show correct table rows", function () {
+                chaisePage.recordsetPage.getRows().then(function (rows) {
                     expect(rows.length).toBe(4, "rows length missmatch.");
                     for (var i = 0; i < rows.length; i++) {
-                        (function(index) {
+                        (function (index) {
                             rows[index].all(by.tagName("td")).then(function (cells) {
                                 expect(cells.length).toBe(accommodationParams.columns.length + 1, "cells length missmatch for row=" + index);
                                 expect(cells[1].getText()).toBe(accommodationParams.data[index].title, "title column missmatch for row=" + index);
@@ -433,19 +433,16 @@ describe('View recordset,', function () {
                 });
             });
 
-            it("should display the Export dropdown button with proper tooltip.", function(done) {
+            it("should display the Export dropdown button with proper tooltip.", function (done) {
                 const exportDropdown = chaisePage.recordsetPage.getExportDropdown();
                 expect(exportDropdown.isDisplayed()).toBe(true, "The export dropdown button is not visible on the recordset app");
-                browser.actions().mouseMove(exportDropdown).perform();
-                var tooltip = chaisePage.getTooltipDiv();
-                chaisePage.waitForElement(tooltip).then(function () {
-                    expect(tooltip.getText()).toBe(testParams.tooltip.exportDropdown, "Incorrect tooltip on the export dropdown button");
-                    browser.actions().mouseMove(chaisePage.recordsetPage.getTotalCount()).perform();
-                    done();
-                }).catch(function (err) {
-                    console.log(err);
-                    done.fail();
-                });
+
+                chaisePage.testTooltipWithDone(
+                    exportDropdown,
+                    testParams.tooltip.exportDropdown,
+                    done,
+                    'recordset'
+                );
             });
 
             it("should have '2' options in the dropdown menu.", function (done) {
@@ -464,14 +461,14 @@ describe('View recordset,', function () {
             });
 
             if (!process.env.CI) {
-                it("should have 'CSV' as a download option and download the file.", function(done) {
+                it("should have 'CSV' as a download option and download the file.", function (done) {
                     const exportDropdown = chaisePage.recordsetPage.getExportDropdown();
                     exportDropdown.click().then(function () {
                         const csvOption = element(by.partialLinkText('Search results (CSV)'));
                         expect(csvOption.getText()).toBe("Search results (CSV)");
                         return csvOption.click();
                     }).then(function () {
-                        browser.wait(function() {
+                        browser.wait(function () {
                             return fs.existsSync(process.env.PWD + "/test/e2e/Accommodations.csv");
                         }, browser.params.defaultTimeout).then(function () {
                             done();
@@ -484,7 +481,7 @@ describe('View recordset,', function () {
                     });
                 });
 
-                it("should have 'BDBag' as a download option and download the file.", function(done) {
+                it("should have 'BDBag' as a download option and download the file.", function (done) {
                     const exportDropdown = chaisePage.recordsetPage.getExportDropdown();
                     exportDropdown.click().then(function () {
                         const bagOption = chaisePage.recordsetPage.getExportOption("BDBag");
@@ -495,7 +492,7 @@ describe('View recordset,', function () {
                     }).then(function () {
                         return chaisePage.waitForElementInverse(chaisePage.recordsetPage.getExportModal());
                     }).then(function () {
-                        return browser.wait(function() {
+                        return browser.wait(function () {
                             return fs.existsSync(process.env.PWD + "/test/e2e/accommodation.zip");
                         }, browser.params.defaultTimeout);
                     }).then(function () {
@@ -512,26 +509,26 @@ describe('View recordset,', function () {
                 });
                 chaisePage.recordsetPage.getColumnsWithTooltipIcon().then(function (pageColumns) {
                     expect(pageColumns.length).toBe(columns.length);
-                    var index = 0;
-                    pageColumns.forEach(function (c, index) {
-                        var comment = columns[index++].comment;
 
-                        const testColumnTooltip = (idx) => {
-                            if (index === pageColumns.length) {
-                                return;
-                            }
-              
-                            chaisePage.testTooltipReturnPromise(c, comment, 'recordset').then(() => {
-                                testColumnTooltip(index + 1);
-                            }).catch((err) => {
-                                done.fail(err);
-                            })
-                        };
-              
-                        testColumnTooltip(index);
-                    });
+                    const testColumnTooltip = (index) => {
+                        if (index === pageColumns.length) {
+                            done(); return;
+                        }
+
+                        var columnElement = pageColumns[index]
+                        var comment = columns[index].comment;
+                        chaisePage.testTooltipReturnPromise(columnElement, comment, 'recordset').then(() => {
+                            testColumnTooltip(index + 1);
+                        }).catch((err) => {
+                            done.fail(err);
+                        })
+                    };
+
+                    testColumnTooltip(0);
                 });
+            });
 
+            it("have coorect tooltip for action column", function (done) {
                 // Check tooltip of Action column
                 var actionCol = chaisePage.recordsetPage.getActionHeaderSpan();
                 chaisePage.testTooltipWithDone(

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -358,17 +358,16 @@ describe('View recordset,', function () {
                 });
             });
 
-            it('should display the permalink button & a tooltip on hovering over it', function () {
+            it('should display the permalink button & a tooltip on hovering over it', function (done) {
                 var permalink = chaisePage.recordsetPage.getPermalinkButton();
                 expect(permalink.isDisplayed()).toBe(true, "The permalink button is not visible on the recordset app");
-                browser.actions().mouseMove(permalink).perform();
-                var tooltip = chaisePage.getTooltipDiv();
-                chaisePage.waitForElement(tooltip).then(function () {
-                    expect(tooltip.getText()).toBe(testParams.tooltip.permalink, "Incorrect tooltip on the Permalink button");
-                    browser.actions().mouseMove(chaisePage.recordsetPage.getTotalCount()).perform();
-                }).catch(function (err) {
-                    console.log(err);
-                });
+
+                chaisePage.testTooltipWithDone(
+                    permalink,
+                    testParams.tooltip.permalink,
+                    done,
+                    'recordset'
+                );
             });
 
             it("should autofocus on search box", function () {
@@ -507,44 +506,40 @@ describe('View recordset,', function () {
                 });
             }
 
-            it("should show information icon next in column headers which have a comment and inspect the comment value", function () {
+            it("should show information icon next in column headers which have a comment and inspect the comment value", function (done) {
                 var columns = accommodationParams.columns.filter(function (c) {
                     return typeof c.comment == 'string';
                 });
                 chaisePage.recordsetPage.getColumnsWithTooltipIcon().then(function (pageColumns) {
                     expect(pageColumns.length).toBe(columns.length);
                     var index = 0;
-                    pageColumns.forEach(function (c) {
+                    pageColumns.forEach(function (c, index) {
                         var comment = columns[index++].comment;
 
-                        // hover over column header
-                        browser.actions().mouseMove(c).perform();
-
-                        var tooltip = chaisePage.getTooltipDiv();
-                        chaisePage.waitForElement(tooltip).then(function () {
-                            expect(tooltip.getText()).toBe(comment);
-                            // move cursor to hide tooltip
-                            return browser.actions().mouseMove(chaisePage.recordsetPage.getTotalCount()).perform();
-                        }).then(function () {
-                            chaisePage.waitForElementInverse(tooltip);
-                        }).catch(function (err) {
-                            console.log(err);
-                        });
+                        const testColumnTooltip = (idx) => {
+                            if (index === pageColumns.length) {
+                                return;
+                            }
+              
+                            chaisePage.testTooltipReturnPromise(c, comment, 'recordset').then(() => {
+                                testColumnTooltip(index + 1);
+                            }).catch((err) => {
+                                done.fail(err);
+                            })
+                        };
+              
+                        testColumnTooltip(index);
                     });
                 });
 
                 // Check tooltip of Action column
                 var actionCol = chaisePage.recordsetPage.getActionHeaderSpan();
-                browser.actions().mouseMove(actionCol).perform();
-
-                var tooltip = chaisePage.getTooltipDiv();
-                chaisePage.waitForElement(tooltip).then(function () {
-                    expect(tooltip.getText()).toBe(testParams.tooltip.actionCol);
-                    // move cursor to hide tooltip
-                    browser.actions().mouseMove(chaisePage.recordsetPage.getTotalCount()).perform();
-                }).catch(function (err) {
-                    console.log(err);
-                });
+                chaisePage.testTooltipWithDone(
+                    actionCol,
+                    testParams.tooltip.actionCol,
+                    done,
+                    'recordset'
+                );
             });
 
             it("apply different searches, ", function (done) {

--- a/test/e2e/specs/all-features/navbar/base-config.spec.js
+++ b/test/e2e/specs/all-features/navbar/base-config.spec.js
@@ -187,7 +187,6 @@ describe('Navbar ', function() {
     xit('should display a "Log Out" link', function(done) {
         var logOutLink = element(by.id('logout-link'));
         browser.wait(EC.elementToBeClickable(logOutLink), browser.params.defaultTimeout).then(function() {
-            browser.ignoreSynchronization = true;
             expect(logOutLink.isDisplayed()).toBeTruthy();
             done();
         });

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -1,3 +1,4 @@
+const { browser } = require('protractor');
 var chaisePage = require('../../../utils/chaise.page.js');
 var recordHelpers = require('../../../utils/record-helpers.js');
 var recordSetHelpers = require('../../../utils/recordset-helpers.js');
@@ -33,10 +34,9 @@ describe('View existing record,', function() {
 
         beforeAll(function() {
             var keys = [];
-            browser.ignoreSynchronization = true;
             keys.push(relatedTableTestParams.key.name + relatedTableTestParams.key.operator + relatedTableTestParams.key.value);
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/product-max-RT:" + relatedTableTestParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             chaisePage.recordPageReady();
         });
 
@@ -56,9 +56,13 @@ describe('View existing record,', function() {
         });
 
         // TODO test table of contents
-        // it('should hide empty related tables on load',function(){
-        //     expect(chaisePage.recordPage.getSidePanelTableTitles()).toEqual(testParams.tocHeaders, "list of related tables in toc is incorrect");
-        // });
+        it('should hide empty related tables on load',function(){
+            chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
+                headings.forEach(function (heading, idx) {
+                    expect(heading.getText()).toEqual(testParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");
+                })
+            })
+        });
 
     });
 
@@ -68,8 +72,7 @@ describe('View existing record,', function() {
         var currentBrowserUrl;
         beforeAll(function() {
             var keys = [];
-            browser.ignoreSynchronization=true;
-            browser.get(testParams.html_table_name_record_url);
+            chaisePage.navigate(testParams.html_table_name_record_url);
             chaisePage.recordPageReady();
         });
 
@@ -91,12 +94,12 @@ describe('View existing record,', function() {
         });
 
         // TODO test table of contents
-        // it("should hide the column headers and collapse the table of contents based on table-display annotation.", function () {
-        //     chaisePage.recordPage.getColumns().then(function (cols) {
-        //         expect(cols[0].isDisplayed()).toBeFalsy("Column names are showing.");
-        //         expect(chaisePage.recordPage.getSidePanel().getAttribute("class")).toContain('close-panel', 'Side Panel is visible.');
-        //     });
-        // });
+        it("should hide the column headers and collapse the table of contents based on table-display annotation.", function () {
+            chaisePage.recordPage.getColumns().then(function (cols) {
+                expect(cols[0].isDisplayed()).toBeFalsy("Column names are showing.");
+                expect(chaisePage.recordPage.getSidePanel().getAttribute("class")).toContain('close-panel', 'Side Panel is visible.');
+            });
+        });
 
         // test that no citation appears in share modal when no citation is defined on table
         // and also version link is not displayed when the table doesn't support history
@@ -165,9 +168,8 @@ describe('View existing record,', function() {
             testParams.keys.forEach(function(key) {
                 keys.push(key.name + key.operator + key.value);
             });
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/editable-id:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
             chaisePage.recordPageReady();
         });
 
@@ -178,12 +180,15 @@ describe('View existing record,', function() {
         });
 
         it ("should not have the default csv export option and only the defined template should be available", function (done) {
-            chaisePage.recordsetPage.getExportDropdown().click().then(function () {
+            const exportDropdown = chaisePage.recordsetPage.getExportDropdown()
+            exportDropdown.click().then(function () {
                 const options = chaisePage.recordsetPage.getExportOptions();
                 expect(options.count()).toBe(1, "count missmatch");
 
                 const csvOption = chaisePage.recordsetPage.getExportOption("Defined template");
                 expect(csvOption.getText()).toBe("Defined template");
+                return exportDropdown.click();
+            }).then(function () {
                 done();
             }).catch(function(err) {
                 done.fail(err);
@@ -229,7 +234,6 @@ describe('View existing record,', function() {
 
             it("should redirect to recordedit when clicked.", function(done) {
                 var titleElement = chaisePage.recordEditPage.getEntityTitleElement();
-
                 chaisePage.clickButton(copyButton).then(function() {
                     return chaisePage.waitForElement(element(by.id('submit-record-button')));
                 }).then(function() {

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -55,7 +55,6 @@ describe('View existing record,', function() {
           }).catch(chaisePage.catchTestError(done));
         });
 
-        // TODO test table of contents
         it('should hide empty related tables on load',function(){
             chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
                 headings.forEach(function (heading, idx) {
@@ -93,7 +92,6 @@ describe('View existing record,', function() {
             expect(chaisePage.recordsetPage.getExportDropdown().getAttribute("disabled")).toBeTruthy();
         });
 
-        // TODO test table of contents
         it("should hide the column headers and collapse the table of contents based on table-display annotation.", function () {
             chaisePage.recordPage.getColumns().then(function (cols) {
                 expect(cols[0].isDisplayed()).toBeFalsy("Column names are showing.");

--- a/test/e2e/specs/all-features/record/permissions-annotation.spec.js
+++ b/test/e2e/specs/all-features/record/permissions-annotation.spec.js
@@ -18,7 +18,7 @@ describe('When viewing Record app', function() {
 
     describe('for a read-only table', function() {
         beforeAll(function() {
-            browser.get(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_read_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
+            chaisePage.navigate(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_read_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
             var title = chaisePage.recordPage.getEntityTitleElement();
             chaisePage.waitForElement(title).then(function() {
                 expect(title.isDisplayed()).toBeTruthy();
@@ -59,7 +59,7 @@ describe('When viewing Record app', function() {
 
     describe('for a create-only table', function() {
         beforeAll(function() {
-            browser.get(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_create_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
+            chaisePage.navigate(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_create_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
             var title = chaisePage.recordPage.getEntityTitleElement();
             chaisePage.waitForElement(title).then(function() {
                 expect(title.isDisplayed()).toBeTruthy();
@@ -136,7 +136,7 @@ describe('When viewing Record app', function() {
 
     describe('for a table that allows edit and create (but no delete)', function() {
         beforeAll(function() {
-            browser.get(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_update_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
+            chaisePage.navigate(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_update_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
             var title = chaisePage.recordPage.getEntityTitleElement();
             chaisePage.waitForElement(title).then(function() {
                 expect(title.isDisplayed()).toBeTruthy();
@@ -186,7 +186,7 @@ describe('When viewing Record app', function() {
 
     describe('for a delete-only table', function() {
         beforeAll(function() {
-            browser.get(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_delete_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
+            chaisePage.navigate(browser.params.url + "/record/#" + browser.params.catalogId + "/multi-permissions:main_delete_table/" + testParams.key.columnName + testParams.key.operator + testParams.key.value);
             var title = chaisePage.recordPage.getEntityTitleElement();
             chaisePage.waitForElement(title).then(function() {
                 expect(title.isDisplayed()).toBeTruthy();

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -77,7 +77,6 @@ describe ("Viewing exisiting record with related entities, ", function () {
     });
 
     it ("should show the related table names in the correct order in the Table of Contents", function (done) {
-        // TODO fix this test case
         chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
             headings.forEach(function (heading, idx) {
                 expect(heading.getText()).toEqual(testParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -2,6 +2,7 @@ var chaisePage = require('../../../utils/chaise.page.js');
 var recordHelpers = require('../../../utils/record-helpers.js');
 var EC = protractor.ExpectedConditions;
 var moment = require('moment');
+const { browser } = require('protractor');
 
 var testParams = {
     schemaName: "product-unordered-related-tables-links",
@@ -43,14 +44,14 @@ var testParams = {
     ]
 };
 
-const pageReadyCondition = chaisePage.recordPageReady();
+const pageReadyCondition = () => chaisePage.recordPageReady();
 
 describe ("Viewing exisiting record with related entities, ", function () {
     beforeAll(function (done) {
         var keys = [];
         keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
         var url = browser.params.url + "/record/#" + browser.params.catalogId + "/" + testParams.schemaName + ":" + testParams.table_name + "/" + keys.join("&");
-
+        
         chaisePage.navigate(url).then(function () {
             return pageReadyCondition();
         }).then(function () {
@@ -77,7 +78,11 @@ describe ("Viewing exisiting record with related entities, ", function () {
 
     it ("should show the related table names in the correct order in the Table of Contents", function (done) {
         // TODO fix this test case
-        expect(chaisePage.recordPage.getSidePanelTableTitles()).toEqual(testParams.tocHeaders, "list of related tables in toc is incorrect");
+        chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
+            headings.forEach(function (heading, idx) {
+                expect(heading.getText()).toEqual(testParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");
+            })
+        })
         done();
     });
 
@@ -238,18 +243,18 @@ describe ("Viewing exisiting record with related entities, ", function () {
             // we unlink rows 2 and 4 ("Air Conditioning" and "UHD TV")
             catalogId: browser.params.catalogId,
             relatedDisplayname: "association_table",
-            modalTitle: "Unlink association_table from Accommodations : Super 8 North Hollywood Motel",
+            modalTitle: "Unlink association_table from Accommodations: Super 8 North Hollywood Motel",
             totalCount: 5,
-            postDeleteMessage: "2 records successfully unlinked.\n\nClick OK to dismiss this dialog.",
+            postDeleteMessage: "2 records successfully unlinked.",
             countAfterUnlink: 3,
             rowValuesAfter: [
                 ["Television"],
                 ["Coffee Maker"],
                 ["Space Heater"]
             ],
-            failedPostDeleteMessage: "2 records could not be unlinked. Check the error details below to see more information.\n\nClick OK to dismiss this dialog.\nShow Error Details",
+            failedPostDeleteMessage: "2 records could not be unlinked. Check the error details below to see more information.\n\nShow Error Details",
             // we unlink row 5 ("Space Heater")
-            aclPostDeleteMessage: "1 record successfully unlinked.\n\nClick OK to dismiss this dialog.",
+            aclPostDeleteMessage: "1 record successfully unlinked.",
             countAfterAclUnlink: 2,
             rowValuesAfterAclRemove: [
                 ["Television"],
@@ -311,7 +316,7 @@ describe ("Viewing exisiting record with related entities, ", function () {
             }).then(function(ct){
                 expect(ct).toBe(2, "association count missmatch for file domain table.");
 
-                expect(chaisePage.recordsetPage.getTotalCount().getText()).toBe("Displaying\nfirst 2\nrecords", "hide_row_count not honored");
+                expect(chaisePage.recordsetPage.getModalRecordsetTotalCount().getText()).toBe("Displaying first\n2\nrecords", "hide_row_count not honored");
 
                 return chaisePage.recordEditPage.getModalCloseBtn().click();
             }).then(function () {
@@ -639,13 +644,12 @@ describe ("Viewing exisiting record with related entities, ", function () {
         });
 
         it("should have the proper tooltip", function (done) {
-            chaisePage.recordPage.getColumnCommentHTML(addBtn.element(by.xpath("./.."))).then(function(comment) {
-                expect(comment).toBe("'Unable to connect to <code>" + displayname + "</code> records until <code>" + columnname + "</code> in <code>" + tablename + "</code> is set.'", "Incorrect tooltip on disabled Add button");
-                done();
-            }).catch(function(error) {
-                console.log(error);
-                done.fail();
-            });
+            chaisePage.testTooltipWithDone(
+                addBtn.element(by.xpath("./..")),
+                `'Unable to connect to <code>${displayname}</code> records until <code>${columnname}</code> in <code>${tablename}</code> is set.'`,
+                done,
+                'record'
+            );
         });
     });
 
@@ -671,16 +675,12 @@ describe ("Viewing exisiting record with related entities, ", function () {
         });
 
         it("should have the proper tooltip", function (done) {
-            chaisePage.recordPage.getColumnCommentHTML(addBtn.element(by.xpath("./.."))).then(function(comment) {
-                expect(comment).toBe(
-                  `'Unable to create <code>${displayname}</code> records for this <code>${tablename}</code> until <code>${colname}</code> in this <code>${tablename}</code> is set'`,
-                  "Incorrect tooltip on disabled Add button"
-                );
-                done();
-            }).catch(function(error) {
-                console.log(error);
-                done.fail();
-            });
+            chaisePage.testTooltipWithDone(
+                addBtn.element(by.xpath("./..")),
+                `'Unable to create <code>${displayname}</code> records for this <code>${tablename}</code> until <code>${columnname}</code> in this <code>${tablename}</code> is set'`,
+                done,
+                'record'
+            );
         });
     });
 
@@ -724,7 +724,7 @@ describe("For scroll to query parameter", function() {
     });
 
     it("should scroll to the related table.", function (done) {
-        var heading = chaisePage.recordPage.getRelatedTableAccordion(displayname);
+        var heading = chaisePage.recordPage.getRelatedTableAccordion(displayname).element(by.css('.accordion-collapse'));
 
         browser.wait(function () {
             return heading.isDisplayed().then(function (bool) {
@@ -736,7 +736,7 @@ describe("For scroll to query parameter", function() {
         }).then(function () {
             return heading.getAttribute("class")
         }).then(function(className) {
-            expect(className).toContain("panel-open", "Related table panel is not open when autoscrolled.");
+            expect(className).toContain("show", "Related table panel is not open when autoscrolled.");
             done()
         }).catch(function(error) {
             console.log(error);

--- a/test/e2e/specs/default-config/record/links.spec.js
+++ b/test/e2e/specs/default-config/record/links.spec.js
@@ -115,17 +115,21 @@ describe('View existing record,', function() {
         });
 
         // TODO test table of contents
-        // it ("should show the empty related association tables and table of contents on page load", function (done) {
-        //     browser.wait(function() {
-        //         return chaisePage.recordPage.getSidePanelHeadings().count().then(function(ct) {
-        //             return (ct == testParams.tocHeaders.length);
-        //         });
-        //     }, browser.params.defaultTimeout);
-        //     expect(chaisePage.recordPage.getSidePanelTableTitles()).toEqual(testParams.tocHeaders, "list of related tables in toc is incorrect");
+        it ("should show the empty related association tables and table of contents on page load", function (done) {
+            browser.wait(function() {
+                return chaisePage.recordPage.getSidePanelHeadings().count().then(function(ct) {
+                    return (ct == testParams.tocHeaders.length);
+                });
+            }, browser.params.defaultTimeout);
+            chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
+                headings.forEach(function (heading, idx) {
+                    expect(heading.getText()).toEqual(testParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");
+                })
+            })
 
-        //     expect(chaisePage.recordPage.getRelatedTableTitles()).toEqual(testParams.headers, "list of related table accordion headers is incorret");
-        //     done();
-        // });
+            expect(chaisePage.recordPage.getRelatedTableTitles()).toEqual(testParams.headers, "list of related table accordion headers is incorret");
+            done();
+        });
 
         it ("The proper permalink (browser url) should appear in the share popup if resolverImplicitCatalog is undefined", function (done) {
             var shareButton = chaisePage.recordPage.getShareButton(),
@@ -206,41 +210,45 @@ describe('View existing record,', function() {
 });
 
 // TODO test table of contents
-// var inlineParams = {
-//     table_name: "inline_table",
-//     key: {
-//         name: "id",
-//         value: "1",
-//         operator: "="
-//     },
-//     headers: ["inline_association_table"],
-//     tocHeaders: ["Summary", "inline_association_table (0)"],
-// }
-// describe('View existing record for testing "show empty sections" heuristics,', function() {
+var inlineParams = {
+    table_name: "inline_table",
+    key: {
+        name: "id",
+        value: "1",
+        operator: "="
+    },
+    headers: ["inline_association_table"],
+    tocHeaders: ["Summary", "inline_association_table (0)"],
+}
+describe('View existing record for testing "show empty sections" heuristics,', function() {
 
-//     describe("For table " + inlineParams.table_name + ",", function() {
+    describe("For table " + inlineParams.table_name + ",", function() {
 
-//         beforeAll(function () {
-//             var keys = [];
-//             keys.push(inlineParams.key.name + inlineParams.key.operator + inlineParams.key.value);
-//             browser.ignoreSynchronization=true;
-//             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/links:" + inlineParams.table_name + "/" + keys.join("&");
-//             browser.get(url);
+        beforeAll(function () {
+            var keys = [];
+            keys.push(inlineParams.key.name + inlineParams.key.operator + inlineParams.key.value);
+            browser.ignoreSynchronization=true;
+            var url = browser.params.url + "/record/#" + browser.params.catalogId + "/links:" + inlineParams.table_name + "/" + keys.join("&");
+            browser.get(url);
 
-//             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
-//         });
+            chaisePage.waitForElement(element(by.css('.record-main-section-table')));
+        });
 
 
-//         it ("should show the empty related association tables and table of contents on page load", function (done) {
-//             browser.wait(function() {
-//                 return chaisePage.recordPage.getSidePanelHeadings().count().then(function(ct) {
-//                     return (ct == inlineParams.tocHeaders.length);
-//                 });
-//             }, browser.params.defaultTimeout);
-//             expect(chaisePage.recordPage.getSidePanelTableTitles()).toEqual(inlineParams.tocHeaders, "list of related tables in toc is incorrect");
+        it ("should show the empty related association tables and table of contents on page load", function (done) {
+            browser.wait(function() {
+                return chaisePage.recordPage.getSidePanelHeadings().count().then(function(ct) {
+                    return (ct == inlineParams.tocHeaders.length);
+                });
+            }, browser.params.defaultTimeout);
+            chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
+                headings.forEach(function (heading, idx) {
+                    expect(heading.getText()).toEqual(inlineParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");
+                })
+            })
 
-//             expect(chaisePage.recordPage.getRelatedTableTitles()).toEqual(inlineParams.headers, "list of related table accordion headers is incorret");
-//             done();
-//         });
-//     });
-// });
+            expect(chaisePage.recordPage.getRelatedTableTitles()).toEqual(inlineParams.headers, "list of related table accordion headers is incorret");
+            done();
+        });
+    });
+});

--- a/test/e2e/specs/default-config/record/links.spec.js
+++ b/test/e2e/specs/default-config/record/links.spec.js
@@ -26,9 +26,8 @@ describe('View existing record,', function() {
         beforeAll(function () {
             var keys = [];
             keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/links:" + testParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
 
             chaisePage.recordPageReady();
         });
@@ -227,9 +226,8 @@ describe('View existing record for testing "show empty sections" heuristics,', f
         beforeAll(function () {
             var keys = [];
             keys.push(inlineParams.key.name + inlineParams.key.operator + inlineParams.key.value);
-            browser.ignoreSynchronization=true;
             var url = browser.params.url + "/record/#" + browser.params.catalogId + "/links:" + inlineParams.table_name + "/" + keys.join("&");
-            browser.get(url);
+            chaisePage.navigate(url);
 
             chaisePage.waitForElement(element(by.css('.record-main-section-table')));
         });

--- a/test/e2e/specs/default-config/record/links.spec.js
+++ b/test/e2e/specs/default-config/record/links.spec.js
@@ -113,7 +113,6 @@ describe('View existing record,', function() {
             });
         });
 
-        // TODO test table of contents
         it ("should show the empty related association tables and table of contents on page load", function (done) {
             browser.wait(function() {
                 return chaisePage.recordPage.getSidePanelHeadings().count().then(function(ct) {
@@ -208,7 +207,6 @@ describe('View existing record,', function() {
     });
 });
 
-// TODO test table of contents
 var inlineParams = {
     table_name: "inline_table",
     key: {

--- a/test/e2e/specs/delete-prohibited/navbar/catalog-chaise-config.spec.js
+++ b/test/e2e/specs/delete-prohibited/navbar/catalog-chaise-config.spec.js
@@ -81,8 +81,7 @@ describe('Navbar ', function() {
     }
 
     it('should hide the navbar bar if the hideNavbar query parameter is set to true', function () {
-        browser.get(url + "?hideNavbar=true");
-        browser.refresh();
+        chaisePage.refresh(url + "?hideNavbar=true");
         // browser wait for navbar if not needed, only checking recordset table is present is sufficient 
         chaisePage.recordsetPageReady()
 

--- a/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
+++ b/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
@@ -52,7 +52,6 @@ describe('View existing record,', function() {
             done();
         });
 
-        // TODO test table of contents
         it('Related tables should all show by default because of showWriterEmptyRelatedOnLoad=true', function () {
             chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
                 headings.forEach(function (heading, idx) {

--- a/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
+++ b/test/e2e/specs/delete-prohibited/record/no-delete-btn.spec.js
@@ -53,9 +53,13 @@ describe('View existing record,', function() {
         });
 
         // TODO test table of contents
-        // it('Related tables should all show by default because of showWriterEmptyRelatedOnLoad=true', function () {
-        //     expect(chaisePage.recordPage.getSidePanelTableTitles()).toEqual(testParams.tocHeaders, "list of related tables in toc is incorrect");
-        // });
+        it('Related tables should all show by default because of showWriterEmptyRelatedOnLoad=true', function () {
+            chaisePage.recordPage.getSidePanelTableTitles().then(function (headings) {
+                headings.forEach(function (heading, idx) {
+                    expect(heading.getText()).toEqual(testParams.tocHeaders[idx], "related table heading with index: " + idx + " in toc is incorrect");
+                })
+            })
+        });
 
         if (process.env.CI) {
             it ("Should have the proper permalink in the share popup if resolverImplicitCatalog is the same as catalogId", function (done) {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -755,7 +755,7 @@ var recordPage = function() {
     }
 
     this.getSidePanelItemById = function (idx) {
-        return element(by.id("recordSidePan-" + idx));
+        return element(by.id("recordSidePan-heading-" + idx));
     }
 
     this.getSidePanelHeadings = function() {
@@ -1061,11 +1061,6 @@ var recordsetPage = function() {
     this.getSelectedRowsFilters = function () {
         // adding ".selected-chiclet-name" to the selector to not select the clear-all-btn
         return element(by.css(".selected-chiclets")).all(by.css(".selected-chiclet .selected-chiclet-name"));
-    }
-
-    //TODO: remove when record app migrated
-    this.getAngularSelectedRowsFilters = function () {
-        return element(by.css(".recordset-selected-rows")).all(by.css(".selected-chiclet"));
     }
 
     this.getFacetFilters = function () {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -568,6 +568,10 @@ var recordPage = function() {
         return this.getRelatedTableHeading(displayName).element(by.css('.rt-section-header'));
     };
 
+    this.getRelatedTableSectionHeaderDisplayname = function(displayName) {
+        return this.getRelatedTableHeading(displayName).element(by.css('.rt-section-header .rt-displayname'));
+    };
+
     this.getRelatedTableInlineComment = function(displayname) {
         return this.getRelatedTableAccordion(displayname).element(by.css('.inline-tooltip'));
     }
@@ -652,7 +656,7 @@ var recordPage = function() {
     };
 
     this.getConfirmDeleteTitle = function() {
-        return element(by.css(".modal-title"));
+        return element(by.css(".confirm-delete-modal .modal-title"));
     };
 
     this.getConfirmDeleteButton = function () {
@@ -678,6 +682,14 @@ var recordPage = function() {
     this.getModalText = function() {
         return element(by.css(".modal-body"));
     };
+
+    this.getConfirmDeleteModalText = function () {
+        return element(by.css(".confirm-delete-modal .modal-body"));
+    }
+
+    this.getErrorModalText = function () {
+        return element(by.css(".modal-error .modal-body"));
+    }
 
     this.getShareModal = function() {
         return element(by.css(".chaise-share-citation-modal"));
@@ -755,7 +767,7 @@ var recordPage = function() {
     }
 
     this.getSidePanelTableTitles = function() {
-        return browser.executeScript("return $('.columns-container li.toc-heading').map(function(i, a) { return a.innerText.trim(); });");
+        return element.all(by.css('.columns-container li.toc-heading'));
     }
 
     this.getHideTocBtn = function() {
@@ -813,6 +825,10 @@ var recordsetPage = function() {
 
     this.getTotalCount = function() {
         return element(by.css('.chaise-table-header-total-count'));
+    };
+
+    this.getModalRecordsetTotalCount = function() {
+        return element(by.css('.modal-body .chaise-table-header-total-count'));
     };
 
     this.getColumnNames = function() {
@@ -930,7 +946,7 @@ var recordsetPage = function() {
     };
 
     this.getConfirmDeleteTitle = function() {
-        return element(by.css(".modal-title"));
+        return element(by.css(".confirm-delete-modal .modal-title"));
     };
 
     this.getConfirmDeleteButton = function () {
@@ -1043,7 +1059,8 @@ var recordsetPage = function() {
     }
 
     this.getSelectedRowsFilters = function () {
-        return element(by.css(".selected-chiclets")).all(by.css(".selected-chiclet"));
+        // adding ".selected-chiclet-name" to the selector to not select the clear-all-btn
+        return element(by.css(".selected-chiclets")).all(by.css(".selected-chiclet .selected-chiclet-name"));
     }
 
     //TODO: remove when record app migrated
@@ -1362,9 +1379,10 @@ function chaisePage() {
         return this.waitForElement(element(by.css(".recordset-table")));
     }
     this.recordPageReady = function() {
-        this.waitForElement(this.recordPage.getEntityTitleElement());
+        var self = this;
+        this.waitForElement(self.recordPage.getEntityTitleElement());
         this.waitForElement(element(by.css('.record-main-section-table')));
-        return this.waitForElementInverse(this.recordPage.getRelatedSectionSpinner());
+        return this.waitForElementInverse(self.recordPage.getRelatedSectionSpinner());
     }
     this.recordeditPageReady = function() {
         this.waitForClickableElement(element(by.id("submit-record-button")));

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -1516,7 +1516,6 @@ exports.testBatchUnlinkDynamicAclsAssociationTable = function (params, isInline,
         });
 
         it("should have rows still selected after failed delete", function (done) {
-            // TODO: change once record app migrated
             expect(chaisePage.recordsetPage.getSelectedRowsFilters().count()).toBe(2);
             done();
         });

--- a/test/manual/specs/recordset.spec.js
+++ b/test/manual/specs/recordset.spec.js
@@ -2,8 +2,7 @@ var chaisePage = require('./../../e2e/utils/chaise.page.js');
 
 describe('View recordset,', function () {
     beforeAll(function () {
-        browser.ignoreSynchronization = true;
-        browser.get(browser.params.url + "/recordset/#" + browser.params.catalogId + "/product-recordset:accommodation");
+        chaisePage.navigate(browser.params.url + "/recordset/#" + browser.params.catalogId + "/product-recordset:accommodation");
 
         chaisePage.recordsetPageReady()
         chaisePage.waitForAggregates();


### PR DESCRIPTION
Changes in this PR include unlink pure and binary functionality and record tests updated to support unlink pure and binary, table of contents changes, and scrollTo changes. Now that unlink pure and binary is implemented, `related-table.spec.js` has been migrated as well.

Opening this PR to run the tests in GA while I refactor the use of `OverlayTrigger` and `Tooltip` to use `ChaiseTooltip`.