### PR TITLE
handle date and time inputs manually

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-dom": "^18.2.0",
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.36.1",
+        "react-imask": "^6.5.0-alpha.0",
         "react-plotly.js": "^2.5.1",
         "sass": "^1.58.3",
         "sass-loader": "^13.2.0",
@@ -6209,6 +6210,14 @@
         "quantize": "^1.0.2"
       }
     },
+    "node_modules/imask": {
+      "version": "6.5.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-6.5.0-alpha.0.tgz",
+      "integrity": "sha512-yv/MGZB65SC+EkYE8DPE9YWj8SfOOtoLd4G70tH5G20sj1Ek9MdeUl+KvDhuxY+y8C2vkouTCrhSYwylFsalcw==",
+      "engines": {
+        "npm": ">=4.0.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -8705,6 +8714,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-imask": {
+      "version": "6.5.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-6.5.0-alpha.0.tgz",
+      "integrity": "sha512-LnMf7oH/0ISJ98ZzGFGrkFoLjVvPIg0Xy+W7qNgxHjNLEPPkQWYjSkQ3WBmuEty8aLunczXWHu2JEAapmkeJnQ==",
+      "dependencies": {
+        "imask": "^6.5.0-alpha.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-is": {
@@ -15837,6 +15861,11 @@
         "quantize": "^1.0.2"
       }
     },
+    "imask": {
+      "version": "6.5.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-6.5.0-alpha.0.tgz",
+      "integrity": "sha512-yv/MGZB65SC+EkYE8DPE9YWj8SfOOtoLd4G70tH5G20sj1Ek9MdeUl+KvDhuxY+y8C2vkouTCrhSYwylFsalcw=="
+    },
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -17720,6 +17749,15 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.36.1.tgz",
       "integrity": "sha512-EbYYkCG2p8ywe7ikOH2l02lAFMrrrslZi1I8fqd8ifDGNAkhomHZQzQsP6ksvzrWBKntRe8b5L5L7Zsd+Gm02Q==",
       "requires": {}
+    },
+    "react-imask": {
+      "version": "6.5.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-6.5.0-alpha.0.tgz",
+      "integrity": "sha512-LnMf7oH/0ISJ98ZzGFGrkFoLjVvPIg0Xy+W7qNgxHjNLEPPkQWYjSkQ3WBmuEty8aLunczXWHu2JEAapmkeJnQ==",
+      "requires": {
+        "imask": "^6.5.0-alpha.0",
+        "prop-types": "^15.8.1"
+      }
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.36.1",
+    "react-imask": "^6.5.0-alpha.0",
     "react-plotly.js": "^2.5.1",
     "sass": "^1.58.3",
     "sass-loader": "^13.2.0",

--- a/src/assets/scss/_input-switch.scss
+++ b/src/assets/scss/_input-switch.scss
@@ -77,31 +77,14 @@
 }
 
 .input-switch-datetime {
-  flex-direction: column;
-
-  .chaise-input-control {
-    min-height: auto;
-
-    // TODO this rule is not needed for recordedit, is it needed for range-inputs?
-    // .input-switch-clear {
-      // top: -2px;
-    // }
+  .input-switch-time {
+    margin: 3px 0;
   }
 
-  .chaise-input-control:first-child {
-    margin-bottom: 5px;
+  .chaise-btn-group {
+    float: right;
   }
 }
-
-.input-switch-date,
-.input-switch-datetime {
-
-  .date-input-show-clear,
-  .time-input-show-clear {
-    margin-right: 10px;
-  }
-}
-
 
 .chaise-firefox .input-switch-date.chaise-input-control.has-feedback,
 .chaise-firefox .input-switch-time.chaise-input-control.has-feedback {

--- a/src/assets/scss/_range-input.scss
+++ b/src/assets/scss/_range-input.scss
@@ -37,7 +37,7 @@
         }
 
         &.time-width {
-            min-width: 150px;
+            min-width: 165px;
             max-width: 180px;
         }
 

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -978,8 +978,7 @@ const FacetRangePicker = ({
         inputType={getInputType(facetColumn.column.type)}
         classes='facet-range-input'
         addRange={addFilter}
-        absMin={compState.rangeOptions.absMin}
-        absMax={compState.rangeOptions.absMax}
+        rangeOptions={compState.rangeOptions}
         disabled={facetColumn.hasNotNullFilter}
       />
       {renderHistogram()}

--- a/src/components/input-switch/date-field.tsx
+++ b/src/components/input-switch/date-field.tsx
@@ -1,32 +1,99 @@
 // components
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 import InputField, { InputFieldProps } from '@isrd-isi-edu/chaise/src/components/input-switch/input-field';
+import { IMaskInput, IMask } from 'react-imask';
+
+// hooks
+import { useFormContext } from 'react-hook-form';
 
 // utils
 import { VALIDATE_VALUE_BY_TYPE } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+
+type DateFieldProps = InputFieldProps & {
+  /**
+   * whether we should show the extra buttons or not
+   */
+  displayExtraDateTimeButtons?: boolean,
+  /**
+   * when date-field used in date-time-field we want the prepend text
+   */
+  displayTimePrependText?: boolean
+}
 
 
-const DateField = (props: InputFieldProps): JSX.Element => {
+const DateField = (props: DateFieldProps): JSX.Element => {
+
+  const { setValue } = useFormContext();
 
   const rules = {
     validate: VALIDATE_VALUE_BY_TYPE['date']
   };
 
+  const applyToday = (e: any) => {
+    e.stopPropagation();
+    setValue(props.name, windowRef.moment().format(dataFormats.date));
+  }
+
   return (
     <InputField {...props} controllerRules={rules}>
       {(field, onChange, showClear, clearInput) => (
-        <div className={`chaise-input-control has-feedback input-switch-date ${props.classes} ${props.disableInput ? ' input-disabled' : ''}`}>
-          <input
-            className={`${props.inputClasses} input-switch ${showClear ? 'date-input-show-clear' : ''}`} {...field}
-            onChange={onChange} type='date' step='1' pattern='\d{4}-\d{2}-\d{2}' disabled={props.disableInput}
-            // TODO are the following needed?
-            min='1970-01-01' max='2999-12-31'
-          />
-          <ClearInputBtn
-            btnClassName={`${props.clearClasses} input-switch-clear`}
-            clickCallback={clearInput}
-            show={showClear && !props.disableInput}
-          />
+        <div className='chaise-input-group input-switch-date'>
+          {props.displayTimePrependText && <div className='chaise-input-group-prepend'>
+            <div className='chaise-input-group-text dt-width'>Date</div>
+          </div>}
+          <div className={`chaise-input-control has-feedback ${props.classes} ${props.disableInput ? ' input-disabled' : ''}`}>
+            <IMaskInput
+              // ------------ input props ----------- //
+              className={`${props.inputClasses} input-switch ${showClear ? 'date-input-show-clear' : ''}`}
+              disabled={props.disableInput}
+              placeholder={props.placeholder ? props.placeholder : dataFormats.placeholder.date}
+              /**
+               * this will make sure we're calling the onChange of react-hook-forms
+               * on each data update.
+               * if we don't want to show the validation error while user is typing,
+               * we can add validation logic to this to skip calling onChange.
+               */
+              onAccept={(value, mask) => {
+                // the value is the "masked" value so we have to make sure we're treating the mask as empty
+                onChange({ target: { value : value === dataFormats.date ? '' : value } })
+                return true;
+              }}
+              {...field}
+              // ------------ IMask specific props ----------- //
+              mask={Date}
+              pattern={dataFormats.date}
+              /**
+               * the underlying value in IMaskInput is a "Date" object.
+               * The following two functions will make sure we're properly
+               * converting a strored "Date" object to string (what user sees)
+               * and vice versa.
+               */
+              format={(date) => windowRef.moment(date).format(dataFormats.date)}
+              parse={(str) => windowRef.moment(str, dataFormats.date)}
+              autofix={false}
+              /**
+               * when lazy is turned on, it will always show the pattern (even if value is empty).
+               * but when the field is empty we don't want to show the pattern (and want to show the placeholder instead)
+               */
+              lazy={field.value === '' ? true : false}
+              blocks={{
+                // `0` in mask means any numbers. so this is saying any numbers.
+                YYYY: { mask: '0000', placeholderChar: 'Y' },
+                MM: { mask: IMask.MaskedRange, from: 1, to: 12, maxLength: 2, placeholderChar: 'M' },
+                DD: { mask: IMask.MaskedRange, from: 1, to: 31, maxLength: 2, placeholderChar: 'D' }
+              }}
+            />
+            <ClearInputBtn
+              btnClassName={`${props.clearClasses} input-switch-clear`}
+              clickCallback={clearInput}
+              show={showClear && !props.disableInput}
+            />
+          </div>
+          {!props.disableInput && props.displayExtraDateTimeButtons && <div className='chaise-input-group-append'>
+            <button type='button' className='chaise-btn chaise-btn-secondary' onClick={applyToday}>Today</button>
+          </div>}
         </div>
       )}
     </InputField>

--- a/src/components/input-switch/date-time-field.tsx
+++ b/src/components/input-switch/date-time-field.tsx
@@ -40,6 +40,11 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
     /**
      * this will make sure we're updating the underlying value after
      * each update to the date and time fields.
+     *
+     * NOTE: just claling setError will not mark the form as invalid and the form.
+     * when users submit the form, the validators on the input itself will trigger
+     * that's why I'm setting the values to something invalid so it can then invalidate
+     * them and disallow submit.
      */
     const sub = watch((data, options) => {
       const name = props.name
@@ -58,6 +63,7 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
         // if date is missing, this is invalid
         if (!dateVal) {
           setError(name, { type: 'custom', message: ERROR_MESSAGES.INVALID_DATE });
+          setValue(name, 'invalid-value');
           return;
         }
         // otherwise validate the date value
@@ -65,7 +71,7 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
           const err = VALIDATE_VALUE_BY_TYPE['date'](dateVal);
           if (typeof err === 'string') {
             setError(name, { type: 'custom', message: err});
-            setValue(name, '');
+            setValue(name, 'invalid-value');
             return;
           }
         }
@@ -79,7 +85,7 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
           const err = VALIDATE_VALUE_BY_TYPE['time'](timeVal);
           if (typeof err === 'string') {
             setError(name, { type: 'custom', message: err });
-            setValue(name, '');
+            setValue(name, 'invalid-value');
             return;
           }
         }
@@ -161,7 +167,7 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
 
   return (
     <InputField {...props}
-      // make sure to mark the whole input as "touched" if any of the inpust are touched
+      // make sure to mark the whole input as "touched" if any of the inputs are touched
       checkIsTouched={() => isDateTouched || isTimeTouched}
       /**
        * the validation is done above and this one is technically not needed

--- a/src/components/input-switch/date-time-field.tsx
+++ b/src/components/input-switch/date-time-field.tsx
@@ -1,15 +1,17 @@
 // components
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 import InputField, { InputFieldProps } from '@isrd-isi-edu/chaise/src/components/input-switch/input-field';
+import DateField from '@isrd-isi-edu/chaise/src/components/input-switch/date-field';
 
 // hooks
 import { useEffect } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
 // utils
-import { ERROR_MESSAGES, VALIDATE_VALUE_BY_TYPE } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+import { ERROR_MESSAGES, formatDatetime, VALIDATE_VALUE_BY_TYPE } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+
 
 type DateTimeFieldProps = InputFieldProps & {
   /**
@@ -20,12 +22,18 @@ type DateTimeFieldProps = InputFieldProps & {
    * classes for styling the clear button for time field
    */
   clearTimeClasses?: string,
-  hasTimezone?: boolean
+  hasTimezone?: boolean,
+  /**
+   * whether we should show the extra buttons or not
+   */
+  displayExtraDateTimeButtons?: boolean
 }
 
 const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
 
   const { setValue, control, clearErrors, watch, setError } = useFormContext();
+
+  const DATE_TIME_FORMAT = props.hasTimezone ? dataFormats.datetime.return : dataFormats.timestamp;
 
   useEffect(() => {
 
@@ -46,19 +54,51 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
           setValue(name, '');
           return;
         }
-        // if only the date is missing, this is invalid
+
+        // if date is missing, this is invalid
         if (!dateVal) {
-          setError(name, {type: 'custom', message: ERROR_MESSAGES.INVALID_DATE});
+          setError(name, { type: 'custom', message: ERROR_MESSAGES.INVALID_DATE });
           return;
         }
+        // otherwise validate the date value
+        else {
+          const err = VALIDATE_VALUE_BY_TYPE['date'](dateVal);
+          if (typeof err === 'string') {
+            setError(name, { type: 'custom', message: err});
+            setValue(name, '');
+            return;
+          }
+        }
+
         // if only time is missing, just use 00:00:00 for it
         if (!timeVal) {
           timeVal = '00:00:00';
         }
+        // otherwise validate the time value
+        else {
+          const err = VALIDATE_VALUE_BY_TYPE['time'](timeVal);
+          if (typeof err === 'string') {
+            setError(name, { type: 'custom', message: err });
+            setValue(name, '');
+            return;
+          }
+        }
 
-        let valueToSet = `${dateVal}T${timeVal}`;
+        /**
+         * concatenate date and time together
+         * since time can have multiple formats, we cannot simply concatenate the strings
+         * and have to rely on moment to do this for us.
+         */
+        const date = windowRef.moment(dateVal, dataFormats.date);
+        const time = windowRef.moment(timeVal, dataFormats.time);
+        const dateTime = date.set({
+          hour: time.get('hour'),
+          minute: time.get('minute'),
+          second: time.get('second')
+        });
+
         // adds the timezone info if needed
-        if (props.hasTimezone) valueToSet = windowRef.moment(valueToSet).format(dataFormats.datetime.return);
+        const valueToSet = dateTime.format(DATE_TIME_FORMAT);
 
         clearErrors(name);
         setValue(name, valueToSet);
@@ -80,7 +120,6 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
   const dateFieldState = formInputDate?.fieldState;
   const { isTouched: isDateTouched } = dateFieldState;
 
-
   const formInputTime = useController({
     name: `${props.name}-time`,
     control,
@@ -93,10 +132,15 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
   const timeFieldState = formInputTime?.fieldState;
   const { isTouched: isTimeTouched } = timeFieldState;
 
-  const handleDateChange = (v: any) => {
-    dateField.onChange(v);
-    dateField.onBlur();
-  };
+  const applyNow = (e: any) => {
+    e.stopPropagation();
+
+    const v = formatDatetime(windowRef.moment(), { outputMomentFormat: DATE_TIME_FORMAT })
+
+    setValue(props.name, v?.datetime);
+    setValue(`${props.name}-date`, v?.date);
+    setValue(`${props.name}-time`, v?.time);
+  }
 
   const handleTimeChange = (v: any) => {
     timeField.onChange(v);
@@ -113,43 +157,54 @@ const DateTimeField = (props: DateTimeFieldProps): JSX.Element => {
     setValue(`${props.name}-time`, '');
   }
 
-  const showDateClear = () => Boolean(dateFieldValue);
   const showTimeClear = () => Boolean(timeFieldValue);
 
   return (
     <InputField {...props}
+      // make sure to mark the whole input as "touched" if any of the inpust are touched
       checkIsTouched={() => isDateTouched || isTimeTouched}
+      /**
+       * the validation is done above and this one is technically not needed
+       * (it's basically just validating the watch above and not the user action)
+       */
       controllerRules={{
         validate: VALIDATE_VALUE_BY_TYPE[(props.hasTimezone ? 'timestamptz' : 'timestamp')]
       }}
     >
       {(field) => (
         <div className='input-switch-datetime'>
-          <div className={`chaise-input-control has-feedback input-switch-date ${props.classes} ${props.disableInput ? ' input-disabled' : ''}`}>
-            <input
-              className={`${props.inputClasses} input-switch ${showDateClear() ? 'date-input-show-clear' : ''}`}
-              type='date' step='1' disabled={props.disableInput}
-              {...dateField} onChange={handleDateChange}
-            />
-            <ClearInputBtn
-              btnClassName={`${props.clearClasses} input-switch-clear`}
-              clickCallback={clearDate}
-              show={showDateClear() && !props.disableInput}
-            />
+          <DateField
+            type={'date'}
+            name={`${props.name}-date`}
+            classes={props.classes ? props.classes : ''}
+            inputClasses={props.inputClasses}
+            clearClasses={props.clearClasses}
+            disableInput={props.disableInput}
+            displayErrors={false}
+            displayExtraDateTimeButtons={false}
+            displayTimePrependText={true}
+          />
+          <div className='chaise-input-group input-switch-time'>
+            <div className='chaise-input-group-prepend'>
+              <div className='chaise-input-group-text dt-width'>Time</div>
+            </div>
+            <div className={`chaise-input-control has-feedback ${props.classes} ${props.disableInput ? ' input-disabled' : ''}`}>
+              <input
+                className={`${props.timeClasses} input-switch ${showTimeClear() ? 'time-input-show-clear' : ''}`}
+                type='text' disabled={props.disableInput} {...timeField} onChange={handleTimeChange}
+                placeholder={dataFormats.placeholder.time}
+              />
+              <ClearInputBtn
+                btnClassName={`${props.clearTimeClasses} input-switch-clear`}
+                clickCallback={clearTime}
+                show={showTimeClear() && !props.disableInput}
+              />
+            </div>
           </div>
-          <div className={`chaise-input-control has-feedback input-switch-time ${props.classes} ${props.disableInput ? ' input-disabled' : ''}`}>
-            <input
-              className={`${props.timeClasses} input-switch ${showTimeClear() ? 'time-input-show-clear' : ''}`}
-              type='time' min='00:00:00' max='23:59:59' step='1'
-              disabled={props.disableInput}
-              {...timeField} onChange={handleTimeChange}
-            />
-            <ClearInputBtn
-              btnClassName={`${props.clearTimeClasses} input-switch-clear`}
-              clickCallback={clearTime}
-              show={showTimeClear() && !props.disableInput}
-            />
-          </div>
+          {!props.disableInput && props.displayExtraDateTimeButtons && <div className='chaise-btn-group'>
+            <button type='button' className='chaise-btn chaise-btn-secondary' onClick={applyNow}>Now</button>
+            <button type='button' className='chaise-btn chaise-btn-secondary' onClick={() => { clearTime(); clearDate(); }}>Clear</button>
+          </div>}
           <input {...field} type='hidden' />
         </div>
       )}

--- a/src/components/input-switch/input-field.tsx
+++ b/src/components/input-switch/input-field.tsx
@@ -1,20 +1,11 @@
 import '@isrd-isi-edu/chaise/src/assets/scss/_input-switch.scss';
 
-// components
-import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
-
 // hooks
-import { useEffect, useState, useRef } from 'react';
-import { useFormContext, useController, useWatch, ControllerRenderProps, FieldValues } from 'react-hook-form';
-
-// models
-import { RangeOption, TimeStamp } from '@isrd-isi-edu/chaise/src/models/range-picker';
-import { RecordeditColumnModel } from '@isrd-isi-edu/chaise/src/models/recordedit';
+import { useEffect, useState } from 'react';
+import { useFormContext, useController, ControllerRenderProps, FieldValues, UseControllerReturn } from 'react-hook-form';
 
 // utils
-import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
-import { arrayFieldPlaceholder, ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
-import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { isObjectAndNotNull } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 
@@ -64,9 +55,10 @@ export type InputFieldProps = {
 type InputFieldChildFn = (
   (
     field: ControllerRenderProps<FieldValues, string>,
-    onChange: (value: any) => void,
+    onChange: (event?: any) => void,
     showClear: boolean,
-    clearInput: (e: any) => void
+    clearInput: (e: any) => void,
+    formInput: UseControllerReturn<FieldValues, string>,
   ) => JSX.Element
 )
 
@@ -176,7 +168,7 @@ const InputField = ({
 
   return (
     <div className={`${containerClasses} input-switch-container-${makeSafeIdAttr(name)}`} style={styles}>
-      {typeof children === 'function' ? children(field, onChange, showClear, clearInput) : children}
+      {typeof children === 'function' ? children(field, onChange, showClear, clearInput, formInput) : children}
       {showError && error?.message && <span className='input-switch-error text-danger'>{error.message}</span>}
     </div>
   );

--- a/src/components/input-switch/input-switch.tsx
+++ b/src/components/input-switch/input-switch.tsx
@@ -117,6 +117,10 @@ export type InputSwitchProps = {
    * whether we're still waiting for foreignkey data
    */
   waitingForForeignKeyData?: boolean,
+  /**
+   * whether we should offer the extra now/today buttons
+   */
+  displayExtraDateTimeButtons?: boolean
 };
 
 const InputSwitch = ({
@@ -141,7 +145,8 @@ const InputSwitch = ({
   parentLogStack,
   parentLogStackPath,
   foreignKeyData,
-  waitingForForeignKeyData
+  waitingForForeignKeyData,
+  displayExtraDateTimeButtons
 }: InputSwitchProps): JSX.Element | null => {
 
 
@@ -222,6 +227,7 @@ const InputSwitch = ({
           styles={styles}
           displayErrors={displayErrors}
           placeholder={placeholder as string}
+          displayExtraDateTimeButtons={displayExtraDateTimeButtons}
         />;
       case 'date':
         return <DateField
@@ -236,6 +242,7 @@ const InputSwitch = ({
           styles={styles}
           displayErrors={displayErrors}
           placeholder={placeholder as string}
+          displayExtraDateTimeButtons={displayExtraDateTimeButtons}
         />;
       case 'integer2':
       case 'integer4':

--- a/src/components/recordedit/form-container.tsx
+++ b/src/components/recordedit/form-container.tsx
@@ -231,7 +231,8 @@ const FormRow = ({ columnModelIndex }: FormRowProps): JSX.Element => {
       }
       <InputSwitch
         key={colName}
-        displayErrors={true}
+        displayErrors
+        displayExtraDateTimeButtons
         disableInput={isDisabled}
         requiredInput={columnModel.isRequired}
         name={`${formNumber}-${colName}`}
@@ -381,7 +382,8 @@ const SelectAllRow = ({ columnModelIndex }: FormRowProps) => {
       <div className='select-all-input'>
         <InputSwitch
           key={colName}
-          displayErrors={true}
+          displayErrors
+          displayExtraDateTimeButtons
           disableInput={false}
           requiredInput={false}
           name={inputName}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -74,6 +74,7 @@ export const dataFormats = {
     time: 'HH:MM:SS'
   },
   date: 'YYYY-MM-DD',
+  time: ['H:m:s', 'H:m', 'H'],
   time12: 'hh:mm:ss', // used for displaying values in recordedit properly
   time24: 'HH:mm:ss',
   timestamp: 'YYYY-MM-DDTHH:mm:ss',

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -121,10 +121,16 @@ export function getDisabledInputValue(column: any) {
   }
 }
 
-export function formatDatetime(value: string, options: TimestampOptions) {
+export function formatDatetime(value: any, options: TimestampOptions) {
   if (value) {
-    // create a moment object (value should be string format)
-    const momentObj = options.currentMomentFormat ? windowRef.moment(value, options.currentMomentFormat) : windowRef.moment(value);
+    let momentObj;
+    if (typeof value === 'string') {
+      // create a moment object (value should be string format)
+      momentObj = options.currentMomentFormat ? windowRef.moment(value, options.currentMomentFormat) : windowRef.moment(value);
+    } else {
+      momentObj = value;
+    }
+
     return {
       date: momentObj.format(dataFormats.date),
       time: momentObj.format(dataFormats.time24),
@@ -154,7 +160,8 @@ export const ERROR_MESSAGES = {
   INTEGER_8_MAX: 'This field requires a value less than ' + INTEGER_LIMITS.INT_8_MAX + '.',
   INVALID_INTEGER: 'Please enter a valid integer value.',
   INVALID_NUMERIC: 'Please enter a valid decimal value.',
-  INVALID_DATE: 'Please enter a valid date value.',
+  INVALID_DATE: `Please enter a valid date value in ${dataFormats.placeholder.date} format.`,
+  INVALID_TIME: `Please enter a valid time value in 24-hr ${dataFormats.placeholder.time} format.`,
   INVALID_TIMESTAMP: 'Please enter a valid date and time value.',
   INVALID_JSON: 'Please enter a valid JSON value.'
 }
@@ -280,6 +287,12 @@ const dateFieldValidation = (value: string) => {
   return date.isValid() || ERROR_MESSAGES.INVALID_DATE;
 };
 
+const timeFieldValidation = (value: string) => {
+  if (!value) return;
+  const date = windowRef.moment(value, dataFormats.time, true);
+  return date.isValid() || ERROR_MESSAGES.INVALID_TIME;
+};
+
 const timestampFieldValidation = (value: string) => {
   if (!value) return;
   const timestamp = windowRef.moment(value, dataFormats.timestamp, true);
@@ -302,6 +315,7 @@ export const VALIDATE_VALUE_BY_TYPE: {
   'float': numericFieldValidation,
   'number': numericFieldValidation,
   'date': dateFieldValidation,
+  'time': timeFieldValidation,
   'timestamp': timestampFieldValidation,
   'timestamptz': timestamptzFieldValidation,
 };

--- a/src/utils/recordedit-utils.ts
+++ b/src/utils/recordedit-utils.ts
@@ -7,9 +7,9 @@ import { dataFormats } from '@isrd-isi-edu/chaise/src/utils/constants';
 
 // models
 import { LogStackPaths, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
-import { 
-  appModes, PrefillObject, RecordeditColumnModel, 
-  SELECT_ALL_INPUT_FORM_VALUE, TimestampOptions 
+import {
+  appModes, PrefillObject, RecordeditColumnModel,
+  SELECT_ALL_INPUT_FORM_VALUE, TimestampOptions
 } from '@isrd-isi-edu/chaise/src/models/recordedit'
 
 // services


### PR DESCRIPTION
When we migrated the recordset app, we used the browser's `date` and `time` inputs for facet range pickers.

But now that we've used this feature more and discussed it, we prefer the old AngularJS method where we used `text` inputs with special masks and validators. The following are some of the issues with `date`/`time` input type:
  - The behavior is not consistent between browsers. It also shows different formats based on user locale (e.g., 24hr time vs. 12hr), which could confuse UX.
Partial values were causing issues in both date and time.
  - We cannot easily support multiple formats for time.
  - We have to test the validation and date/time pickers manually.

Therefore, this will modify date and time inputs into text inputs with special masks and validators (the same as AngularJS) implementation.


Notes and other changes,
  - In AngularJS implementation, we allowed 24hr format and had AM/PM toggle. Since this would leak to confusing UX, I didn't implement AM/PM toggle (this is consistent with range-input behavior as in AngularJS it was just 24hr format).
  - Added a mask to date inputs using [imaskjs](https://imask.js.org/).
  - Changed the DateTimeField component to use DateField instead of repeating the same structure in two places.
  - Changed RangeInputs to fix a side effect where the facet wasn't updating the min/max displayed on the inputs.



**Pending**:
- There's a bug in my implementation where even though I'm showing the errors for date-time-field properly, the react-hoo-form submit is firing the successful callback and submitting the form (the value is empty in this case, so it's not a usage issue).