### PR TITLE
Properly handle required check for boolean inputs

### DIFF
--- a/src/components/input-switch/boolean-field.tsx
+++ b/src/components/input-switch/boolean-field.tsx
@@ -5,6 +5,7 @@ import Dropdown from 'react-bootstrap/Dropdown';
 
 
 // utils
+import { ERROR_MESSAGES } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { formatBoolean } from '@isrd-isi-edu/chaise/src/utils/input-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 
@@ -22,12 +23,52 @@ const BooleanField = (props: BooleanFieldProps): JSX.Element => {
     return (typeof v === 'boolean');
   };
 
+  /**
+   * check if the parameter is empty
+   */
+  const isEmptyValue = (v: any) => {
+    return v === '' || v === null || v === undefined;
+  }
+
+  /**
+   * defining the validators this way, so we can also modify the "required" check.
+   * The default react-hook-forms check is "truthy" which will not allow "false"
+   * values for required inputs.
+   */
+  const booleanFieldValidation = {
+    required: (v: any) => {
+      if (props.requiredInput && isEmptyValue(v)) {
+        return ERROR_MESSAGES.REQUIRED;
+      }
+      return true;
+    },
+    validateBoolean: (v: any) => {
+      // ignore empty values as we're handling them in the "required" validator
+      if (isEmptyValue(v)) {
+        return true;
+      }
+
+      // if it has a boolean value, then it's valid
+      if (typeof v === 'boolean') {
+        return true;
+      }
+
+      // this won't happen through the current UI but added for completeness
+      return ERROR_MESSAGES.INVALID_BOOLEAN;
+    }
+  }
+
   // first option is true, and second is false.
   const rawOptions = [true, false];
   const displayedOptions = rawOptions.map((op) => props.columnModel ? formatBoolean(props.columnModel.column, op) : op.toString());
 
   return (
-    <InputField {...props} checkHasValue={hasValue}>
+    <InputField {...props}
+      requiredInput={false} checkHasValue={hasValue}
+      controllerRules={{
+        validate: booleanFieldValidation
+      }}
+    >
       {(field, onChange, showClear, clearInput) => (
         <div className='input-switch-boolean'>
           <Dropdown aria-disabled={props.disableInput}>

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -539,7 +539,8 @@ export default function RecordeditProvider({
 
   // NOTE: most likely not needed
   const onSubmitInvalid = (errors: Object, e?: any) => {
-
+    $log.debug('errors in the form:');
+    $log.debug(errors);
     const invalidMessage = 'Sorry, the data could not be submitted because there are errors on the form. Please check all fields and try again.';
     addAlert(invalidMessage, ChaiseAlertType.ERROR);
   }

--- a/src/utils/input-utils.ts
+++ b/src/utils/input-utils.ts
@@ -164,7 +164,8 @@ export const ERROR_MESSAGES = {
   INVALID_TIME: `Please enter a valid time value in 24-hr ${dataFormats.placeholder.time} format.`,
   INVALID_TIMESTAMP: 'Please enter a valid date and time value.',
   INVALID_COLOR: 'Please enter a valid color value.',
-  INVALID_JSON: 'Please enter a valid JSON value.'
+  INVALID_JSON: 'Please enter a valid JSON value.',
+  INVALID_BOOLEAN: 'Please enter a valid boolean value.'
 }
 
 export function formatInt(value: string) {

--- a/test/e2e/data_setup/schema/recordedit/product-add.json
+++ b/test/e2e/data_setup/schema/recordedit/product-add.json
@@ -270,8 +270,7 @@
         {
           "comment": null,
           "name": "luxurious",
-          "default": null,
-          "nullok": true,
+          "nullok": false,
           "type": {
             "typename": "boolean"
           },

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -26,7 +26,7 @@ var testParams = {
             { name: "no_of_rooms", title: "Number of Rooms", type: "int2"},
             { name: "opened_on", title: "Operational Since", type: "timestamptz", nullok: false },
             { name: "date_col", title: "date_col", type: "date"},
-            { name: "luxurious", title: "Is Luxurious", type: "boolean" },
+            { name: "luxurious", title: "Is Luxurious", type: "boolean", nullok: false },
             { name: "text_array", title: "text_array", type: "array", baseType: "text" },
             { name: "boolean_array", title: "boolean_array", type: "array", baseType: "boolean" },
             { name: "int4_array", title: "int4_array", type: "array", baseType: "integer" },


### PR DESCRIPTION
We're relying on react-hook-form for the "required" check. But it's doing a "truthy" check which doesn't work well with how we've implemented the `BooleanField`s.  This field is special as we're storing the actual boolean value in the form, and the logic to turn this boolean to the displayed dropdown is hidden inside the field implementation. 

So in this PR, I created a custom `required` validator for this component. 


This wasn't an issue for other inputs like an integer. For those inputs, we're using "text" input, so to react-hook-form, a `0` value is actually `"0"` and therefore "truthy".


Fixes #2303.
