### PR TITLE
React boolean input

### DIFF
--- a/src/assets/scss/_input-switch.scss
+++ b/src/assets/scss/_input-switch.scss
@@ -108,3 +108,15 @@
     }
   }
 }
+
+.input-switch-boolean {
+  // remove the default bootstrap caret
+  .dropdown-toggle::after {
+    content: none !important;
+  }
+
+  // make sure the menu expands the whole row
+  .dropdown-menu {
+    width: 100%;
+  }
+}

--- a/src/components/input-switch.tsx
+++ b/src/components/input-switch.tsx
@@ -14,7 +14,7 @@ import { RangeOption, TimeStamp } from '@isrd-isi-edu/chaise/src/models/range-pi
 import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 
 // utils
-import { getDisabledInputValue } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { ERROR_MESSAGES, getDisabledInputValue } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 
@@ -39,12 +39,12 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 
 const integerFieldValidation = {
   value:  INTEGER_REGEXP,
-  message: 'Please enter a valid integer value'
+  message: ERROR_MESSAGES.INVALID_INTEGER
 };
 
 const numericFieldValidation = {
   value: FLOAT_REGEXP,
-  message: 'Please enter a valid decimal value'
+  message: ERROR_MESSAGES.INVALID_NUMERIC
 };
 
 
@@ -52,13 +52,13 @@ const numericFieldValidation = {
 const dateFieldValidation =  (value: string) => {
   if (!value) return;
   const date = windowRef.moment(value, DATE_FORMAT, true);
-  return date.isValid() || 'Please enter a valid date value';
+  return date.isValid() || ERROR_MESSAGES.INVALID_DATE;
 };
 
 const timestampFieldValidation = (value: string) => {
   if (!value) return;
   const timestamp = windowRef.moment(value, TIMESTAMP_FORMAT, true);
-  return timestamp.isValid() || 'Please enter a valid date and time value';
+  return timestamp.isValid() || ERROR_MESSAGES.INVALID_TIMESTAMP;
 };
 
 const validationFunctionMap : {
@@ -176,7 +176,7 @@ const TextField = ({
 
   return (
     <div className={`${containerClasses} input-switch-container-${name}`} style={styles}>
-      <div className={`chaise-input-control has-feedback input-switch-numeric ${classes} ${disableInput ? ' input-disabled' : ''}`}>
+      <div className={`chaise-input-control has-feedback input-switch-text ${classes} ${disableInput ? ' input-disabled' : ''}`}>
         <input placeholder={placeholder}className={`${inputClasses} input-switch`} {...field} onChange={handleChange} />
         <ClearInputBtn
           btnClassName={`${clearClasses} input-switch-clear`}
@@ -267,7 +267,7 @@ type NumericFieldProps = {
   /**
    * the handler function called on input change
    */
-  onFieldChange?: ((value: string) => void)
+  onFieldChange?: ((value: string) => void),
 };
 
 const NumericField = ({

--- a/src/components/input-switch.tsx
+++ b/src/components/input-switch.tsx
@@ -3,6 +3,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_input-switch.scss';
 // components
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 import ColorField from '@isrd-isi-edu/chaise/src/components/input-switch/color-field';
+import BooleanField from '@isrd-isi-edu/chaise/src/components/input-switch/boolean-field';
 
 // hooks
 import { useEffect, useState, useRef } from 'react';
@@ -10,11 +11,13 @@ import { useFormContext, useController, useWatch } from 'react-hook-form';
 
 // models
 import { RangeOption, TimeStamp } from '@isrd-isi-edu/chaise/src/models/range-picker';
+import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 
 // utils
 import { getDisabledInputValue } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+
 
 
 /**
@@ -331,7 +334,7 @@ const NumericField = ({
   };
 
   useEffect(() => {
-    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'number' });  
+    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'number' });
   }, [error?.message])
 
   return (
@@ -446,7 +449,7 @@ const DateField = ({
   };
 
   useEffect(() => {
-    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'date' });  
+    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'date' });
   }, [error?.message])
 
   return (
@@ -631,7 +634,7 @@ const TimestampField = ({
   };
 
   useEffect(() => {
-    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'timestamp' });  
+    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'timestamp' });
   }, [error?.message])
 
   const clearDate = () => {
@@ -730,6 +733,11 @@ type InputSwitchProps = {
    * inline styling for the input switch component
    */
   styles?: object,
+  /**
+   * The column model that is used for this input
+   * boolean and foreignkey inputs need this. other types might need it as well.
+   */
+  columnModel?: RecordeditColumnModel
 };
 
 const InputSwitch = ({
@@ -747,6 +755,7 @@ const InputSwitch = ({
   displayErrors = true,
   onFieldChange,
   styles={},
+  columnModel,
 }: InputSwitchProps): JSX.Element | null => {
 
   return (() => {
@@ -796,14 +805,6 @@ const InputSwitch = ({
           styles={styles}
           onFieldChange={onFieldChange}
         />
-      case 'disabled':
-          return <DisabledField
-            name={name}
-            classes={classes}
-            inputClasses={inputClasses}
-            containerClasses={containerClasses}
-            placeholder={placeholder as string}
-          />
       case 'color':
         return <ColorField
           name={name}
@@ -815,6 +816,26 @@ const InputSwitch = ({
           disableInput={disableInput}
           onFieldChange={onFieldChange}
         />
+      case 'boolean':
+        return <BooleanField
+          name={name}
+          classes={classes}
+          inputClasses={inputClasses}
+          containerClasses={containerClasses}
+          clearClasses={clearClasses}
+          value={value as string}
+          disableInput={disableInput}
+          onFieldChange={onFieldChange}
+          columnModel={columnModel}
+        />
+      case 'disabled':
+          return <DisabledField
+            name={name}
+            classes={classes}
+            inputClasses={inputClasses}
+            containerClasses={containerClasses}
+            placeholder={placeholder as string}
+          />
       case 'text':
       default:
         return <TextField

--- a/src/components/input-switch/boolean-field.tsx
+++ b/src/components/input-switch/boolean-field.tsx
@@ -1,0 +1,164 @@
+// components
+import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
+import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import Dropdown from 'react-bootstrap/Dropdown';
+
+// hooks
+import { useEffect, useState } from 'react';
+import { useFormContext, useController } from 'react-hook-form';
+
+// models
+import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
+
+// utils
+import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
+import { formatBoolean } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+
+
+type BooleanFieldProps = {
+  /**
+   *  the name of the field
+   */
+  name: string,
+  /**
+  * placeholder text
+  */
+  placeholder?: string,
+  /**
+  * classes for styling the input element
+  */
+  classes?: string,
+  inputClasses?: string,
+  containerClasses?: string,
+  /**
+  * classes for styling the clear button
+  */
+  clearClasses?: string
+  /**
+  * flag for disabling the input
+  */
+  disableInput?: boolean,
+  /**
+  * flag to show error below the input switch component
+  */
+  displayErrors?: boolean,
+  value: string,
+  styles?: any,
+  /**
+  * the handler function called on input change
+  */
+  onFieldChange?: ((value: string) => void),
+  /**
+   * The column model representing this field in the form.
+   */
+  columnModel?: RecordeditColumnModel,
+};
+
+const BooleanField = ({
+  name,
+  placeholder,
+  classes,
+  inputClasses,
+  clearClasses,
+  disableInput,
+  displayErrors,
+  value,
+  containerClasses,
+  styles,
+  onFieldChange,
+  columnModel
+}: BooleanFieldProps): JSX.Element => {
+  const { setValue, control, clearErrors } = useFormContext();
+
+  const registerOptions = {
+    required: columnModel?.isRequired,
+  };
+
+  const formInput = useController({
+    name,
+    control,
+    rules: registerOptions,
+  });
+
+  const field = formInput?.field;
+
+  const fieldValue = field?.value;
+
+  const fieldState = formInput?.fieldState;
+
+  const [showClear, setShowClear] = useState<boolean>(typeof fieldValue !== 'boolean');
+
+  const { error, isTouched } = fieldState;
+
+  const clearInput = (e: MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setValue(name, '');
+    clearErrors(name);
+  }
+
+  useEffect(() => {
+    if (onFieldChange) {
+      onFieldChange(fieldValue);
+    }
+    const nonEmpty = (typeof fieldValue === 'boolean');
+    if (showClear !== nonEmpty) {
+      setShowClear(nonEmpty);
+    }
+  }, [fieldValue]);
+
+  useEffect(() => {
+    if (value === undefined) return;
+    setValue(name, value);
+  }, [value]);
+
+  const handleChange = (v: any) => {
+    field.onChange(v);
+    field.onBlur();
+  };
+
+  useEffect(() => {
+    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message) });
+  }, [error?.message]);
+
+
+  const rawOptions = [true, false];
+  const displayedOptions = rawOptions.map((op) => columnModel ? formatBoolean(columnModel.column, op) : op.toString());
+
+  return (
+    <div className={`${containerClasses} input-switch-boolean input-switch-container-${name}`} style={styles}>
+      <Dropdown>
+        <Dropdown.Toggle as='div' disabled={disableInput} className='chaise-input-group'>
+          <div className={`chaise-input-control has-feedback ${classes} ${disableInput ? ' input-disabled' : ''}`}>
+            {typeof fieldValue === 'boolean' ?
+              displayedOptions[rawOptions.indexOf(fieldValue)] :
+              <span className='chaise-input-placeholder'>Select a value</span>
+            }
+            <ClearInputBtn btnClassName={`${clearClasses} input-switch-clear`} clickCallback={clearInput} show={showClear} />
+          </div>
+          <div className='chaise-input-group-append'>
+            <button className='chaise-btn chaise-btn-primary' role='button' type='button'>
+              <span className='chaise-btn-icon fa-solid fa-chevron-down' />
+            </button>
+          </div>
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {displayedOptions.map((option: any, index: number) => (
+            <Dropdown.Item
+              as='li'
+              key={`boolean-val-${name}-${index}`}
+              // first option is true, and second is false.
+              onClick={() => handleChange(rawOptions[index])}
+            >
+              {option}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
+      <input {...field} type='hidden' />
+      {displayErrors && isTouched && error?.message && <span className='input-switch-error text-danger'>{error.message}</span>}
+    </div >
+  );
+};
+
+export default BooleanField;

--- a/src/components/input-switch/boolean-field.tsx
+++ b/src/components/input-switch/boolean-field.tsx
@@ -12,7 +12,7 @@ import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedi
 
 // utils
 import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
-import { formatBoolean } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { ERROR_MESSAGES, formatBoolean } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 
 
 type BooleanFieldProps = {
@@ -71,7 +71,12 @@ const BooleanField = ({
   const { setValue, control, clearErrors } = useFormContext();
 
   const registerOptions = {
-    required: columnModel?.isRequired,
+    /**
+     * TODO this is not working properly. while the formInput.formState is reporting the
+     * error, the formInput.fieldState is not. we need to fix this issue for all the
+     * inputs that we have. none of them are properly setting this boolean.
+     */
+    required: columnModel?.isRequired ? ERROR_MESSAGES.REQUIRED : false,
   };
 
   const formInput = useController({
@@ -132,7 +137,7 @@ const BooleanField = ({
           <div className={`chaise-input-control has-feedback ${classes} ${disableInput ? ' input-disabled' : ''}`}>
             {typeof fieldValue === 'boolean' ?
               displayedOptions[rawOptions.indexOf(fieldValue)] :
-              <span className='chaise-input-placeholder'>Select a value</span>
+              <span className='chaise-input-placeholder'>{placeholder ? placeholder : 'Select a value'}</span>
             }
             <ClearInputBtn btnClassName={`${clearClasses} input-switch-clear`} clickCallback={clearInput} show={showClear} />
           </div>
@@ -155,7 +160,7 @@ const BooleanField = ({
           ))}
         </Dropdown.Menu>
       </Dropdown>
-      <input {...field} type='hidden' />
+      <input className={inputClasses} {...field} type='hidden' />
       {displayErrors && isTouched && error?.message && <span className='input-switch-error text-danger'>{error.message}</span>}
     </div >
   );

--- a/src/components/recordedit/form-container.tsx
+++ b/src/components/recordedit/form-container.tsx
@@ -75,6 +75,7 @@ const ChaiseForm = ({ classes = '', idx, allowRemove }: ChaiseFormProps) => {
           classes='column-cell-input'
           placeholder={placeholder}
           styles={{ 'height': heightparam }}
+          columnModel={cm}
         />
       );
     })
@@ -112,7 +113,7 @@ const ChaiseFormContainer = (): JSX.Element => {
   const handleHeightAdjustment = (event: any) => {
     const fieldName = event.detail.inputFieldName;
     const msgCleared = event.detail.msgCleared;
-    
+
     const fieldType = event.detail.type;
     // call provider function
     handleInputHeightAdjustment(fieldName, msgCleared, fieldType);

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -33,6 +33,7 @@ import { attachContainerHeightSensors, attachMainContainerPaddingSensor } from '
 import { appModes, RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { replaceNullOrUndefined } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 
 export type RecordeditProps = {
   appMode: string;
@@ -288,7 +289,8 @@ const RecordeditInner = ({
       const formIndex = newFormIndexValues[i];
       columnModels.forEach((cm: RecordeditColumnModel) => {
         const colName = cm.column.name;
-        tempFormValues[`${formIndex}-${colName}`] = tempFormValues[`${lastFormIdx}-${colName}`] || '';
+        // should be able to handle falsy values
+        tempFormValues[`${formIndex}-${colName}`] =  replaceNullOrUndefined(tempFormValues[`${lastFormIdx}-${colName}`], '');
 
         if (cm.column.type.name.indexOf('timestamp') !== -1) {
           tempFormValues[`${formIndex}-${colName}-date`] = tempFormValues[`${lastFormIdx}-${colName}-date`] || '';

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -24,7 +24,7 @@ import { updateHeadTitle } from '@isrd-isi-edu/chaise/src/utils/head-injector';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { columnToColumnModel, populateCreateInitialValues, populateEditInitialValues } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
-import { DEFAULT_HEGHT_MAP } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { DEFAULT_HEGHT_MAP, replaceNullOrUndefined } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { createRedirectLinkFromPath } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
@@ -413,7 +413,7 @@ export default function RecordeditProvider({
   }
 
   const handleInputHeightAdjustment = (fieldName: string, msgCleared: boolean, fieldType: string) => {
-    
+
     const ele: HTMLElement | null = document.querySelector(`.input-switch-container-${fieldName}`);
     const height = ele?.offsetHeight || 0;
     // how to handle this ? get default heights

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -252,7 +252,8 @@ export default function RecordeditProvider({
       const currRow: any = {};
       reference.columns.forEach((col: any) => {
         // TODO: fix indexing
-        currRow[col.name] = data[idx + '-' + col.displayname.value] || null
+        const v = data[idx + '-' + col.displayname.value];
+        currRow[col.name] = (v === undefined || v === '') ? null : v;
       });
       submissionRows.push(currRow);
     });

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -136,8 +136,8 @@ export const DEFAULT_HEGHT_MAP: any = {
   'markdown': 47,
   'longtext': 47,
   'json': 47,
-  'color': 47, 
-  'shorttext': 47, 
+  'color': 47,
+  'shorttext': 47,
   'disabled': 47
 }
 
@@ -149,4 +149,19 @@ export function formatInt(value: string) {
 export function formatFloat(value: string) {
   const floatVal = parseFloat(value);
   return !isNaN(floatVal) ? floatVal : null;
+}
+
+/**
+ * given the column and a valid, return the displayed value.
+ * checks for preformat config before returning true/falsew
+ */
+export function formatBoolean(column: any, value: any) {
+  return column.formatvalue(value);
+}
+
+/**
+ * If the value is not null or undefined, return it. otherwise return the alt.
+ */
+export function replaceNullOrUndefined(val: any, alt: any) {
+  return (val === null || val === undefined) ? alt : val;
 }

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -141,6 +141,14 @@ export const DEFAULT_HEGHT_MAP: any = {
   'disabled': 47
 }
 
+export const ERROR_MESSAGES = {
+  REQUIRED: 'Please enter a value for this field.',
+  INVALID_INTEGER: 'Please enter a valid integer value.',
+  INVALID_NUMERIC: 'Please enter a valid decimal value.',
+  INVALID_DATE: 'Please enter a valid date value.',
+  INVALID_TIMESTAMP: 'Please enter a valid date and time value.'
+}
+
 export function formatInt(value: string) {
   const intVal = parseInt(value, 10);
   return !isNaN(intVal) ? intVal : null;

--- a/src/utils/recordedit-utils.ts
+++ b/src/utils/recordedit-utils.ts
@@ -13,7 +13,7 @@ import { RecordeditColumnModel, TimestampOptions } from '@isrd-isi-edu/chaise/sr
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 
 // utilities
-import { formatDatetime, formatFloat, formatInt, getInputType, isDisabled } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { formatBoolean, formatDatetime, formatFloat, formatInt, getInputType, replaceNullOrUndefined, isDisabled } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 
 /**
  * Create a columnModel based on the given column that can be used in a recordedit form
@@ -39,21 +39,9 @@ export function columnToColumnModel(column: any): RecordeditColumnModel {
     type = getInputType(column.type);
   }
 
-  // if (type == 'boolean') {
-  //   var trueVal = InputUtils.formatBoolean(column, true),
-  //     falseVal = InputUtils.formatBoolean(column, false),
-  //     booleanArray = [trueVal, falseVal];
-
-  //   // create map
-  //   var booleanMap = {};
-  //   booleanMap[trueVal] = true;
-  //   booleanMap[falseVal] = false;
-  // }
 
   return {
     // allInput: undefined,
-    // booleanArray: booleanArray || [],
-    // booleanMap: booleanMap || {},
     column: column,
     isDisabled: isInputDisabled,
     isRequired: !column.nullok && !isInputDisabled,
@@ -66,11 +54,11 @@ export function columnToColumnModel(column: any): RecordeditColumnModel {
 }
 
 /**
- * 
- * @returns 
+ *
+ * @returns
  * @param columnModels
  * @param forms
- * @param prefillQueryParam 
+ * @param prefillQueryParam
  * --not implemented - used by viewer app @param initialValues
  */
 export function populateCreateInitialValues(
@@ -161,11 +149,6 @@ export function populateCreateInitialValues(
           initialModelValue = formatDatetime(defaultValue, tsOptions);
           isTimestamp = true;
           break;
-        // case 'boolean':
-        //     if (defaultValue != null) {
-        //         initialModelValue = InputUtils.formatBoolean(column, defaultValue);
-        //     }
-        //     break;
         default:
           if (column.isAsset) {
             const metaObj: any = {};
@@ -251,7 +234,7 @@ export function populateCreateInitialValues(
           values[`${formIdx}-${column.name}-time`] = initialModelValue?.time || '';
         }
       } else {
-        values[`${formIdx}-${column.name}`] = initialModelValue || '';
+        values[`${formIdx}-${column.name}`] = replaceNullOrUndefined(initialModelValue, '');
       }
     }
   });
@@ -310,7 +293,7 @@ export function populateEditInitialValues(
 
       // Transform column values for use in view model
       const options: TimestampOptions = { outputMomentFormat: '' }
-      let isTimestamp = false;
+      let isTimestamp = false
       switch (column.type.name) {
         case 'timestamp':
           value = formatDatetime(tupleValues[i], options);
@@ -332,9 +315,6 @@ export function populateEditInitialValues(
         case 'numeric':
           // If input is disabled, there's no need to transform the column value.
           value = isDisabled ? tupleValues[i] : formatFloat(tupleValues[i]);
-          break;
-        case 'boolean':
-          // value = formatBoolean(column, tupleValues[i]);
           break;
         default:
           // the structure for asset type columns is an object with a 'url' property
@@ -378,9 +358,9 @@ export function populateEditInitialValues(
           values[`${tupleIndex}-${column.name}-time`] = value?.time || '';
         }
       } else {
-        values[`${tupleIndex}-${column.name}`] = value || '';
+        values[`${tupleIndex}-${column.name}`] = replaceNullOrUndefined(value, '');
       }
-      
+
     });
   });
 


### PR DESCRIPTION
This PR will add `boolean-field.tsx` component. While working on this I found several issues. I created this PR mainly to be able to explain those issues so later we can get back to this and fix them.

- Recordedit doesn't behave properly if the column names have white space. It's failing to pick up the value, and in dev mode, as soon as I change the input I'm getting an error that says, `A component is changing an uncontrolled input to be controlled`. This shows that the input wasn't even setup properly.
- Recordedit is not ensuring the required fields are non-empty before sending the request to ermrestjs. As far as I could tell, in `react-hook-form` we should be able to do the following:
  ```ts
  const registerOptions = {
    required: columnModel?.isRequired ? ERROR_MESSAGES.REQUIRED : false,
  };

  const formInput = useController({
    name,
    control,
    rules: registerOptions,
  });
  ```

  But this is different from our desired behavior. By doing this, the form will be in "error state" as soon as it loads. But we want the form to check for this error only after the submission is attempted.

  We should also probably change how we show the error for each field. We currently have an `isTouched` condition for showing errors, but the required error should be displayed regardless of whether the user has "touched" the input.

