### PR TITLE
Change recordedit layout to be row-based and add dynamic ACL support

### DIFF
--- a/src/assets/scss/_button-group.scss
+++ b/src/assets/scss/_button-group.scss
@@ -25,6 +25,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
+    gap: 5px;
 
     .input-group {
         width: auto;

--- a/src/assets/scss/_inputs.scss
+++ b/src/assets/scss/_inputs.scss
@@ -132,12 +132,6 @@
   }
 }
 
-.chaise-btn-toolbar > .chaise-btn,
-.chaise-btn-toolbar > .chaise-btn-group,
-.chaise-btn-toolbar > .chaise-input-group {
-    margin-left: 5px;
-}
-
 .chaise-boolean-dropdown {
     .chaise-input-control.has-feedback {
         padding-right: $input-remove-width + $btn-height;

--- a/src/assets/scss/_recordedit.scss
+++ b/src/assets/scss/_recordedit.scss
@@ -1,340 +1,304 @@
-@import 'helpers';
-@import 'variables';
+@import "helpers";
+@import "variables";
 
 // From _recordedit-app.scss
 #recordedit .app-container {
-    .btn-sm[data-handler="bootstrap-markdown-cmdRidLink"] {
-        padding: 5px 3px;
+  .btn-sm[data-handler="bootstrap-markdown-cmdRidLink"] {
+    padding: 5px 3px;
+  }
+
+  .form-controls {
+    display: flex;
+    align-items: flex-end;
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    .add-forms {
+      width: auto;
+      margin-left: auto;
+
+      .add-rows-input {
+        width: 50px;
+        padding-left: 5px;
+      }
+    }
+  }
+
+  @mixin shift-above-edit-forms() {
+    height: 15px;
+    position: fixed;
+    z-index: 5;
+    margin-top: -15px;
+  }
+
+  #form-section {
+    display: flex;
+    flex-direction: row;
+    overflow-y: auto;
+    overflow-x: hidden;
+    width: 100%;
+    position: relative;
+    padding-top: 15px;
+    // padding at bottom of page so edit form isn't touching the bottom of viewport
+    // padding instead of margin so it doesn't mess with scrollable area
+    padding-bottom: 40px;
+
+    .entity-key-column {
+      display: flex;
+      flex-direction: column;
+      flex-shrink: 0;
+
+      .entity-key,
+      .match-entity-key {
+        width: $chaise-caption-column-width;
+        border-left: $chaise-RE-border-width solid $chaise-RE-border-color;
+        border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
+        border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
+        // margin-left: 10px;
+        background: white;
+        padding: 8px;
+
+        min-height: 47px;
+        height: 47px;
+
+        flex: none;
+      }
+
+      .match-entity-key.select-all-opened {
+        border-top: none;
+      }
     }
 
-    .form-controls {
+    .form-container {
+      width: 100%;
+      overflow-x: auto;
+      height: fit-content;
+
+      .recordedit-form {
         display: flex;
-        align-items: flex-end;
-        padding-top: 10px;
-        padding-bottom: 10px;
-
-        .add-forms {
-            width: auto;
-            margin-left: auto;
-
-            .add-rows-input {
-                width: 50px;
-                padding-left: 5px;
-            }
-        }
-    }
-
-    @mixin shift-above-edit-forms() {
-        height: 15px;
-        position: fixed;
-        z-index: 5;
-        margin-top: -15px;
-    }
-
-    .bottom-panel-container {
-        display: flex;
-        width: 100%;
-    }
-
-    // .main-container {
-    //     overflow-y: auto;
-    //     overflow-x: hidden;
-    //     // changes a style from app.scss
-    //     flex-direction: row;
-    // }
-
-    #form-section {
-        display: flex;
-        flex-direction: row;
-        overflow-y: auto;
-        overflow-x: hidden;
-        width: 100%;
+        flex-direction: column;
+        background-color: white;
+        height: 100%;
+        min-width: 250px;
+        color: black;
         position: relative;
-        padding-top: 15px;
-        // padding at bottom of page so edit form isn't touching the bottom of viewport
-        // padding instead of margin so it doesn't mess with scrollable area
-        padding-bottom: 40px;
 
-        .entity-key-column {
-            display: flex;
-            flex-direction: column;
-            flex-shrink: 0;
-
-            .entity-key,
-            .match-entity-key {
-                width: $chaise-caption-column-width;
-                border-left: $chaise-RE-border-width solid $chaise-RE-border-color;
-                border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
-                border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
-                // margin-left: 10px;
-                background: white;
-                padding: 8px;
-
-                min-height: 47px;
-                height: 47px;
-
-                flex: none;
-            }
-
-            .match-entity-key.select-all-opened {
-                border-top: none;
-            }
+        .form-inputs-row,
+        .form-header-row {
+          display: flex;
         }
 
-        .form-container {
+        // form header and form inputs
+        .entity-value {
+          // make sure the inputs take up as much space as they can
+          // and are the same size
+          flex: 1 1 0;
+          position: relative;
+
+          .column-permission-overlay {
+            position: absolute;
+            left: 0;
+            top: 0;
+            height: 100%;
             width: 100%;
-            overflow-x: auto;
-            height: fit-content;
+            z-index: 6; // higher than the chaise-clear
+          }
 
-            .recordedit-form {
-                display: flex;
-                background-color: white;
-                height: 100%;
-                min-width: 250px;
-                color: black;
-                position: relative;
+          .column-permission-warning {
+            margin: 0;
+            padding: 5px;
+            color: rgb(180, 95, 6);
+          }
 
-                .column-form {
-                    flex-grow: 1;
-                    flex-shrink: 0;
-                    flex-direction: column;
-
-                    // form header and form inputs
-                    .entity-value {
-                        position: relative;
-
-                        .column-permission-overlay {
-                            position: absolute;
-                            left: 0;
-                            top: 0;
-                            height: 100%;
-                            width: 100%;
-                            z-index: 6; // higher than the chaise-clear
-                        }
-
-                        .column-permission-warning {
-                            margin: 0;
-                            padding: 5px;
-                            color: rgb(180, 95, 6);
-                        }
-                    }
-
-                    // only form header
-                    .entity-value.form-header {
-                        .remove-form-btn {
-                            float: right;
-                            padding: 1px 7px 0px 7px;
-                        }
-
-                        .disabled-row-icon {
-                            margin: 6px 10px 0 0;
-                            font-size: 1.3em;
-                        }
-                    }
-
-                    // only form inputs
-                    .column-cell {
-                        border-left: none;
-                        border-top: none;
-                        border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
-                        border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
-                        border-radius: 0;
-                        // height: 47px;
-                        min-height: 47px;
-                        padding: 8px 10px;
-
-                        .chaise-input-control.column-cell-input {
-                            border: 1px solid $border-color;
-                            border-radius: 4px;
-                            padding: 0 10px;
-                            display: flex;
-                            align-items: center;
-
-                            .input-switch {
-                                height: auto;
-                            }
-                        }
-                    }
-                }
+          // displayed while loading the fk data
+          .column-cell-spinner-container {
+            $column-cell-backdrop-z-index: 5;
+            .column-cell-spinner-backdrop {
+              position: absolute;
+              top: 0;
+              left: 0;
+              height: 100%;
+              width: 100%;
+              z-index: $column-cell-backdrop-z-index;
+              background: $disabled-background-color;
+              opacity: 0.55;
             }
-        }
-
-        // nested inside entity-key-column AND form-container
-        .form-header {
-            height: 47px;
-            border-top: $chaise-RE-border-width solid $chaise-RE-border-color;
-            color: $disabled-color;
-            font-weight: normal;
-            font-size: 1rem;
+            .spinner-border-sm {
+              left: 50%;
+              top: 15px;
+              position: absolute;
+              z-index: calc($column-cell-backdrop-z-index + 1);
+            }
+          }
         }
 
         .entity-value,
         .match-entity-value {
-            word-wrap: break-word;
-            min-width: 250px;
-            border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
-            border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
+          word-wrap: break-word;
+          min-width: 250px;
+          border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
+          border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
 
-            // border-left: none;
-            // border-top: none;
+          // border-left: none;
+          // border-top: none;
 
-            border-radius: 0;
-            min-height: 47px;
-            padding: 8px 10px;
+          border-radius: 0;
+          min-height: 47px;
+          padding: 8px 10px;
         }
 
-        .entity-value {
-            position: relative;
+        // only form inputs
+        .column-cell {
+          border-left: none;
+          border-top: none;
+          border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
+          border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
+          border-radius: 0;
+          // height: 47px;
+          min-height: 47px;
+          padding: 8px 10px;
 
-            // displayed while loading the fk data
-            .column-cell-spinner-container {
-              $column-cell-backdrop-z-index: 5;
-              .column-cell-spinner-backdrop {
-                position: absolute;
-                top: 0;
-                left: 0;
-                height: 100%;
-                width: 100%;
-                z-index: $column-cell-backdrop-z-index;
-                background: $disabled-background-color;
-                opacity: 0.55;
-              }
-              .spinner-border-sm {
-                left: 50%;
-                top: 15px;
-                position: absolute;
-                z-index: calc($column-cell-backdrop-z-index + 1);
-              }
+          .chaise-input-control.column-cell-input {
+            border: 1px solid $border-color;
+            border-radius: 4px;
+            padding: 0 10px;
+            display: flex;
+            align-items: center;
+
+            .input-switch {
+              height: auto;
             }
-
-            .column-permission-overlay {
-                position: absolute;
-                left: 0;
-                top: 0;
-                height: 100%;
-                width: 100%;
-                z-index: 6; // higher than the chaise-clear
-            }
-
-            .column-permission-warning {
-                margin: 0;
-                padding: 5px;
-                color: rgb(180, 95, 6);
-            }
-
+          }
         }
+      }
     }
 
-    // // end #form-section
+    // in both entity-key-column and form-container
+    .form-header {
+      height: 47px;
+      border-top: $chaise-RE-border-width solid $chaise-RE-border-color;
+      color: $disabled-color;
 
-    .modal-popup {
-        width: 100%;
-        margin-bottom: 0px;
-    }
-
-    .record-number {
-        font-size: 14px;
-        margin-left: 10px;
-        color: $disabled-color;
-    }
-
-    tbody.highlight {
-        background-color: #f7f0cf !important;
-    }
-
-    .chaise-input-control[readonly] {
-        background-color: $white-color;
-        opacity: 1;
-    }
-
-    textarea,
-    .disabled-textarea {
-        resize: vertical;
-        height: auto;
-    }
-
-    .input-timestamptz {
-        min-width: 112px;
-    }
-
-    .adjust-boolean-dropdown {
-        border-top: 0;
-    }
-
-    .select-all-text {
-        padding: 4px;
-        border: 1px solid transparent;
-    }
-
-    @-moz-document url-prefix() {
-        #form-edit>table>tbody>tr>td:first-child {
-            margin-top: -1px;
+      .form-header-buttons-container {
+        float: right;
+        .remove-form-btn {
+          padding: 1px 7px 0px 7px;
         }
+
+        .disabled-row-icon {
+          margin-right: 10px;
+          font-size: 1.3em;
+          vertical-align: middle;
+        }
+      }
     }
+  }
 
-    .resultset-tables {
-      padding-top: 10px;
-      padding-bottom: 20px;
+  // // end #form-section
+
+  .modal-popup {
+    width: 100%;
+    margin-bottom: 0px;
+  }
+
+  .record-number {
+    font-size: 14px;
+    margin-left: 10px;
+    color: $disabled-color;
+  }
+
+  tbody.highlight {
+    background-color: #f7f0cf !important;
+  }
+
+  .chaise-input-control[readonly] {
+    background-color: $white-color;
+    opacity: 1;
+  }
+
+  textarea,
+  .disabled-textarea {
+    resize: vertical;
+    height: auto;
+  }
+
+  .input-timestamptz {
+    min-width: 112px;
+  }
+
+  .adjust-boolean-dropdown {
+    border-top: 0;
+  }
+
+  .select-all-text {
+    padding: 4px;
+    border: 1px solid transparent;
+  }
+
+  @-moz-document url-prefix() {
+    #form-edit > table > tbody > tr > td:first-child {
+      margin-top: -1px;
     }
+  }
 
-    /****************** Upload modal css *****************/
+  .resultset-tables {
+    padding-top: 10px;
+    padding-bottom: 20px;
+  }
 
+  /****************** Upload modal css *****************/
 
-    // .progress-percent {
-    //   font-weight: bold;
-    //   margin-top: -25px;
-    //   margin-left: 50%;
-    // }
+  // .progress-percent {
+  //   font-weight: bold;
+  //   margin-top: -25px;
+  //   margin-left: 50%;
+  // }
 
-    // .inner-progress-percent {
-    //   margin-top: -18px;
-    //   font-size: 12px;
-    // }
+  // .inner-progress-percent {
+  //   margin-top: -18px;
+  //   font-size: 12px;
+  // }
 
-    // table.upload-table {
+  // table.upload-table {
 
-    // }
+  // }
 
-    // table.upload-table > tbody {
-    //   border: none;
-    // }
+  // table.upload-table > tbody {
+  //   border: none;
+  // }
 
-    // table.upload-table > tbody > tr > td:first-child {
-    //   padding-left: 20px;
+  // table.upload-table > tbody > tr > td:first-child {
+  //   padding-left: 20px;
 
-    // }
+  // }
 
-    // table.upload-table > tbody > tr > td:last-child {
-    //   width: 40%;
-    // }
+  // table.upload-table > tbody > tr > td:last-child {
+  //   width: 40%;
+  // }
 
-    // table.upload-table > tbody > tr > td:nth-child(2) {
-    //   padding-left: 0px;
-    //   padding-right: 0px;
-    // }
+  // table.upload-table > tbody > tr > td:nth-child(2) {
+  //   padding-left: 0px;
+  //   padding-right: 0px;
+  // }
 
+  // table.upload-table > tbody > tr:last-child > td {
+  //   border-bottom: 1px solid $disabled-background-color;
+  //   background-color: white;
+  // }
 
-    // table.upload-table > tbody > tr:last-child > td {
-    //   border-bottom: 1px solid $disabled-background-color;
-    //   background-color: white;
-    // }
+  // table.upload-table > tbody > tr:first-child > td {
+  //   padding-left:0px;
+  //   padding-top: 15px;
+  //   border-bottom: 2px solid gainsboro;
+  //   font-weight: 600;
+  // }
 
+  // table.upload-table .progress {
+  //   height: 20px;
+  // }
 
-    // table.upload-table > tbody > tr:first-child > td {
-    //   padding-left:0px;
-    //   padding-top: 15px;
-    //   border-bottom: 2px solid gainsboro;
-    //   font-weight: 600;
-    // }
-
-
-    // table.upload-table .progress {
-    //   height: 20px;
-    // }
-
-
-    // .upload-progress-bar {
-    //   width: 0%;
-    //   background-color: #8cacc7 !important;
-    // }
+  // .upload-progress-bar {
+  //   width: 0%;
+  //   background-color: #8cacc7 !important;
+  // }
 }

--- a/src/components/input-switch.tsx
+++ b/src/components/input-switch.tsx
@@ -20,7 +20,6 @@ import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedi
 // utils
 import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { arrayFieldPlaceholder, ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 
@@ -154,14 +153,6 @@ const TextField = ({
     field.onChange(v);
     field.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'text' }
-    );
-  }, [error?.message]);
 
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)}`} style={styles}>
@@ -322,14 +313,6 @@ const NumericField = ({
     field.onBlur();
   };
 
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'number' }
-    );
-  }, [error?.message])
-
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)}`} style={styles}>
       <div className={`chaise-input-control has-feedback input-switch-numeric ${classes} ${disableInput ? ' input-disabled' : ''}`}>
@@ -440,14 +423,6 @@ const DateField = ({
     field.onChange(v);
     field.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'date' }
-    );
-  }, [error?.message])
 
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)}`} style={styles}>
@@ -630,14 +605,6 @@ const TimestampField = ({
     timeField.onChange(v);
     timeField.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'timestamp' }
-    );
-  }, [error?.message])
 
   const clearDate = () => {
     setValue(`${name}-date`, '');

--- a/src/components/input-switch/array-field.tsx
+++ b/src/components/input-switch/array-field.tsx
@@ -2,15 +2,13 @@
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 
 // hooks
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext, useController } from 'react-hook-form';
 
 // utils
 import { getSimpleColumnType } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
-import { ResizeSensor } from 'css-element-queries';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 
 type ArrayFieldProps = {
@@ -121,8 +119,6 @@ const ArrayField = ({
     return true;
   };
 
-  const textAreaRef = useRef(null);
-
   // react-hook-form setup
   const { setValue, control, clearErrors } = useFormContext();
   const registerOptions = {
@@ -143,23 +139,6 @@ const ArrayField = ({
   const fieldState = formInput?.fieldState;
   const { error, isTouched } = fieldState;
 
-  // hooks
-  useEffect(() => {
-    const textAreaElement = textAreaRef.current;
-    if (!textAreaElement) return;
-    const sensor = new ResizeSensor(textAreaElement, () => {
-      fireCustomEvent(
-        'input-switch-error-update',
-        `.input-switch-container-${makeSafeIdAttr(name)}`,
-        { inputFieldName: name, msgCleared: false, type: 'array' }
-      );
-    });
-
-    return () => {
-      sensor.detach();
-    }
-  }, []);
-
   useEffect(() => {
     if (onFieldChange) {
       onFieldChange(fieldValue);
@@ -175,14 +154,6 @@ const ArrayField = ({
     setValue(name, value);
   }, [value]);
 
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'array' }
-    );
-  }, [error?.message]);
-
   // acllback functions
   const handleChange = (v: any) => {
     field.onChange(v);
@@ -196,7 +167,7 @@ const ArrayField = ({
 
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)} input-switch-array-container`} style={styles}>
-      <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`} ref={textAreaRef}>
+      <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`}>
         <textarea placeholder={placeholder} rows={5} className={`${inputClasses} input-switch`} {...field} onChange={handleChange} />
         <ClearInputBtn
           btnClassName={`${clearClasses} input-switch-clear`}

--- a/src/components/input-switch/boolean-field.tsx
+++ b/src/components/input-switch/boolean-field.tsx
@@ -1,6 +1,5 @@
 // components
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
-import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 // hooks
@@ -11,7 +10,6 @@ import { useFormContext, useController } from 'react-hook-form';
 import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 
 // utils
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { ERROR_MESSAGES, formatBoolean } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 
@@ -122,15 +120,6 @@ const BooleanField = ({
     field.onChange(v);
     field.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message) }
-    );
-  }, [error?.message]);
-
 
   const rawOptions = [true, false];
   const displayedOptions = rawOptions.map((op) => columnModel ? formatBoolean(columnModel.column, op) : op.toString());

--- a/src/components/input-switch/color-field.tsx
+++ b/src/components/input-switch/color-field.tsx
@@ -10,7 +10,6 @@ import { useFormContext, useController } from 'react-hook-form';
 import useClickOutside from '@isrd-isi-edu/chaise/src/hooks/click-outside';
 
 // utils
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { isStringAndNotEmpty } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 
 type ColorFieldProps = {
@@ -125,10 +124,6 @@ const ColorField = ({
     field.onChange(v);
     field.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent('input-switch-error-update', `.input-switch-container-${name}`, { inputFieldName: name, msgCleared: !Boolean(error?.message) });
-  }, [error?.message]);
 
   /**
    * The color preview rectangle. used in two places

--- a/src/components/input-switch/foreignkey-field.tsx
+++ b/src/components/input-switch/foreignkey-field.tsx
@@ -21,7 +21,6 @@ import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utils
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { RECORDSET_DEAFULT_PAGE_SIZE } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { getColumnModelLogStack, populateSubmissionRow } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
@@ -186,14 +185,6 @@ const ForeignkeyField = ({
     field.onChange(v);
     field.onBlur();
   };
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message) }
-    );
-  }, [error?.message]);
 
   const openRecordsetModal = (e: any) => {
     e.preventDefault();

--- a/src/components/input-switch/json-field.tsx
+++ b/src/components/input-switch/json-field.tsx
@@ -2,14 +2,12 @@
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 
 // hooks
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext, useController } from 'react-hook-form';
 
 // utils
 import { ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
-import { ResizeSensor } from 'css-element-queries';
 
 const jsonFieldValidation = (value: string) => {
   if (!value) return;
@@ -71,8 +69,6 @@ const JsonField = ({
   onFieldChange,
 }: JsonFieldProps): JSX.Element => {
 
-  const textAreaRef = useRef(null);
-
   // react-hook-form setup
   const { setValue, control, clearErrors } = useFormContext();
 
@@ -95,22 +91,6 @@ const JsonField = ({
   const { error, isTouched } = fieldState;
 
   useEffect(() => {
-    const textAreaElement = textAreaRef.current;
-    if (!textAreaElement) return;
-    const sensor = new ResizeSensor(textAreaElement, () => {
-      fireCustomEvent(
-        'input-switch-error-update',
-        `.input-switch-container-${makeSafeIdAttr(name)}`,
-        { inputFieldName: name, msgCleared: false, type: 'json' }
-      );
-    });
-
-    return () => {
-      sensor.detach();
-    }
-  }, []);
-
-  useEffect(() => {
     if (onFieldChange) {
       onFieldChange(fieldValue);
     }
@@ -125,14 +105,6 @@ const JsonField = ({
     setValue(name, value);
   }, [value]);
 
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'json' }
-    );
-  }, [error?.message]);
-
   const handleChange = (v: any) => {
     field.onChange(v);
     field.onBlur();
@@ -145,7 +117,7 @@ const JsonField = ({
 
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)} input-switch-json-container`} style={styles}>
-      <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`} ref={textAreaRef}>
+      <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`}>
         <textarea placeholder={placeholder} rows={5} className={`${inputClasses} input-switch`} {...field} onChange={handleChange} />
         <ClearInputBtn
           btnClassName={`${clearClasses} input-switch-clear`}

--- a/src/components/input-switch/longtext-field.tsx
+++ b/src/components/input-switch/longtext-field.tsx
@@ -9,10 +9,8 @@ import { useEffect, useState, useRef } from 'react';
 import { useFormContext, useController } from 'react-hook-form';
 
 // utils
-import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import MarkdownCallbacks from '@isrd-isi-edu/chaise/src/utils/markdown-utils';
-import { ResizeSensor } from 'css-element-queries';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 
 type LongtextFieldProps = {
@@ -64,13 +62,11 @@ const LongtextField = ({
   onFieldChange,
 }: LongtextFieldProps): JSX.Element => {
 
-  // reference hook to access contents of input
-  const textAreaContainerRef = useRef<HTMLDivElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const [showPreview, setShowPreview] = useState<boolean>(false);
   const [showModalPreview, setShowModalPreview] = useState<boolean>(false);
-  const [previewContent, setPreviewContent] = useState<string>(''); 
+  const [previewContent, setPreviewContent] = useState<string>('');
 
   // react-hook-form setup
   const { setValue, control, clearErrors } = useFormContext();
@@ -89,22 +85,6 @@ const LongtextField = ({
 
   // hooks
   useEffect(() => {
-    const textAreaElement = textAreaContainerRef.current;
-    if (!textAreaElement) return;
-    const sensor = new ResizeSensor(textAreaElement, () => {
-      fireCustomEvent(
-        'input-switch-error-update',
-        `.input-switch-container-${makeSafeIdAttr(name)}`,
-        { inputFieldName: name, msgCleared: false, type: 'longtext' }
-      );
-    });
-
-    return () => {
-      sensor.detach();
-    }
-  }, []);
-
-  useEffect(() => {
     if (onFieldChange) {
       onFieldChange(fieldValue);
     }
@@ -118,15 +98,6 @@ const LongtextField = ({
     if (value === undefined) return;
     setValue(name, value);
   }, [value]);
-
-  useEffect(() => {
-    fireCustomEvent(
-      'input-switch-error-update',
-      `.input-switch-container-${makeSafeIdAttr(name)}`,
-      { inputFieldName: name, msgCleared: !Boolean(error?.message), type: 'longtext' }
-    );
-  }, [error?.message]);
-
 
   // callback functions
   const handleChange = (v: any) => {
@@ -163,7 +134,7 @@ const LongtextField = ({
       <div className='md-editor'>
         <div className='md-header chaise-btn-toolbar'>
           <div className='chaise-btn-group'>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Heading' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setHeading(textAreaRef.current);
@@ -173,7 +144,7 @@ const LongtextField = ({
             >
               <span className='fa fa-header'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Bold' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setBold(textAreaRef.current);
@@ -183,7 +154,7 @@ const LongtextField = ({
             >
               <span className='fa fa-bold'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Italic' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setItalic(textAreaRef.current);
@@ -195,7 +166,7 @@ const LongtextField = ({
             </button>
           </div>
           <div className='chaise-btn-group'>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='URL/Link' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setLink(textAreaRef.current);
@@ -205,7 +176,7 @@ const LongtextField = ({
             >
               <span className='fa fa-link'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Image' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setImage(textAreaRef.current);
@@ -215,7 +186,7 @@ const LongtextField = ({
             >
               <span className='fa-regular fa-image'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn chaise-btn-no-padding' 
+            <button className='chaise-btn-secondary chaise-btn chaise-btn-no-padding'
               type='button' title='RID link' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setRidLink(textAreaRef.current);
@@ -227,7 +198,7 @@ const LongtextField = ({
             </button>
           </div>
           <div className='chaise-btn-group'>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Unordered List' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setList(textAreaRef.current);
@@ -237,7 +208,7 @@ const LongtextField = ({
             >
               <span className='fa fa-list'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Ordered List' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setListOrdered(textAreaRef.current);
@@ -247,7 +218,7 @@ const LongtextField = ({
             >
               <span className='fa fa-list-ol'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Quote' disabled={showPreview}
               onClick={() => {
                   MarkdownCallbacks.setQuote(textAreaRef.current);
@@ -259,19 +230,19 @@ const LongtextField = ({
             </button>
           </div>
           <div className='chaise-btn-group'>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Help' disabled={showPreview}
               onClick={MarkdownCallbacks.openHelp}
             >
               <span className='fa-solid fa-circle-question'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
-              type='button' title='Preview' 
+            <button className='chaise-btn-secondary chaise-btn'
+              type='button' title='Preview'
               onClick={togglePreview}
             >
               <span className='fa-solid fa-eye'></span>
             </button>
-            <button className='chaise-btn-secondary chaise-btn' 
+            <button className='chaise-btn-secondary chaise-btn'
               type='button' title='Fullscreen Preview' disabled={showPreview}
               onClick={modalPreview}
             >
@@ -279,9 +250,12 @@ const LongtextField = ({
             </button>
           </div>
         </div>
-        {!showPreview ? 
-          <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`} ref={textAreaContainerRef}>
-            <textarea placeholder={placeholder} rows={5} className={`${inputClasses} input-switch`} {...field} onChange={handleChange} ref={textAreaRef} data-provide='markdown' />
+        {!showPreview ?
+          <div className={`chaise-input-control has-feedback content-box ${classes} ${disableInput ? ' input-disabled' : ''}`}>
+            <textarea
+              placeholder={placeholder} rows={5} className={`${inputClasses} input-switch`} {...field}
+              onChange={handleChange} ref={textAreaRef} data-provide='markdown'
+            />
             <ClearInputBtn
               btnClassName={`${clearClasses} input-switch-clear`}
               clickCallback={clearInput}
@@ -294,13 +268,13 @@ const LongtextField = ({
         }
       </div>
       {displayErrors && isTouched && error?.message && <span className='input-switch-error text-danger'>{error.message}</span>}
-      {showModalPreview && 
-        <MarkdownPreviewModal 
+      {showModalPreview &&
+        <MarkdownPreviewModal
           markdownContent={previewContent}
           onClose={() => {
               setShowModalPreview(false)
               setPreviewContent('')
-            } 
+            }
           }
         />
       }

--- a/src/components/recordedit/key-column.tsx
+++ b/src/components/recordedit/key-column.tsx
@@ -5,16 +5,9 @@ import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 // hooks
 import useRecordedit from '@isrd-isi-edu/chaise/src/hooks/recordedit';
 
-// utils
-import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
-import { DEFAULT_HEGHT_MAP } from '@isrd-isi-edu/chaise/src/utils/input-utils';
-
-import { getInputTypeOrDisabled } from '@isrd-isi-edu/chaise/src/utils/input-utils';
-
-
 const KeyColumn = (): JSX.Element => {
 
-  const { columnModels, keysHeightMap } = useRecordedit();
+  const { columnModels } = useRecordedit();
 
   const renderColumnHeader = (column: any) => {
     const headerClassName = `column-displayname${column.comment ? ' chaise-icon-for-tooltip' : ''}`;
@@ -29,17 +22,15 @@ const KeyColumn = (): JSX.Element => {
   return (
     <div className='entity-key-column'>
       <div className='form-header entity-key'>Record Number</div>
-      {columnModels.map((cm: any) => {
+      {columnModels.map((cm: any, cmIndex: number) => {
         const column = cm.column;
         const colName = column.name;
-        const height = keysHeightMap[colName];
-        const colType = getInputTypeOrDisabled(cm);
-        const defaultHeight = DEFAULT_HEGHT_MAP[colType];
-        const heightparam = height === -1 ? defaultHeight : `${height}px`;
 
         // try changing to div if height adjustment does not work
         return (
-          <span key={colName} className='entity-key' style={{ 'height': heightparam }}>
+          // NOTE `entity-key-${cmIndex}` is used in form-container.tsx
+          // to ensure consistent height between this element and FormRow
+          <span key={colName} className={`entity-key entity-key-${cmIndex}`} >
             {cm.isRequired && <span className='text-danger'><b>*</b> </span>}
             {column.comment ?
               <ChaiseTooltip

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -6,7 +6,7 @@ import ChaiseSpinner from '@isrd-isi-edu/chaise/src/components/spinner';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import DeleteConfirmationModal from '@isrd-isi-edu/chaise/src/components/modals/delete-confirmation-modal';
 import KeyColumn from '@isrd-isi-edu/chaise/src/components/recordedit/key-column';
-import ChaiseFormContainer from '@isrd-isi-edu/chaise/src/components/recordedit/form-container';
+import FormContainer from '@isrd-isi-edu/chaise/src/components/recordedit/form-container';
 import Title from '@isrd-isi-edu/chaise/src/components/title';
 import ResultsetTable from '@isrd-isi-edu/chaise/src/components/recordedit/resultset-table';
 import ResultsetTableHeader from '@isrd-isi-edu/chaise/src/components/recordedit/resultset-table-header';
@@ -503,7 +503,7 @@ const RecordeditInner = ({
             {columnModels.length > 0 && !resultsetProps &&
               <div id='form-section'>
                 <KeyColumn />
-                <ChaiseFormContainer />
+                <FormContainer />
               </div>
             }
             {resultsetProps &&

--- a/src/models/recordedit.ts
+++ b/src/models/recordedit.ts
@@ -6,6 +6,12 @@ export const appModes = {
 
 export interface RecordeditColumnModel {
   column: any;
+  /**
+   * NOTE
+   * whether the column should be disabled based on model, or is prefilled.
+   * this will not properly handle per-column dynamic ACLs and we should use
+   * getInputTypeOrDisabled for it instead.
+   */
   isDisabled: boolean;
   isRequired: boolean;
   inputType: string;

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -102,11 +102,21 @@ export function isDisabled(column: any): boolean {
   return column.inputDisabled ? true : false;
 }
 
-export function getInputTypeOrDisabled(columnModel: RecordeditColumnModel): string {
-  if (columnModel.isDisabled) {
+/**
+ * Return `disabled` if,
+ *  - columnModel is marked as disabled
+ *  - based on dynamic ACLs the column cannot be updated (based on canUpdateValues)
+ *  - TODO show all
+ * @param formNumber
+ * @param columnModel
+ * @param canUpdateValues
+ * @returns
+ */
+export function getInputTypeOrDisabled(formNumber: number, columnModel: RecordeditColumnModel, canUpdateValues: any): string {
+  const valName = `${formNumber}-${columnModel.column.name}`;
+
+  if (columnModel.isDisabled || (canUpdateValues && valName in canUpdateValues && canUpdateValues[valName] === false)) {
     // TODO: if columnModel.showSelectAll, disable input
-    // TODO: create column models, no column model, enable!
-    // TODO: is editMode and user cannot update this row, disable
     return 'disabled';
   }
   return columnModel.inputType;
@@ -143,30 +153,6 @@ export function formatDatetime(value: string, options: TimestampOptions) {
   return null;
 }
 
-/**
- * Map type to default heights for different inputs (currently for recordedit)
- */
-export const DEFAULT_HEGHT_MAP: any = {
-  'array': 127, // should be same as json
-  'boolean': 47,
-  'color': 47,
-  'date': 47,
-  'disabled': 47,
-  'float4': 47,
-  'float8': 47,
-  'integer2': 47,
-  'integer4': 47,
-  'integer8': 47,
-  'json': 127, // should be same as array
-  'longtext': 170, // also markdown
-  'number': 47,
-  'numeric': 47,
-  'shorttext': 47,
-  'text': 47,
-  'textarea': 108, // for textarea html element
-  'timestamp': 82,
-  'timestamptz': 82
-}
 
 export const ERROR_MESSAGES = {
   REQUIRED: 'Please enter a value for this field.',

--- a/src/utils/recordedit-utils.ts
+++ b/src/utils/recordedit-utils.ts
@@ -254,13 +254,12 @@ export function populateEditInitialValues(
   // the data associated with the foreignkeys
   const foreignKeyData: any = {};
 
-  const canUpdateRows: any[] = [];
+  // whether the value can be updated or not
+  const canUpdateValues: {[key: string]: boolean} = {};
 
   forms.forEach((formValue: any, formIndex: number) => {
     const tupleIndex = formIndex;
     const tuple = tuples[tupleIndex];
-
-    if (!isCopy) canUpdateRows[tupleIndex] = {};
 
     const tupleValues = tuple.values;
 
@@ -269,12 +268,9 @@ export function populateEditInitialValues(
       foreignKeyData[`${formValue}-${k}`] = tuple.linkedData[k];
     });
 
-    columnModels.forEach((colModel: RecordeditColumnModel) => {
+    columnModels.forEach((colModel: RecordeditColumnModel, i: number) => {
       const column = colModel.column;
       let value;
-
-      // columnModels array might not be the same size as column list
-      const i = columns.findIndex((col: any) => { return col.name === column.name });
 
       // If input is disabled, and it's copy, we don't want to copy the value
       let isDisabled = colModel.inputType === 'disabled';
@@ -282,7 +278,10 @@ export function populateEditInitialValues(
 
       if (!isCopy) {
         // whether certain columns are disabled or not
-        canUpdateRows[tupleIndex][column.name] = tuple.canUpdate && tuple.canUpdateValues[i];
+        canUpdateValues[`${formValue}-${column.name}`] = tuple.canUpdate && tuple.canUpdateValues[i];
+
+        // while we cannot change the isDisabled state, this will be
+        // taken care of by calling getInputTypeOrDisabled in other places
         isDisabled = isDisabled || !(tuple.canUpdate && tuple.canUpdateValues[i]);
       }
 
@@ -378,7 +377,7 @@ export function populateEditInitialValues(
     });
   });
 
-  return { values, foreignKeyData };
+  return { values, foreignKeyData, canUpdateValues };
 }
 
 /**


### PR DESCRIPTION
While implementing dynamic ACLs I realized that the column-based layout for recordedit form is going to make the implementation very difficult. This layout caused a lot of issues related to height management and we had to add several state-variables just to handle heights. 

Most of the changes in this PR is removing the state-variables and height logic that we had. By using row-based, we don't need to worry about the height of the `.form-container` and we just need to make sure `.entity-key-column` has the same height as `.form-contaner`. To do so, I just had to add a `ResizeSensor`.

P.S. I also changed the indentation of `_recordedit.scss`, so you'll notice a lot of changes in that file as well.