### PR TITLE
Limit the number of displayed selected items in facet panel

### DIFF
--- a/src/assets/scss/_facet-choice-picker.scss
+++ b/src/assets/scss/_facet-choice-picker.scss
@@ -9,6 +9,11 @@
       margin-bottom: 10px;
     }
 
+    .more-filters {
+      margin-left: 5px;
+      font-style: italic;
+    }
+
     .button-container {
       margin-top: auto;
       height: 20px;

--- a/src/assets/scss/_facet-choice-picker.scss
+++ b/src/assets/scss/_facet-choice-picker.scss
@@ -12,6 +12,15 @@
     .more-filters {
       margin-left: 5px;
       font-style: italic;
+
+      .fa-triangle-exclamation {
+        margin-left: 1px;
+        font-size: 1.2em;
+      }
+      .more-filters-text {
+        margin-left: 3px;
+      }
+
     }
 
     .button-container {

--- a/src/assets/scss/_recordset.scss
+++ b/src/assets/scss/_recordset.scss
@@ -2,7 +2,16 @@
 @import "variables";
 
 .chaise-body {
+
   .recordset-container {
+    // override the minimum width of side-panel (written the same way as app.scss
+    // this is done to fit the more-filters message
+    .top-panel-container .top-flex-panel .top-left-panel.open-panel,
+    .bottom-panel-container .side-panel-resizable.open-panel {
+      min-width: 250px;
+    }
+
+
     .top-panel-container {
       .top-flex-panel .top-left-panel div.panel-header {
         bottom: 10px;

--- a/src/assets/scss/_recordset.scss
+++ b/src/assets/scss/_recordset.scss
@@ -8,7 +8,7 @@
     // this is done to fit the more-filters message
     .top-panel-container .top-flex-panel .top-left-panel.open-panel,
     .bottom-panel-container .side-panel-resizable.open-panel {
-      min-width: 250px;
+      min-width: 270px;
     }
 
 

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -32,11 +32,12 @@ $dropdown-menu-anchor-color: #9d9d9d;
 // Spacing
 $left-panel-width-lg: 21vw;
 $left-panel-width-sm: 15vw;
+$left-panel-min-width: 170px;
 $viewport-margin: 20px;
 $main-alley:30px;
 
 
-
+// button props
 $btn-border-radius: 4px;
 $btn-height: 30px;
 $btn-height-sm: 24px;
@@ -53,6 +54,10 @@ $chaise-input-group-text-border-color: $border-color;
 
 // edit column name column
 $chaise-caption-column-width: 200px;
+
+// checkbox
+$chaise-checkbox-width: 20px;
+$chaise-checkbox-height: 20px;
 
 
 // fonts

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -513,7 +513,7 @@ html {
         &.open-panel {
           flex: 0;
           flex-basis: $left-panel-width-lg;
-          min-width: 170px;
+          min-width: $left-panel-min-width;
 
           &.small-panel {
             flex-basis: $left-panel-width-sm;
@@ -583,7 +583,7 @@ html {
       &.open-panel {
         flex: 0;
         flex-basis: $left-panel-width-lg;
-        min-width: 170px;
+        min-width: $left-panel-min-width;
 
         &.small-panel {
           flex-basis: $left-panel-width-sm;
@@ -703,7 +703,7 @@ html {
       font-weight: 400;
       position: relative;
       vertical-align: middle;
-      min-height: 20px;
+      min-height: $chaise-checkbox-height;
       margin-bottom: 0;
     }
     &.no-left-padding label {
@@ -714,8 +714,8 @@ html {
       position: absolute;
       z-index: 1;
       cursor: pointer;
-      width: 20px;
-      height: 20px;
+      width: $chaise-checkbox-width;
+      height: $chaise-checkbox-height;
       top: 0;
       margin-top: 2px;
 
@@ -740,8 +740,8 @@ html {
         content: "";
         display: inline-block;
         position: absolute;
-        width: 20px;
-        height: 20px;
+        width: $chaise-checkbox-width;
+        height: $chaise-checkbox-height;
         left: 0;
         top: 0;
         border: 1px solid $primary-color;

--- a/src/components/faceting/facet-check-list.tsx
+++ b/src/components/faceting/facet-check-list.tsx
@@ -31,7 +31,11 @@ type FacetCheckListProps = {
   /**
    * If true, we should disable other options
    */
-  hasNotNullFilter?: boolean
+  hasNotNullFilter?: boolean,
+  /**
+   * limit the number of displayed rows (regardless of available height)
+   */
+  maxDisplayedRows?: number,
   // TODO favorites support
   // enableFavorites?: boolean,
   // onFavoritesChanged: Function
@@ -108,7 +112,8 @@ const FacetCheckList = ({
   setHeight,
   rows,
   onRowClick,
-  hasNotNullFilter
+  hasNotNullFilter,
+  maxDisplayedRows
 }: FacetCheckListProps): JSX.Element => {
   // TODO favorites support:
   // const [favoritesLoading, setFavoritesLoading] = useState<{[key: number]: boolean}>({});
@@ -148,6 +153,8 @@ const FacetCheckList = ({
     }
 
     return rows.map((row: FacetCheckBoxRow, index: number) => {
+      if (maxDisplayedRows && index >= maxDisplayedRows) return;
+
       let rowClass = 'chaise-checkbox ellipsis-text';
       // if there's a not-null, all the other options should be disabled
       const disabled = hasNotNullFilter && !row.isNotNull;

--- a/src/components/faceting/facet-choice-picker.tsx
+++ b/src/components/faceting/facet-choice-picker.tsx
@@ -598,6 +598,13 @@ const FacetChoicePicker = ({
   )).length;
 
   const renderPickerContainer = () => {
+    const useShowMore = (hasMore || showFindMore);
+
+    let showMoreTooltip = 'Click here to see more information about available items.';
+    if (useShowMore) {
+      showMoreTooltip = 'Click here to show more available items with details.';
+    }
+
     return (
       <div className='picker-container'>
         {facetColumn.column.type.name !== 'boolean' &&
@@ -618,18 +625,23 @@ const FacetChoicePicker = ({
           />
         </div>
         {hiddenSelectedCount > 0 &&
-          <span className='more-filters'>...{hiddenSelectedCount} more filters selected</span>
+          <span className='more-filters'>
+            <span className='fa-solid fa-triangle-exclamation' />
+            <span className='more-filters-text'> {hiddenSelectedCount} selected items not shown.</span>
+          </span>
         }
         <div className='button-container'>
           {/* TODO id='show-more' removed */}
-          <button
-            className='chaise-btn chaise-btn-sm chaise-btn-tertiary show-more-btn'
-            disabled={facetColumn.hasNotNullFilter}
-            onClick={() => openRecordsetModal()}
-          >
-            <span className='chaise-btn-icon far fa-window-restore'></span>
-            <span>{(hasMore || showFindMore) ? 'Show More' : 'Show Details'}</span>
-          </button>
+          <ChaiseTooltip placement='right' tooltip={showMoreTooltip}>
+            <button
+              className='chaise-btn chaise-btn-sm chaise-btn-tertiary show-more-btn'
+              disabled={facetColumn.hasNotNullFilter}
+              onClick={() => openRecordsetModal()}
+            >
+              <span className='chaise-btn-icon far fa-window-restore'></span>
+              <span>{useShowMore ? 'Show More' : 'Show Details'}</span>
+            </button>
+          </ChaiseTooltip>
           {facetModel.noConstraints &&
             <ChaiseTooltip
               tooltip='Retry updating the facet values with constraints.'

--- a/src/components/faceting/facet-choice-picker.tsx
+++ b/src/components/faceting/facet-choice-picker.tsx
@@ -592,6 +592,11 @@ const FacetChoicePicker = ({
 
   //-------------------  render logic:   --------------------//
 
+  // number of rows that are selected and not visible to users (as we're only showing 10 facets)
+  const hiddenSelectedCount = checkboxRows.filter((r: FacetCheckBoxRow, i: number) => (
+    i >= FACET_PANEL_DEFAULT_PAGE_SIZE && r.selected
+  )).length;
+
   const renderPickerContainer = () => {
     return (
       <div className='picker-container'>
@@ -609,9 +614,12 @@ const FacetChoicePicker = ({
           <FacetCheckList
             setHeight={facetModel.isOpen && facetModel.initialized && facetPanelOpen}
             rows={checkboxRows} hasNotNullFilter={facetColumn.hasNotNullFilter}
-            onRowClick={onRowClick}
+            onRowClick={onRowClick} maxDisplayedRows={FACET_PANEL_DEFAULT_PAGE_SIZE}
           />
         </div>
+        {hiddenSelectedCount > 0 &&
+          <span className='more-filters'>...{hiddenSelectedCount} more filters selected</span>
+        }
         <div className='button-container'>
           {/* TODO id='show-more' removed */}
           <button

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -192,7 +192,7 @@ const RecordsetTable = ({
           <>
             <ChaiseTooltip
               placement='right'
-              tooltip={'Select all rows on this page.'}
+              tooltip={'Select all items on this page.'}
             >
               <button className='table-select-all-rows chaise-btn chaise-btn-secondary chaise-btn-sm'
                 type='button' onClick={selectAllOnPage}
@@ -203,7 +203,7 @@ const RecordsetTable = ({
             </ChaiseTooltip>
             <ChaiseTooltip
               placement='right'
-              tooltip={'Deselect all rows on this page.'}
+              tooltip={'Deselect all items on this page.'}
             >
               <button className='chaise-btn chaise-btn-secondary chaise-btn-sm'
                 type='button' onClick={DeselectAllOnPage}

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -49,13 +49,17 @@ const RecordsetTable = ({
   let isRowSelected = Array(page ? page.length : 0).fill(false);
   if (page && page.length && Array.isArray(selectedRows) && selectedRows.length > 0) {
     isRowSelected = page.tuples.map((tuple: any) => (
-      selectedRows.some((obj) => obj.uniqueId === tuple.uniqueId)
+      // ermrestjs always returns a string for uniqueId, but internally we don't
+      // eslint-disable-next-line eqeqeq
+      selectedRows.some((obj) => obj.uniqueId == tuple.uniqueId)
     ));
   }
   let isRowDisabled = Array(page ? page.length : 0).fill(false);
   if (page && page.length && Array.isArray(disabledRows) && disabledRows.length > 0) {
     isRowDisabled = page.tuples.map((tuple: any) => (
-      disabledRows.some((obj) => obj.uniqueId === tuple.uniqueId)
+      // ermrestjs always returns a string for uniqueId, but internally we don't
+      // eslint-disable-next-line eqeqeq
+      disabledRows.some((obj) => obj.uniqueId == tuple.uniqueId)
     ));
   }
 

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -598,7 +598,7 @@ const RecordsetInner = ({
             <FilterChiclet
               key={`selected-filter-chiclet-${facetIndex}`}
               identifier={facetIndex}
-              iconTooltip={'Clear filter applied'}
+              iconTooltip={'Clear applied filter.'}
               title={facetDisplayname}
               titleTooltip={<span>Go to <DisplayValue value={facetDisplayname} /> filter</span>}
               value={chicletValue}
@@ -618,7 +618,7 @@ const RecordsetInner = ({
         {showClearAll &&
           <ChaiseTooltip
             placement='bottom-start'
-            tooltip={'Clear all filters applied'}
+            tooltip={'Clear all applied filters.'}
           >
             <button
               className='clear-all-filters chaise-btn chaise-btn-tertiary clear-all-btn'

--- a/src/components/selected-rows.tsx
+++ b/src/components/selected-rows.tsx
@@ -63,7 +63,7 @@ const SelectedRows = ({
       <>
         <ChaiseTooltip
           placement='bottom-start'
-          tooltip='Clear selected row'
+          tooltip='Clear selected item.'
         >
           <div className='selected-chiclet-remove' onClick={(event) => removeCallback(row, event)}>
             <i className='fa-solid fa-xmark selected-chiclet-remove-icon' />
@@ -82,7 +82,7 @@ const SelectedRows = ({
   const renderShowMoreLessBtn = (isMoreBtn: boolean) => (
     <ChaiseTooltip
       placement='bottom-start'
-      tooltip={isMoreBtn ? 'Click to show all selected values.' : 'Click to hide some selected values.'}
+      tooltip={isMoreBtn ? 'Click to show all selected items.' : 'Click to hide some of the selected items.'}
     >
       <button
         className={`chaise-btn chaise-btn-tertiary selected-chiclets-btn ${isMoreBtn ? 'show-more-btn' : 'show-less-btn'}`}
@@ -96,7 +96,7 @@ const SelectedRows = ({
   const renderClearAllBtn = () => (
     <ChaiseTooltip
       placement='bottom-start'
-      tooltip='Clear all selected rows'
+      tooltip='Clear all the selected items.'
     >
       <button
         className='chaise-btn chaise-btn-tertiary clear-all-btn selected-chiclets-btn'

--- a/src/models/recordset.ts
+++ b/src/models/recordset.ts
@@ -143,8 +143,8 @@ export type FacetRequestModel = {
 export type SelectedRow = {
   displayname: Displayname;
   uniqueId: string | null;
-  data?: any; // TODO
-  tupleReference: any; // TODO
+  data?: any;
+  tupleReference?: any;
   // the following can be added for plot app and might require change:
   // cannotBeRemoved?: boolean;
 }

--- a/test/e2e/data_setup/schema/recordset/faceting.json
+++ b/test/e2e/data_setup/schema/recordset/faceting.json
@@ -205,8 +205,8 @@
                     ],
                     "filter": {
                         "and": [
-                            {"source": "id", "ux_mode": "choices", "choices": ["1"], "comment": "ID comment", "hide_null_choice": true},
-                            {"source": "int_col", "ranges": [{"min": "-2"}], "bar_plot": false, "comment": "int comment"},
+                            {"source": "id", "ux_mode": "choices", "choices": [1], "comment": "ID comment", "hide_null_choice": true},
+                            {"source": "int_col", "ranges": [{"min": -2}], "bar_plot": false, "comment": "int comment"},
                             {"source": "float_col", "bar_plot": false},
                             {"source": "date_col", "bar_plot": false},
                             {"source": "timestamp_col", "bar_plot": false, "comment": "timestamp column"},

--- a/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
+++ b/test/e2e/specs/delete-prohibited/recordset/ind-facet.spec.js
@@ -333,7 +333,7 @@ describe("Viewing Recordset with Faceting,", function () {
         });
 
         describe("default presentation based on facets annotation ", function () {
-            it("should have " + testParams.totalNumFacets + " facets", function () {
+            it("should have " + testParams.totalNumFacets + " facets", function (done) {
                 browser.wait(function () {
                     return chaisePage.recordsetPage.getAllFacets().count().then(function (ct) {
                         return (ct == testParams.totalNumFacets);
@@ -344,11 +344,12 @@ describe("Viewing Recordset with Faceting,", function () {
                     titles.forEach(function (title, idx) {
                         expect(title.getText()).toEqual(testParams.facetNames[idx], "All facets' names is incorrect");
                     });
-                });
+                    done();
+                }).catch(chaisePage.catchTestError(done));
 
             });
 
-            it("verify the text is truncated properly based on the 'maxRecordsetRowHeight=100', then not truncated after clicking 'more'", function () {
+            it("verify the text is truncated properly based on the 'maxRecordsetRowHeight=100', then not truncated after clicking 'more'", function (done) {
                 // default config: maxRecordsetRowHeight = 100
                 // 100 for max height, 10 for padding, 1 for border
                 var testCell, cellHeight = 110;
@@ -369,9 +370,8 @@ describe("Viewing Recordset with Faceting,", function () {
                     return testCell.getSize();
                 }).then(function (tallerDimensions) {
                     expect(tallerDimensions.height).toBeGreaterThan(cellHeight);
-                }).catch(function (err) {
-                    console.log(err);
-                });
+                    done();
+                }).catch(chaisePage.catchTestError(done));
             });
 
             it("should have 3 facets open", function (done) {

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -1102,6 +1102,10 @@ var recordsetPage = function() {
         return element(by.css(".fc-" + idx)).all(by.css(".chaise-checkbox input.checked"));
     }
 
+    this.getFacetMoreFiltersText = function (idx) {
+      return element(by.css(".fc-" + idx)).element(by.css('.more-filters'));
+    }
+
     this.getFacetOptionsText = function (idx) {
       return browser.executeScript(`
         return Array.from(document.querySelectorAll('.fc-${idx} .chaise-checkbox label')).map((el) => el.textContent.trim())


### PR DESCRIPTION
Currently, we're showing all the selected choices in the facet panel. So if users open the facet panel and select 50 rows, we will show all the selected 50 items in the facet panel. This would make the facet panel very difficult to use as users must scroll a lot to get to the other displayed facets.

This PR will ensure we're limiting the number of selected items we're displaying in the panel. In this case, I'm showing a warning below the list to inform users about the hidden items.

As part of this PR, I also added tooltips to show more/details buttons and ensured all the tooltips/text related to facets were consistent. 
