### PR TITLE
Properly set asset metadata values

### DIFF
--- a/test/e2e/data_setup/data/editable-id/editable-id-table.json
+++ b/test/e2e/data_setup/data/editable-id/editable-id-table.json
@@ -1,1 +1,11 @@
-[{"id": 1, "text": "text", "int": 17, "generated": 1}]
+[
+  {
+    "id": 1,
+    "text": "text",
+    "int": 17,
+    "generated": 1,
+    "asset1_uri": "https://example.com/path/to/saved_filename.png",
+    "asset1_filename": "saved_filename.png",
+    "asset1_bytes": 512000
+  }
+]

--- a/test/e2e/data_setup/schema/record/editable-id.json
+++ b/test/e2e/data_setup/schema/record/editable-id.json
@@ -29,21 +29,24 @@
                             "hidden"
                         ]
                     }
-                }, {
+                },
+                {
                     "name": "text",
                     "default": "default text",
                     "nullok": true,
                     "type": {
                         "typename": "text"
                     }
-                }, {
+                },
+                {
                     "name": "int",
                     "default": 100,
                     "nullok": true,
                     "type": {
                         "typename": "int"
                     }
-                }, {
+                },
+                {
                     "name": "generated",
                     "nullok": true,
                     "type": {
@@ -53,11 +56,36 @@
                         "tag:isrd.isi.edu,2016:generated": null,
                         "tag:isrd.isi.edu,2016:immutable": null
                     }
+                },
+                {
+                  "name": "asset1_uri",
+                  "type": {
+                    "typename": "text"
+                  },
+                  "annotations": {
+                    "tag:isrd.isi.edu,2017:asset": {
+                      "url_pattern":"hatrac/js/chaise/{{{_fileid}}}/{{{_uri.md5_hex}}}",
+                      "filename_column" : "asset1_filename",
+                      "byte_count_column": "asset1_bytes"
+                    }
+                  }
+                },
+                {
+                  "name": "asset1_filename",
+                  "type": {
+                    "typename": "text"
+                  }
+                },
+                {
+                  "name": "asset1_bytes",
+                  "type": {
+                    "typename": "int8"
+                  }
                 }
             ],
             "annotations": {
                 "tag:isrd.isi.edu,2016:visible-columns" : {
-                    "*": ["RID", "id", "text", "int", "generated"],
+                    "*": ["id", "text", "int", "generated", "asset1_uri", "asset1_filename", "asset1_bytes"],
                     "export": []
                 },
                 "tag:misd.isi.edu,2015:display" : {

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -1817,7 +1817,7 @@ exports.testRecordAppValuesAfterSubmission = function(column_names, column_value
         if (process.env.CI && column_values[columnName].ignoreInCI) {
             continue;
         }
-        else if (typeof column_values[columnName].link === 'string') {
+        else if (column_values[columnName] && typeof column_values[columnName].link === 'string') {
             column = column.element(by.css("a"));
             var link = mustache.render(column_values[columnName].link, {
                 "catalog_id": process.env.catalogId,


### PR DESCRIPTION
When users copy a record, we populate the form based on the copied record. Regarding assets, we only copy the hatrac URL, not the extra metadata columns. This PR will make sure we're also copying the metadata columns. 

This is something that I wasn't sure of when I was finalizing the Recordedit React app and left it so I can discuss it with @jrchudy first. 

We can use this branch to add the extra changes to asset implementation if needed.