### PR TITLE
Dismiss login modal after logging in from 401 http handler

### DIFF
--- a/src/components/modals/login-modal.tsx
+++ b/src/components/modals/login-modal.tsx
@@ -9,24 +9,15 @@ const LoginModal = (): JSX.Element => {
   const { dispatchError, loginModal, hideLoginModal } = useError();
   const { popupLogin } = useAuthn();
 
-  const [closeMessage, setCloseMessage] = useState<string | null>(null)
-  const [show, setShow] = useState<boolean>(true);
+  const login = () => popupLogin(LogActions.LOGIN_LOGIN_MODAL, () => { onExited('login') });
 
-  const login = () => {
-    setCloseMessage('login');
-    popupLogin(LogActions.LOGIN_LOGIN_MODAL);
-  };
+  const cancel = () => onExited('cancel');
 
-  const cancel = () => {
-    setCloseMessage('cancel');
-    setShow(false);
-  };
-
-  const onExited = () => {
+  const onExited = (message: string) => {
     hideLoginModal(); // sets modal to null after it's been hidden
-    if (closeMessage === 'login' && loginModal?.onModalCloseSuccess) {
+    if (message === 'login' && loginModal?.onModalCloseSuccess) {
       loginModal.onModalCloseSuccess()
-    } else if (closeMessage === 'cancel' && loginModal?.onModalClose) {
+    } else if (message === 'cancel' && loginModal?.onModalClose) {
       loginModal.onModalClose('cancel');
     } else {
       // TODO needs discussion
@@ -43,10 +34,9 @@ const LoginModal = (): JSX.Element => {
     <Modal
       className='modal-login-instruction'
       backdropClassName='modal-login-instruction-backdrop'
-      show={show}
+      show={true}
       backdrop='static'
       keyboard={false}
-      onExited={onExited}
     >
       <Modal.Header>
         <Modal.Title as='h2'>{loginModal.title}</Modal.Title>

--- a/src/components/modals/login-modal.tsx
+++ b/src/components/modals/login-modal.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Modal from 'react-bootstrap/Modal';
 import useError from '@isrd-isi-edu/chaise/src/hooks/error';
 import useAuthn from '@isrd-isi-edu/chaise/src/hooks/authn';
@@ -26,9 +25,7 @@ const LoginModal = (): JSX.Element => {
     }
   }
 
-  if (!loginModal) {
-    return <></>;
-  }
+  if (!loginModal) return <></>
 
   return (
     <Modal

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -57,7 +57,7 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
   const PROMPT_EXPIRATION_KEY = 'promptExpiration'; // name of key for prompt expiration value
   const PREVIOUS_SESSION_KEY = 'previousSession'; // name of key for previous session boolean
 
-  const { dispatchError, showLoginModal, setLoginFunction } = useError();
+  const { dispatchError, showLoginModal, hideLoginModal, setLoginFunction } = useError();
   const [session, setSession] = useState<Session | null>(null); // current session object
   const [prevSession, setPrevSession] = useState<Session | null>(null); // previous session object
   const _changeCbs: any = {};
@@ -160,10 +160,12 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
       postLoginCB = () => {
         // fetches the session of the user that just logged in
         getSession('').then((response: any) => {
-          // TODO: make sure this works how we expect with state variables
           if (!shouldReloadPageAfterLogin(session)) {
-            // TODO: discuss this code path
-            // alert(`${response.client.full_name} logged in`);
+            // NOTE: this blindly closes the login modal (assuming it's open)
+            //   - `modalInstance` might be null for some reason
+            //   - this should be extended to check if errors are present and close errors if no login modal
+            //     - maybe it should do both?
+            hideLoginModal();
           } else {
             windowRef.location.reload();
           }

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -164,8 +164,6 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
             // NOTE: this blindly closes the login modal (assuming it's open)
             //   - TODO: we want to check `loginModal` before closing so we aren't assuming it's there
             //     - `loginModal` is null when this function is defined and that variable state (null) is being captured when defining this function
-            //   - this should be extended to check if errors are present and close errors if no login modal
-            //     - maybe it should do both?
             hideLoginModal();
           } else {
             windowRef.location.reload();

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -162,7 +162,8 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
         getSession('').then((response: any) => {
           if (!shouldReloadPageAfterLogin(session)) {
             // NOTE: this blindly closes the login modal (assuming it's open)
-            //   - `modalInstance` might be null for some reason
+            //   - TODO: we want to check `loginModal` before closing so we aren't assuming it's there
+            //     - `loginModal` is null when this function is defined and that variable state is being captured
             //   - this should be extended to check if errors are present and close errors if no login modal
             //     - maybe it should do both?
             hideLoginModal();

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -163,7 +163,7 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
           if (!shouldReloadPageAfterLogin(session)) {
             // NOTE: this blindly closes the login modal (assuming it's open)
             //   - TODO: we want to check `loginModal` before closing so we aren't assuming it's there
-            //     - `loginModal` is null when this function is defined and that variable state is being captured
+            //     - `loginModal` is null when this function is defined and that variable state (null) is being captured when defining this function
             //   - this should be extended to check if errors are present and close errors if no login modal
             //     - maybe it should do both?
             hideLoginModal();

--- a/src/providers/error.tsx
+++ b/src/providers/error.tsx
@@ -51,10 +51,8 @@ export default function ErrorProvider({ children }: ErrorProviderProps): JSX.Ele
   const [loginModal, setLoginModal] = useState<null|LoginModalProps>(null);
 
   let callLoginFunction: Function;
-  const showLoginModal = (props: LoginModalProps)  => {
-    if (!loginModal) {
-      setLoginModal(props);
-    }
+  const showLoginModal = (props: LoginModalProps) => {
+    if (!loginModal) setLoginModal(props);
   };
 
   const hideLoginModal = () => {

--- a/src/providers/error.tsx
+++ b/src/providers/error.tsx
@@ -30,7 +30,7 @@ export const ErrorContext = createContext<{
   loginModal: LoginModalProps | null;
   showLoginModal: (props: LoginModalProps) => void;
   hideLoginModal: () => void;
-  setLoginFunction: Function;
+  setLoginFunction: (cb: Function) => void;
 } |
   // NOTE: since it can be null, to make sure the context is used properly with
   //       a provider, the useRecordset hook will throw an error if it's null.


### PR DESCRIPTION
This PR fixes the attached issue when the login dialog is opened because of ermrestJS triggering the attached function from `setHTTP401Handler`. This fixes the login error case in the issue and any others that would trigger the login modal to show because of improper authorization when `ermrestJS` tries to make a request to `ERMrest`.

I'm also calling `hideLoginModal()` in the callback we talked about that should be addressed. I noted in the comments in the code that this function is registered before the modal is opened so I can't make sure the modal is open before closing it. I also can't check to see if this process was triggered some other way (maybe from the error dialog) that doesn't require a reload and falls into this case.