### PR TITLE
timestamp and timestamptz validation

### DIFF
--- a/src/components/input-switch/input-switch.tsx
+++ b/src/components/input-switch/input-switch.tsx
@@ -16,6 +16,9 @@ import TextField from '@isrd-isi-edu/chaise/src/components/input-switch/text-fie
 // models
 import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
 
+// utils
+import { getInputType } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+
 export type InputSwitchProps = {
   /**
    * the type of input :
@@ -208,6 +211,7 @@ const InputSwitch = ({
           timeClasses={timeClasses}
           clearTimeClasses={clearTimeClasses}
           type={type}
+          hasTimezone={columnModel?.column.type.name === 'timestamptz'}
           name={name}
           classes={classes}
           inputClasses={inputClasses}

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -231,6 +231,12 @@ const timestampFieldValidation = (value: string) => {
   return timestamp.isValid() || ERROR_MESSAGES.INVALID_TIMESTAMP;
 };
 
+const timestamptzFieldValidation = (value: string) => {
+  if (!value) return;
+  const timestamp = windowRef.moment(value, dataFormats.datetime.return, true);
+  return timestamp.isValid() || ERROR_MESSAGES.INVALID_TIMESTAMP;
+};
+
 export const VALIDATE_VALUE_BY_TYPE: {
   [key: string]: any;
 } = {
@@ -242,4 +248,5 @@ export const VALIDATE_VALUE_BY_TYPE: {
   'number': numericFieldValidation,
   'date': dateFieldValidation,
   'timestamp': timestampFieldValidation,
+  'timestamptz': timestamptzFieldValidation,
 };


### PR DESCRIPTION
This PR cleans up the implementation for `timestamp` and `timestamptz` inputs and the places they are used. In the case of `facet-range-picker`, the `absMin`/`absMax` values that are stored in the `compState` variable are no longer objects. Instead the string representation of the `timestamp[tz]` values are stored and passed to `rangeInputs` where they are then digested for setting values in the timestamp, date, and time inputs separately.

The validation for `timestamp[tz]` was triggering on form submission since in some cases the values were not formatted in the format that the validation function expected. When a value changes in the `date` or `time` input, in the case of `timestamp[tz]`, the `datetime` value is passed into moment so the appropriate timezone can be appended.