### PR TITLE
Implement select-all functionality

### DIFF
--- a/src/assets/scss/_recordedit.scss
+++ b/src/assets/scss/_recordedit.scss
@@ -31,11 +31,9 @@
     margin-top: -15px;
   }
 
-  #form-section {
+  .main-body {
     display: flex;
     flex-direction: row;
-    overflow-y: auto;
-    overflow-x: hidden;
     width: 100%;
     position: relative;
     padding-top: 15px;
@@ -48,8 +46,7 @@
       flex-direction: column;
       flex-shrink: 0;
 
-      .entity-key,
-      .match-entity-key {
+      .entity-key {
         width: $chaise-caption-column-width;
         border-left: $chaise-RE-border-width solid $chaise-RE-border-color;
         border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
@@ -64,116 +61,149 @@
         flex: none;
       }
 
-      .match-entity-key.select-all-opened {
-        border-top: none;
+      .toggle-select-all-btn {
+        float: right;
       }
     }
 
-    .form-container {
+    .recordedit-form {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      color: black;
+      background-color: white;
+      height: 100%;
       width: 100%;
+      min-width: 250px;
       overflow-x: auto;
-      height: fit-content;
 
-      .recordedit-form {
+      .form-header-row {
+        display: flex;
+      }
+
+      .form-inputs-row {
         display: flex;
         flex-direction: column;
-        background-color: white;
-        height: 100%;
-        min-width: 250px;
-        color: black;
+        // make sure the form is stretched in one-input case
+        min-width: 100%;
+        // make sure the width is the same as the scrollable width in multi-input case
+        width: fit-content;
+        width: -moz-fit-content;
+        width: -webkit-fit-content;
+
+        &.highlighted-row {
+          background-color: #f7f0cf;
+        }
+
+        .inputs-row {
+          display: flex;
+          flex-direction: row;
+        }
+
+        .select-all-row {
+          width: 100%;
+
+          .select-all-text, .select-all-input, .select-all-buttons {
+            float: left;
+          }
+
+          .select-all-text {
+            padding: 4px;
+            border: 1px solid transparent;
+          }
+
+          .select-all-input {
+            width: 250px;
+            margin: 0px 5px;
+          }
+        }
+      }
+
+      // form header and form inputs
+      .entity-value {
+        // make sure the inputs take up as much space as they can
+        // and are the same size
+        flex: 1 1 0;
         position: relative;
 
-        .form-inputs-row,
-        .form-header-row {
-          display: flex;
+        .column-permission-overlay {
+          position: absolute;
+          left: 0;
+          top: 0;
+          height: 100%;
+          width: 100%;
+          z-index: 6; // higher than the chaise-clear
         }
 
-        // form header and form inputs
-        .entity-value {
-          // make sure the inputs take up as much space as they can
-          // and are the same size
-          flex: 1 1 0;
-          position: relative;
+        .column-permission-warning {
+          margin: 0;
+          padding: 5px;
+          color: rgb(180, 95, 6);
+        }
 
-          .column-permission-overlay {
+        // displayed while loading the fk data
+        .column-cell-spinner-container {
+          $column-cell-backdrop-z-index: 5;
+          .column-cell-spinner-backdrop {
             position: absolute;
-            left: 0;
             top: 0;
+            left: 0;
             height: 100%;
             width: 100%;
-            z-index: 6; // higher than the chaise-clear
+            z-index: $column-cell-backdrop-z-index;
+            background: $disabled-background-color;
+            opacity: 0.55;
           }
-
-          .column-permission-warning {
-            margin: 0;
-            padding: 5px;
-            color: rgb(180, 95, 6);
-          }
-
-          // displayed while loading the fk data
-          .column-cell-spinner-container {
-            $column-cell-backdrop-z-index: 5;
-            .column-cell-spinner-backdrop {
-              position: absolute;
-              top: 0;
-              left: 0;
-              height: 100%;
-              width: 100%;
-              z-index: $column-cell-backdrop-z-index;
-              background: $disabled-background-color;
-              opacity: 0.55;
-            }
-            .spinner-border-sm {
-              left: 50%;
-              top: 15px;
-              position: absolute;
-              z-index: calc($column-cell-backdrop-z-index + 1);
-            }
+          .spinner-border-sm {
+            left: 50%;
+            top: 15px;
+            position: absolute;
+            z-index: calc($column-cell-backdrop-z-index + 1);
           }
         }
+      }
 
-        .entity-value,
-        .match-entity-value {
-          word-wrap: break-word;
-          min-width: 250px;
-          border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
-          border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
+      .entity-value,
+      .match-entity-value {
+        word-wrap: break-word;
+        min-width: 250px;
+        border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
+        border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
 
-          // border-left: none;
-          // border-top: none;
+        // border-left: none;
+        // border-top: none;
 
-          border-radius: 0;
-          min-height: 47px;
-          padding: 8px 10px;
-        }
+        border-radius: 0;
+        min-height: 47px;
+        padding: 8px 10px;
+      }
 
-        // only form inputs
-        .column-cell {
-          border-left: none;
-          border-top: none;
-          border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
-          border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
-          border-radius: 0;
-          // height: 47px;
-          min-height: 47px;
-          padding: 8px 10px;
+      // only form inputs
+      .column-cell {
+        border-left: none;
+        border-top: none;
+        border-right: $chaise-RE-border-width solid $chaise-RE-border-color;
+        border-bottom: $chaise-RE-border-width solid $chaise-RE-border-color;
+        border-radius: 0;
+        // height: 47px;
+        min-height: 47px;
+        padding: 8px 10px;
 
-          .chaise-input-control.column-cell-input {
-            border: 1px solid $border-color;
-            border-radius: 4px;
-            padding: 0 10px;
-            display: flex;
-            align-items: center;
+        .chaise-input-control.column-cell-input {
+          border: 1px solid $border-color;
+          border-radius: 4px;
+          padding: 0 10px;
+          display: flex;
+          align-items: center;
 
-            .input-switch {
-              height: auto;
-            }
+          .input-switch {
+            height: auto;
           }
         }
       }
     }
 
-    // in both entity-key-column and form-container
+    // in both entity-key-column and form
     .form-header {
       height: 47px;
       border-top: $chaise-RE-border-width solid $chaise-RE-border-color;
@@ -193,8 +223,6 @@
       }
     }
   }
-
-  // // end #form-section
 
   .modal-popup {
     width: 100%;
@@ -228,11 +256,6 @@
 
   .adjust-boolean-dropdown {
     border-top: 0;
-  }
-
-  .select-all-text {
-    padding: 4px;
-    border: 1px solid transparent;
   }
 
   @-moz-document url-prefix() {

--- a/src/components/input-switch/boolean-field.tsx
+++ b/src/components/input-switch/boolean-field.tsx
@@ -121,38 +121,38 @@ const BooleanField = ({
     field.onBlur();
   };
 
+  // first option is true, and second is false.
   const rawOptions = [true, false];
   const displayedOptions = rawOptions.map((op) => columnModel ? formatBoolean(columnModel.column, op) : op.toString());
 
   return (
     <div className={`${containerClasses} input-switch-boolean input-switch-container-${makeSafeIdAttr(name)}`} style={styles}>
-      <Dropdown>
-        <Dropdown.Toggle as='div' disabled={disableInput} className='chaise-input-group'>
+      <Dropdown aria-disabled={disableInput}>
+        <Dropdown.Toggle as='div' className='chaise-input-group' disabled={disableInput} aria-disabled={disableInput}>
           <div className={`chaise-input-control has-feedback ${classes} ${disableInput ? ' input-disabled' : ''}`}>
             {typeof fieldValue === 'boolean' ?
               displayedOptions[rawOptions.indexOf(fieldValue)] :
               <span className='chaise-input-placeholder'>{placeholder ? placeholder : 'Select a value'}</span>
             }
-            <ClearInputBtn btnClassName={`${clearClasses} input-switch-clear`} clickCallback={clearInput} show={showClear} />
+            <ClearInputBtn btnClassName={`${clearClasses} input-switch-clear`} clickCallback={clearInput} show={!disableInput && showClear} />
           </div>
-          <div className='chaise-input-group-append'>
+          {!disableInput && <div className='chaise-input-group-append'>
             <button className='chaise-btn chaise-btn-primary' role='button' type='button'>
               <span className='chaise-btn-icon fa-solid fa-chevron-down' />
             </button>
-          </div>
+          </div>}
         </Dropdown.Toggle>
-        <Dropdown.Menu>
+        {!disableInput && <Dropdown.Menu>
           {displayedOptions.map((option: any, index: number) => (
             <Dropdown.Item
               as='li'
               key={`boolean-val-${makeSafeIdAttr(name)}-${index}`}
-              // first option is true, and second is false.
               onClick={() => handleChange(rawOptions[index])}
             >
               {option}
             </Dropdown.Item>
           ))}
-        </Dropdown.Menu>
+        </Dropdown.Menu>}
       </Dropdown>
       <input className={inputClasses} {...field} type='hidden' />
       {displayErrors && isTouched && error?.message && <span className='input-switch-error text-danger'>{error.message}</span>}

--- a/src/components/input-switch/foreignkey-field.tsx
+++ b/src/components/input-switch/foreignkey-field.tsx
@@ -145,7 +145,7 @@ const ForeignkeyField = ({
 
   const fieldState = formInput?.fieldState;
 
-  const [showClear, setShowClear] = useState<boolean>(typeof fieldValue !== 'boolean');
+  const [showClear, setShowClear] = useState<boolean>(Boolean(fieldValue));
 
   const { error, isTouched } = fieldState;
 

--- a/src/components/recordedit/form-container.tsx
+++ b/src/components/recordedit/form-container.tsx
@@ -19,7 +19,7 @@ import { getDisabledInputValue } from '@isrd-isi-edu/chaise/src/utils/input-util
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { copyOrClearValue, getColumnModelLogAction, getColumnModelLogStack } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
-import { makeSafeIdAttr } from '../../utils/string-utils';
+import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 
 const FormContainer = (): JSX.Element => {
 

--- a/src/components/recordedit/form-container.tsx
+++ b/src/components/recordedit/form-container.tsx
@@ -8,13 +8,18 @@ import { useFormContext } from 'react-hook-form';
 import useRecordedit from '@isrd-isi-edu/chaise/src/hooks/recordedit';
 
 // models
-import { appModes, RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
+import { appModes, RecordeditColumnModel, SELECT_ALL_INPUT_FORM_VALUE } from '@isrd-isi-edu/chaise/src/models/recordedit';
+import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
+
+// services
+import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 
 // utils
-import { getDisabledInputValue, getInputTypeOrDisabled } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { getDisabledInputValue, replaceNullOrUndefined } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils';
-import { Prev } from 'react-bootstrap/esm/PageItem';
+import { copyOrClearValue, getColumnModelLogAction, getColumnModelLogStack } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
+import { simpleDeepCopy } from '@isrd-isi-edu/chaise/src/utils/data-utils';
 
 const FormContainer = (): JSX.Element => {
 
@@ -24,39 +29,37 @@ const FormContainer = (): JSX.Element => {
 
   const { handleSubmit } = useFormContext();
   return (
-    <div className='form-container'>
-      <form id='recordedit-form' className='recordedit-form' onSubmit={handleSubmit(onSubmitValid, onSubmitInvalid)}>
-        {/* form header */}
-        <div className='form-header-row'>
-          {forms.map((formNumber: number, formIndex: number) => (
-            <div key={`form-header-${formNumber}`} className='form-header entity-value'>
-              <span>{formIndex + 1}</span>
-              <div className='form-header-buttons-container'>
-                {appMode === appModes.EDIT && tuples && !tuples[formIndex].canUpdate &&
-                  <ChaiseTooltip placement='bottom' tooltip='This record cannot be modified.'>
-                    <i className='disabled-row-icon fas fa-ban'></i>
-                  </ChaiseTooltip>
-                }
-                {forms.length > 1 &&
-                  <ChaiseTooltip
-                    placement='bottom'
-                    tooltip='Click to remove this record from the form.'
-                  >
-                    <button className='chaise-btn chaise-btn-secondary pull-right remove-form-btn' onClick={() => removeForm([formIndex])}>
-                      <i className='fa-solid fa-xmark' />
-                    </button>
-                  </ChaiseTooltip>
-                }
-              </div>
+    <form id='recordedit-form' className='recordedit-form' onSubmit={handleSubmit(onSubmitValid, onSubmitInvalid)}>
+      {/* form header */}
+      <div className='form-header-row'>
+        {forms.map((formNumber: number, formIndex: number) => (
+          <div key={`form-header-${formNumber}`} className='form-header entity-value'>
+            <span>{formIndex + 1}</span>
+            <div className='form-header-buttons-container'>
+              {appMode === appModes.EDIT && tuples && !tuples[formIndex].canUpdate &&
+                <ChaiseTooltip placement='bottom' tooltip='This record cannot be modified.'>
+                  <i className='disabled-row-icon fas fa-ban'></i>
+                </ChaiseTooltip>
+              }
+              {forms.length > 1 &&
+                <ChaiseTooltip
+                  placement='bottom'
+                  tooltip='Click to remove this record from the form.'
+                >
+                  <button className='chaise-btn chaise-btn-secondary pull-right remove-form-btn' onClick={() => removeForm([formIndex])}>
+                    <i className='fa-solid fa-xmark' />
+                  </button>
+                </ChaiseTooltip>
+              }
             </div>
-          ))}
-        </div>
-        {/* inputs for each column */}
-        {columnModels.map(({ }, idx) => (
-          <FormRow key={`form-row-${idx}`} columnModelIndex={idx} />
+          </div>
         ))}
-      </form>
-    </div>
+      </div>
+      {/* inputs for each column */}
+      {columnModels.map(({ }, idx) => (
+        <FormRow key={`form-row-${idx}`} columnModelIndex={idx} />
+      ))}
+    </form>
   )
 };
 
@@ -67,22 +70,24 @@ type FormRowProps = {
 /**
  * each row in the form
  * to make the height logic simpler, I decided to extract the rows as separate
- * components instead of having it in the FormContainer.
+ * components instead of having it in the Form.
  *
  */
 const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
 
   const {
-    forms, appMode, reference, columnModels, tuples,
+    forms, appMode, reference, columnModels, tuples, activeSelectAll, toggleActiveSelectAll,
     canUpdateValues, columnPermissionErrors, foreignKeyData, waitingForForeignKeyData,
   } = useRecordedit();
+
+  const methods = useFormContext();
 
   /**
    * which columns should show the permission error.
    * if a user cannot edit a column in one of the rows, we cannot allow them
    * to edit that column in other rows.
    */
-  const [showPermissionError, setShowPermissionError] = useState<{[key: string]: boolean}>({});
+  const [showPermissionError, setShowPermissionError] = useState<{ [key: string]: boolean }>({});
 
   /**
    * reset the state of showing permission errors whenever the errors changed
@@ -100,7 +105,7 @@ const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
     if (!container || !container.current) return;
 
     let cachedHeight = -1;
-    const sensor = new ResizeSensor(container.current as Element, (dimension) => {
+    const sensor = new ResizeSensor(container.current as Element, () => {
       if (container.current?.offsetHeight === cachedHeight || !container.current) return;
       cachedHeight = container.current?.offsetHeight;
       const header = document.querySelector<HTMLElement>(`.entity-key.entity-key-${columnModelIndex}`);
@@ -114,27 +119,117 @@ const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
     }
   }, []);
 
+
+  // ------------------------ callbacks -----------------------------------//
+
   /**
    * show the error to users after they clicked on the cell.
    */
   const onPermissionClick = (formIndex: number) => {
     setShowPermissionError((prev) => {
-      const res = {...prev};
+      const res = { ...prev };
       res[formIndex] = true;
       return res;
     });
   };
 
-  const renderInput = (formNumber: number, formIndex: number) => {
+  const applyValueToAll = () => {
     const cm = columnModels[columnModelIndex];
 
-    const colName = cm.column.name;
+    const defaultLogInfo = cm.column.reference ? cm.column.reference.defaultLogInfo : reference.defaultLogInfo;
+    // TODO parent log obj
+    LogService.logClientAction({
+      action: getColumnModelLogAction(LogActions.SET_ALL_APPLY, cm, null),
+      stack: getColumnModelLogStack(cm, null)
+    }, defaultLogInfo);
 
-    const inputType = getInputTypeOrDisabled(formNumber, cm, canUpdateValues);
+    setValueForAllInputs();
+  };
+
+  const clearAllValues = () => {
+    const cm = columnModels[columnModelIndex];
+
+    const defaultLogInfo = (cm.column.reference ? cm.column.reference.defaultLogInfo : reference.defaultLogInfo);
+    // TODO parent log obj
+    LogService.logClientAction({
+      action: getColumnModelLogAction(LogActions.SET_ALL_CLEAR, cm, null),
+      stack: getColumnModelLogStack(cm, null)
+    }, defaultLogInfo);
+
+    setValueForAllInputs(true);
+  };
+
+  const closeSelectAll = () => {
+    // TODO client log
+    // var defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : $rootScope.reference.defaultLogInfo);
+    // logService.logClientAction({
+    //     action: recordCreate.getColumnModelLogAction(logService.logActions.SET_ALL_CANCEL, model),
+    //     stack: recordCreate.getColumnModelLogStack(model)
+    // }, defaultLogInfo);
+
+    toggleActiveSelectAll(columnModelIndex);
+  };
+
+  // ------------------------ helper functions ----------------------------//
+  /**
+   * this code is similar to recordedit.tsx:291 (callAddForm)
+   * TODO can be refactored into one function
+   */
+  const setValueForAllInputs = (clearValue?: boolean) => {
+    const cm = columnModels[columnModelIndex];
+
+    forms.forEach((formValue: number) => {
+      // ignore the ones that cannot be updated
+      if (appMode === appModes.EDIT && canUpdateValues && !canUpdateValues[`${formValue}-${cm.column.name}`]) {
+        return;
+      }
+      methods.reset(copyOrClearValue(cm, methods.getValues(), foreignKeyData.current, formValue, SELECT_ALL_INPUT_FORM_VALUE, clearValue));
+    });
+  };
+
+  // -------------------------- render logic ---------------------- //
+
+  const showSelectAll = activeSelectAll === columnModelIndex;
+  const columnModel = columnModels[columnModelIndex];
+
+  /**
+ * Return `disabled` if,
+ *  - columnModel is marked as disabled
+ *  - based on dynamic ACLs the column cannot be updated (based on canUpdateValues)
+ *  - TODO show all
+ * @param formNumber
+ * @param columnModel
+ * @param canUpdateValues
+ * @returns
+ */
+  const getInputTypeOrDisabled = (formNumber?: number, isSelectAllInput?: boolean): string => {
+    if (isSelectAllInput) {
+      return columnModel.inputType;
+    }
+
+    if (columnModel.isDisabled || showSelectAll) {
+      return 'disabled';
+    }
+
+    if (typeof formNumber === 'number') {
+      const valName = `${formNumber}-${columnModel.column.name}`;
+      if (canUpdateValues && valName in canUpdateValues && canUpdateValues[valName] === false) {
+        return 'disabled';
+      }
+    }
+
+    return columnModel.inputType;
+  }
+
+  const renderInput = (formNumber: number, formIndex?: number) => {
+
+    const colName = columnModel.column.name;
+
+    const inputType = getInputTypeOrDisabled(formNumber, formNumber === SELECT_ALL_INPUT_FORM_VALUE);
     let placeholder = '';
     let permissionError = '';
     if (inputType === 'disabled') {
-      placeholder = getDisabledInputValue(cm.column);
+      placeholder = getDisabledInputValue(columnModel.column);
 
       // TODO: extend this for edit mode
       // if value is empty string and we are in edit mode, use the previous value
@@ -148,7 +243,9 @@ const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
     }
 
     return (<>
-      {permissionError && <div className='column-permission-overlay' onClick={() => onPermissionClick(formIndex)} />}
+      {permissionError && typeof formIndex === 'number' &&
+        <div className='column-permission-overlay' onClick={() => onPermissionClick(formIndex)} />
+      }
       <InputSwitch
         key={colName}
         displayErrors={true}
@@ -157,27 +254,54 @@ const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
         classes='column-cell-input'
         placeholder={placeholder}
         // styles={{ 'height': heightparam }}
-        columnModel={cm}
+        columnModel={columnModel}
         appMode={appMode}
         formNumber={formNumber}
         parentReference={reference}
-        parentTuple={appMode === appModes.EDIT ? tuples[formIndex] : undefined}
+        parentTuple={appMode === appModes.EDIT && typeof formIndex === 'number' ? tuples[formIndex] : undefined}
         foreignKeyData={foreignKeyData}
         waitingForForeignKeyData={waitingForForeignKeyData}
       />
-      {formIndex in showPermissionError &&
+      {typeof formIndex === 'number' && formIndex in showPermissionError &&
         <div className='column-permission-warning'>{permissionError}</div>
       }
     </>)
   }
 
   return (
-    <div className='form-inputs-row' ref={container}>
-      {forms.map((formNumber: number, formIndex: number) => (
-        <div key={`form-${formNumber}-input-${columnModelIndex}`} className='entity-value'>
-          {renderInput(formNumber, formIndex)}
+    <div className={`form-inputs-row ${showSelectAll ? 'highlighted-row' : ''}`} ref={container}>
+      <div className='inputs-row'>
+        {forms.map((formNumber: number, formIndex: number) => (
+          <div key={`form-${formNumber}-input-${columnModelIndex}`} className='entity-value'>
+            {renderInput(formNumber, formIndex)}
+          </div>
+        ))}
+      </div>
+      {showSelectAll &&
+        <div className='select-all-row match-entity-value'>
+          <div className='select-all-text'>Set value for all records: </div>
+          <div className='select-all-input'>
+            {renderInput(SELECT_ALL_INPUT_FORM_VALUE)}
+          </div>
+          <div className='chaise-btn-group select-all-buttons'>
+            <ChaiseTooltip tooltip='Click to apply the value to all records.' placement='bottom'>
+              <button type='button' className='chaise-btn chaise-btn-secondary' onClick={applyValueToAll}>
+                Apply All
+              </button>
+            </ChaiseTooltip>
+            <ChaiseTooltip tooltip='Click to clear all values for all records.' placement='bottom'>
+              <button type='button' className='chaise-btn chaise-btn-secondary' onClick={clearAllValues}>
+                Clear All
+              </button>
+            </ChaiseTooltip>
+            <ChaiseTooltip tooltip='Click to close the set all input.' placement='bottom'>
+              <button type='button' className='chaise-btn chaise-btn-secondary' onClick={closeSelectAll}>
+                Close
+              </button>
+            </ChaiseTooltip>
+          </div>
         </div>
-      ))}
+      }
     </div>
   )
 

--- a/src/components/recordedit/key-column.tsx
+++ b/src/components/recordedit/key-column.tsx
@@ -20,7 +20,7 @@ const KeyColumn = (): JSX.Element => {
 
   const {
     appMode, columnModels, activeSelectAll, toggleActiveSelectAll,
-    columnPermissionErrors, forms, reference, canUpdateValues
+    columnPermissionErrors, forms, reference,
   } = useRecordedit();
 
   const onToggleClick = (cmIndex: number) => {
@@ -65,7 +65,7 @@ const KeyColumn = (): JSX.Element => {
       return true;
     }
 
-    // in this case we want toshow the button and instead disable it
+    // in this case we want to show the button and instead disable it
     if (disableSelectAllbtn(columnIndex)) {
       return true;
     }

--- a/src/components/recordedit/key-column.tsx
+++ b/src/components/recordedit/key-column.tsx
@@ -5,9 +5,42 @@ import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 // hooks
 import useRecordedit from '@isrd-isi-edu/chaise/src/hooks/recordedit';
 
+// models
+import { appModes } from '@isrd-isi-edu/chaise/src/models/recordedit';
+import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
+
+// services
+import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
+
+// utils
+import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils';
+import { getColumnModelLogAction, getColumnModelLogStack } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
+
 const KeyColumn = (): JSX.Element => {
 
-  const { columnModels } = useRecordedit();
+  const {
+    appMode, columnModels, activeSelectAll, toggleActiveSelectAll,
+    columnPermissionErrors, forms, reference, canUpdateValues
+  } = useRecordedit();
+
+  const onToggleClick = (cmIndex: number) => {
+    const model = columnModels[cmIndex];
+
+    const defaultLogInfo = (model.column.reference ? model.column.reference.defaultLogInfo : reference.defaultLogInfo);
+
+    const action = cmIndex === activeSelectAll ? LogActions.SET_ALL_CLOSE : LogActions.SET_ALL_OPEN;
+
+    // TODO parent stack model
+    LogService.logClientAction({
+        action: getColumnModelLogAction(action, model, null),
+        stack: getColumnModelLogStack(model, null)
+    }, defaultLogInfo);
+
+    toggleActiveSelectAll(cmIndex);
+  }
+
+
+  // -------------------------- render logic ---------------------- //
 
   const renderColumnHeader = (column: any) => {
     const headerClassName = `column-displayname${column.comment ? ' chaise-icon-for-tooltip' : ''}`;
@@ -19,12 +52,53 @@ const KeyColumn = (): JSX.Element => {
     )
   }
 
+  /**
+   * whether we should show the button
+   * NOTE: we used to show disabled tuples, if we decided to bring that back,
+   * we need to change the logic here.
+   */
+  const canShowSelectAllBtn = (columnIndex: number) => {
+    const cm = columnModels[columnIndex];
+
+    // if we're already showing the select-all UI, then we have to show the button
+    if (activeSelectAll === columnIndex) {
+      return true;
+    }
+
+    // in this case we want toshow the button and instead disable it
+    if (disableSelectAllbtn(columnIndex)) {
+      return true;
+    }
+
+    // it must be multi-row, column must not be disabled,
+    // and at least one row can be edited (if in edit mode)
+    if (cm.isDisabled || forms.length < 2) {
+      return false;
+    }
+
+    return true;
+  };
+
+  /**
+   * if we're going to show column permission errors (one row has disabled a column),
+   * then we should disable this button
+   */
+  const disableSelectAllbtn = (columnIndex: number) => {
+    return appMode === appModes.EDIT && isObjectAndKeyDefined(columnPermissionErrors, columnModels[columnIndex].column.name);
+  }
+
   return (
     <div className='entity-key-column'>
       <div className='form-header entity-key'>Record Number</div>
       {columnModels.map((cm: any, cmIndex: number) => {
         const column = cm.column;
         const colName = column.name;
+
+        const isDisabled = disableSelectAllbtn(cmIndex);
+        let tooltip = cmIndex === activeSelectAll ? 'Click to close the set all input.' : 'Click to set a value for all records.';
+        if (isDisabled) {
+          tooltip = 'Cannot perform this action.';
+        }
 
         // try changing to div if height adjustment does not work
         return (
@@ -40,6 +114,17 @@ const KeyColumn = (): JSX.Element => {
                 {renderColumnHeader(column)}
               </ChaiseTooltip> :
               renderColumnHeader(column)
+            }
+            {canShowSelectAllBtn(cmIndex) &&
+              <ChaiseTooltip placement='bottom' tooltip={tooltip}>
+                <button
+                  className={`chaise-btn chaise-btn-secondary toggle-select-all-btn toggle-select-all-btn-${cmIndex}`}
+                  disabled={isDisabled}
+                  onClick={() => onToggleClick(cmIndex)}
+                >
+                  <span className={`fa-solid ${cmIndex === activeSelectAll ? 'fa-chevron-up' : 'fa-pencil'}`}></span>
+                </button>
+              </ChaiseTooltip>
             }
           </span>
         )

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -36,8 +36,8 @@ import { attachContainerHeightSensors, attachMainContainerPaddingSensor } from '
 import { appModes, RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
-import { replaceNullOrUndefined } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { simpleDeepCopy } from '@isrd-isi-edu/chaise/src/utils/data-utils';
+import { copyOrClearValue } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
 
 export type RecordeditProps = {
   appMode: string;
@@ -326,14 +326,7 @@ const RecordeditInner = ({
     for (let i = 0; i < newFormValues.length; i++) {
       const formValue = newFormValues[i];
       columnModels.forEach((cm: RecordeditColumnModel) => {
-        const colName = cm.column.name;
-        // should be able to handle falsy values
-        tempFormValues[`${formValue}-${colName}`] = replaceNullOrUndefined(tempFormValues[`${lastFormValue}-${colName}`], '');
-
-        if (cm.column.type.name.indexOf('timestamp') !== -1) {
-          tempFormValues[`${formValue}-${colName}-date`] = tempFormValues[`${lastFormValue}-${colName}-date`] || '';
-          tempFormValues[`${formValue}-${colName}-time`] = tempFormValues[`${lastFormValue}-${colName}-time`] || '';
-        }
+        copyOrClearValue(cm, tempFormValues, foreignKeyData.current, formValue, lastFormValue, false, true);
       });
 
       // the code above is just copying the displayed rowname for foreignkeys,

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -501,7 +501,7 @@ const RecordeditInner = ({
           {/* <!-- Form section --> */}
           <div className='main-container' ref={mainContainer}>
             {columnModels.length > 0 && !resultsetProps &&
-              <div id='form-section'>
+              <div className='main-body'>
                 <KeyColumn />
                 <FormContainer />
               </div>

--- a/src/models/recordedit.ts
+++ b/src/models/recordedit.ts
@@ -47,3 +47,9 @@ export interface PrefillObject {
    */
   rowname: any
 }
+
+/**
+ * so we can get the select-all input value for a column by doing:
+ * getValues()[`${SELECT_ALL_INPUT_FORM_VALUE}-${column.name}]
+ */
+export const SELECT_ALL_INPUT_FORM_VALUE = -1;

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -103,26 +103,6 @@ export function isDisabled(column: any): boolean {
 }
 
 /**
- * Return `disabled` if,
- *  - columnModel is marked as disabled
- *  - based on dynamic ACLs the column cannot be updated (based on canUpdateValues)
- *  - TODO show all
- * @param formNumber
- * @param columnModel
- * @param canUpdateValues
- * @returns
- */
-export function getInputTypeOrDisabled(formNumber: number, columnModel: RecordeditColumnModel, canUpdateValues: any): string {
-  const valName = `${formNumber}-${columnModel.column.name}`;
-
-  if (columnModel.isDisabled || (canUpdateValues && valName in canUpdateValues && canUpdateValues[valName] === false)) {
-    // TODO: if columnModel.showSelectAll, disable input
-    return 'disabled';
-  }
-  return columnModel.inputType;
-}
-
-/**
  * return the disabled input value based on input type
  * @param column the column object from ermrestJS
  */

--- a/src/utils/recordedit-utils.ts
+++ b/src/utils/recordedit-utils.ts
@@ -7,19 +7,18 @@ import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
 
 // models
 import { LogStackPaths, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
-import { PrefillObject, RecordeditColumnModel, TimestampOptions } from '@isrd-isi-edu/chaise/src/models/recordedit'
+import { appModes, PrefillObject, RecordeditColumnModel, SELECT_ALL_INPUT_FORM_VALUE, TimestampOptions } from '@isrd-isi-edu/chaise/src/models/recordedit'
 
 // services
-import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
 import { CookieService } from '@isrd-isi-edu/chaise/src/services/cookie';
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
-import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utilities
 import {
   formatDatetime, formatFloat, formatInt, getInputType,
   replaceNullOrUndefined, isDisabled
 } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { simpleDeepCopy } from '@isrd-isi-edu/chaise/src/utils/data-utils';
 
 /**
  * Create a columnModel based on the given column that can be used in a recordedit form
@@ -65,13 +64,10 @@ export function columnToColumnModel(column: any, queryParams?: any): RecordeditC
   }
 
   return {
-    // allInput: undefined,
     column: column,
     isDisabled: isInputDisabled || isPrefilled,
     isRequired: !column.nullok && !isInputDisabled,
     inputType: isPrefilled ? 'disabled' : type,
-    // highlightRow: false,
-    // showSelectAll: false,
     logStackNode, // should not be used directly, take a look at getColumnModelLogStack
     logStackPathChild, // should not be used directly, use getColumnModelLogAction getting the action string
     hasDomainFilter
@@ -99,6 +95,63 @@ export function getColumnModelLogStack(colModel: RecordeditColumnModel, parentSt
 export function getColumnModelLogAction(action: string, colModel: RecordeditColumnModel, parentLogStackPath: string | null) {
   const logStackPath = LogService.getStackPath(parentLogStackPath, colModel.logStackPathChild);
   return LogService.getActionString(action, logStackPath);
+}
+
+/**
+ * NOTE this function is immutating the given value
+ */
+export function copyOrClearValue(columnModel: RecordeditColumnModel,
+  values: any, foreignKeyData: any,
+  destFormValue: number, srcFormValue?: number, clearValue?: boolean
+) {
+
+  const column = columnModel.column;
+
+  const srcKey = typeof srcFormValue === 'number' ? `${srcFormValue}-${column.name}` : null;
+
+  const dstKey = `${destFormValue}-${column.name}`;
+
+
+  if (clearValue) {
+    values[dstKey] = '';
+  } else if (srcKey) {
+    values[dstKey] = replaceNullOrUndefined(values[srcKey], '');
+  }
+
+  if (columnModel.column.type.name.indexOf('timestamp') !== -1) {
+    if (clearValue) {
+      values[`${dstKey}-date`] = '';
+      values[`${dstKey}-time`] = '';
+    } else if (srcKey) {
+      values[`${dstKey}-date`] = values[`${srcKey}-date`] || '';
+      values[`${dstKey}-time`] = values[`${srcKey}-time`] || '';
+    }
+
+  }
+
+  if (columnModel.column.isForeignKey) {
+    // copy the foreignKeyData (used for domain-filter support in foreignkey-field.tsx)
+    if (clearValue) {
+      foreignKeyData[dstKey] = {};
+    } else if (srcKey) {
+      foreignKeyData[dstKey] = simpleDeepCopy(foreignKeyData[srcKey]);
+    }
+
+    // the code above is just copying the displayed rowname for foreignkey
+    // we still need to copy the raw values
+    columnModel.column.foreignKey.colset.columns.forEach((col: any) => {
+      let val;
+      if (clearValue) {
+        val = '';
+      } else if (typeof srcFormValue === 'number') {
+        val = values[`${srcFormValue}-${col.name}`];
+      }
+      if (val === null || val === undefined) return;
+      values[`${destFormValue}-${col.name}`] = val;
+    });
+  }
+
+  return values;
 }
 
 /**
@@ -134,7 +187,7 @@ export function populateCreateInitialValues(
 
   // populate defaults
   // NOTE: should only be 1 form
-  forms.forEach((formValue: number) => {
+  forms.forEach((formValue: number, formIndex: number) => {
     for (let i = 0; i < columnModels.length; i++) {
       // default model initialiation is null
       let initialModelValue = null;
@@ -165,13 +218,15 @@ export function populateCreateInitialValues(
       switch (column.type.name) {
         // timestamp[tz] and asset columns have default model objects if their inputs are NOT disabled
         case 'timestamp':
-          tsOptions.outputMomentFormat = dataFormats.datetime.display;
+          // this is only going to change the underlying raw value
+          tsOptions.outputMomentFormat = dataFormats.timestamp;
           // formatDatetime takes care of column.default if null || undefined
           initialModelValue = formatDatetime(defaultValue, tsOptions);
           isTimestamp = true;
           break;
         case 'timestamptz':
-          tsOptions.outputMomentFormat = dataFormats.datetime.displayZ;
+          // this is only going to change the underlying raw value
+          tsOptions.outputMomentFormat = dataFormats.datetime.return;
           // formatDatetime takes care of column.default if null || undefined
           initialModelValue = formatDatetime(defaultValue, tsOptions);
           isTimestamp = true;
@@ -224,16 +279,23 @@ export function populateCreateInitialValues(
       }
 
       if (isTimestamp) {
-        // string implies the input is disabled
-        if (colModel.inputType === 'disabled') {
-          values[`${formValue}-${column.name}`] = initialModelValue?.datetime || '';
-        } else {
-          values[`${formValue}-${column.name}`] = '';
-          values[`${formValue}-${column.name}-date`] = initialModelValue?.date || '';
-          values[`${formValue}-${column.name}-time`] = initialModelValue?.time || '';
+        values[`${formValue}-${column.name}`] = initialModelValue.datetime || '';
+        values[`${formValue}-${column.name}-date`] = initialModelValue?.date || '';
+        values[`${formValue}-${column.name}-time`] = initialModelValue?.time || '';
+
+        // add the select-all input value
+        if (formIndex === 0) {
+          values[`${SELECT_ALL_INPUT_FORM_VALUE}-${column.name}`] = '';
+          values[`${SELECT_ALL_INPUT_FORM_VALUE}-${column.name}-date`] = '';
+          values[`${SELECT_ALL_INPUT_FORM_VALUE}-${column.name}-time`] = '';
         }
       } else {
         values[`${formValue}-${column.name}`] = replaceNullOrUndefined(initialModelValue, '');
+
+        // add the select-all input value
+        if (formIndex === 0) {
+          values[`${SELECT_ALL_INPUT_FORM_VALUE}-${column.name}`] = '';
+        }
       }
     }
   });
@@ -242,11 +304,11 @@ export function populateCreateInitialValues(
 }
 
 export function populateEditInitialValues(
+  reference: any,
   columnModels: RecordeditColumnModel[],
   forms: number[],
-  columns: any[],
   tuples: any[],
-  isCopy: boolean
+  appMode: string
 ) {
   // initialize row objects {column-name: value,...}
   const values: any = {};
@@ -255,7 +317,7 @@ export function populateEditInitialValues(
   const foreignKeyData: any = {};
 
   // whether the value can be updated or not
-  const canUpdateValues: {[key: string]: boolean} = {};
+  const canUpdateValues: { [key: string]: boolean } = {};
 
   forms.forEach((formValue: any, formIndex: number) => {
     const tupleIndex = formIndex;
@@ -272,11 +334,18 @@ export function populateEditInitialValues(
       const column = colModel.column;
       let value;
 
+      // add the select-all input values
+      if (formIndex === 0) {
+        // just use empty value (this is to make sure react-hook-forms has this key from the beginning)
+        // NOTE if we actually want to show the default values, we should send extra requests.
+        copyOrClearValue(colModel, values, foreignKeyData, SELECT_ALL_INPUT_FORM_VALUE, undefined, true);
+      }
+
       // If input is disabled, and it's copy, we don't want to copy the value
       let isDisabled = colModel.inputType === 'disabled';
-      if (isDisabled && isCopy) return;
+      if (isDisabled && appMode === appModes.COPY) return;
 
-      if (!isCopy) {
+      if (appMode !== appModes.COPY) {
         // whether certain columns are disabled or not
         canUpdateValues[`${formValue}-${column.name}`] = tuple.canUpdate && tuple.canUpdateValues[i];
 
@@ -298,11 +367,14 @@ export function populateEditInitialValues(
       let isTimestamp = false
       switch (column.type.name) {
         case 'timestamp':
+          // this is only going to change the underlying raw value
+          options.outputMomentFormat = dataFormats.timestamp;
           value = formatDatetime(tupleValues[i], options);
           isTimestamp = true;
           break;
         case 'timestamptz':
-          if (isDisabled) options.outputMomentFormat = dataFormats.datetime.return;
+          // this is only going to change the underlying raw value
+          options.outputMomentFormat = dataFormats.datetime.return;
           value = formatDatetime(tupleValues[i], options);
           isTimestamp = true;
           break;
@@ -351,14 +423,9 @@ export function populateEditInitialValues(
       // no need to check for copy here because the case above guards against the negative case for copy
 
       if (isTimestamp) {
-        // string implies the input is disabled
-        if (colModel.inputType === 'disabled') {
-          values[`${formValue}-${column.name}`] = value?.datetime || '';
-        } else {
-          values[`${formValue}-${column.name}`] = '';
-          values[`${formValue}-${column.name}-date`] = value?.date || '';
-          values[`${formValue}-${column.name}-time`] = value?.time || '';
-        }
+        values[`${formValue}-${column.name}`] = value?.datetime || '';
+        values[`${formValue}-${column.name}-date`] = value?.date || '';
+        values[`${formValue}-${column.name}-time`] = value?.time || '';
       } else {
         values[`${formValue}-${column.name}`] = replaceNullOrUndefined(value, '');
       }


### PR DESCRIPTION
The main change in this PR is adding the select-all functionality.

In the AngularJS version, we're creating an `allInput` prop in `columnModel` that captures the select-all input. Since we're assuming `columnModels` will not change after initialization, I'm initializing the form with one additional input for each column and naming them with  `-1-${colName}` format (essentially, we now have a hidden form with formNumber=-1).

I didn't make any changes to how we're storing datetime values. I have to think more about it because what we have works and doesn't add too much overhead compared to alternatives. 

Also, I Made some changes to the HTML layout to fix scrolling behavior and accommodate the select-all UI. So instead of directly merging my changes, I created the PR to double-check the changes.

