### PR TITLE
Various Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@isrd-isi-edu/chaise",
   "description": "An adaptive User Interface for ERMrest data sources",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=14.0.0",

--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -2,7 +2,7 @@
 @use 'variables';
 
 // override the default bootstrap
-.modal-backdrop {
+div.modal-backdrop {
   z-index: map-get(variables.$z-index-map, 'modal-backdrop');
 
   // allows modal on modal (only two levels)
@@ -10,7 +10,7 @@
     z-index: map-get(variables.$z-index-map, 'modal-backdrop-on-modal');
   }
 }
-.modal {
+div.modal {
   z-index: map-get(variables.$z-index-map, 'modal');
 
   // allows modal on modal (only two levels)
@@ -20,7 +20,7 @@
 }
 
 // don't add border to the modal header
-.modal-header {
+div.modal-header {
   border-bottom: none;
 
   &.center-aligned-title {
@@ -29,7 +29,7 @@
   }
 }
 
-.modal-title {
+div.modal-title {
   font-size: variables.$h2-font-size !important;
   font-weight: normal;
 }
@@ -181,7 +181,7 @@
   max-width: 95vw;
 }
 
-.chaise-body .modal-dialog.modal-lg {
+.modal-dialog.modal-lg {
   margin: 2.5vh auto;
   width: auto !important;
   max-width: 80vw;
@@ -189,7 +189,7 @@
 
 // NOTE in bootstrap3 this used to be modal-md,
 // but we don't have that notion anymore and therefore this is just the default size
-.chaise-body .modal:not(.modal-login-instruction) .modal-dialog:not(.modal-sm):not(.modal-lg):not(.modal-xl) {
+.modal:not(.modal-login-instruction) .modal-dialog:not(.modal-sm):not(.modal-lg):not(.modal-xl) {
   margin: 2.5vh auto;
   width: auto !important;
   max-width: 60vw;
@@ -271,12 +271,6 @@
       }
     }
   }
-}
-
-// don't show alerts on modals
-// except facet since it has to show the url length error
-.modal:not(.faceting-show-details-popup) .recordset-container alerts {
-  display: none !important;
 }
 
 .scalar-show-details-popup {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -8,6 +8,7 @@
 @import "buttons";
 @import "button-group";
 @import "inputs";
+@import "modal";
 
 // if we want to hide the page and then show navbar and content together
 .wait-for-navbar {

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -4,7 +4,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/app.scss';
 
 // hooks
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
-import { StrictMode, useEffect, useRef, useState } from 'react';
+import { StrictMode, useEffect, useState } from 'react';
 import useAuthn from '@isrd-isi-edu/chaise/src/hooks/authn';
 import useError from '@isrd-isi-edu/chaise/src/hooks/error';
 

--- a/src/components/modals/profile-modal.tsx
+++ b/src/components/modals/profile-modal.tsx
@@ -1,5 +1,3 @@
-import '@isrd-isi-edu/chaise/src/assets/scss/_modal.scss';
-
 // components
 import Modal from 'react-bootstrap/Modal';
 
@@ -10,10 +8,15 @@ import { useEffect, useState } from 'react';
 // models
 import { Client } from '@isrd-isi-edu/chaise/src/models/user';
 
+type ProfileModalProps = {
+  showProfile: boolean,
+  setShowProfile: Function
+};
 
 const ProfileModal = ({
-  showProfile, setShowProfile,
-}: any): JSX.Element | null => {
+  showProfile,
+  setShowProfile,
+}: ProfileModalProps): JSX.Element => {
   const { session } = useAuthn();
 
   const [initialized, setInitialzed]          = useState<boolean>(false);
@@ -55,7 +58,7 @@ const ProfileModal = ({
 
   // the profile modal only makes sense when we have a user
   if (!session) {
-    return null;
+    return <></>;
   }
 
   const handleClose = () => {
@@ -124,7 +127,7 @@ const ProfileModal = ({
   }
 
   if (!showProfile) {
-    return null;
+    return <></>;
   }
 
   return (

--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -176,7 +176,6 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
         // contenthash will help with avoiding to send unchanged files to server
         filename: '[name].[contenthash].css',
         /**
-         * TODO needs more testing
          * given that we're using CSS modules, this shouldn't cause any issues.
          * The input-switch.scss was causing circular dep issue and this has been
          * added to remove the warning.
@@ -189,23 +188,43 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
       runtimeChunk: 'single',
       splitChunks: {
         chunks: 'all',
+        /**
+         * avoid making very small or very large chunks
+         */
+        minSize: 50000,
+        maxSize: 500000,
+        hidePathInfo: true,
         name: 'common',
         cacheGroups: {
+          // this group is useful for deriva-webapps
+          chaiseVendor: {
+            test: /[\\/]node_modules[\\/]\@isrd-isi-edu[\\/]chaise[\\/]/,
+            name: 'vendor-chaise',
+            chunks: 'all',
+            priority: 4
+          },
           reactVendor: {
             test: /[\\/]node_modules[\\/](react|react-dom|react-bootstrap)[\\/]/,
             name: 'vendor-react',
             chunks: 'all',
+            priority: 3
           },
           bootstrapVendor: {
-            test: /[\\/]node_modules[\\/](bootstrap)[\\/]/,
+            test: /[\\/]node_modules[\\/]bootstrap[\\/]/,
             name: 'vendor-bootstrap',
             chunks: 'all',
+            priority: 2
           },
           vendor: {
-            test: /[\\/]node_modules[\\/]((?!(react|react-dom|react-bootstrap|bootstrap)).*)[\\/]/,
+            test: /[\\/]node_modules[\\/]/,
             name: 'vendor-rest',
             chunks: 'all',
-          },
+            /**
+             * we have to make sure priority of this group is less than the rest
+             * so this rule is used when others failed
+             */
+            priority: 1
+          }
         },
       },
     },


### PR DESCRIPTION
This PR will,
- Properly handle the race condition between facet registration and using the registered facet callbacks in the recordset app. Because of this race condition, the recordset modal in the plot app was sometimes throwing a terminal error. I couldn't reproduce this in Chaise though.
- Ensure the URL is not changed in the recordset app when we show errors (useful for the ‍‍‍`UnsupportedFilters` error where users could technically login and retry).
- Properly include `modal.scss` so it also works in deriva-webapps.
- Improve webpack configuration by,
  - Breaking large chunks into multiple based on size. Apart from the chunks created for each app, I was creating `common`, `vendor`, `vendor-react`, and `vendor-bootstrap` chunks. But now, webpack will break these named chunks into smaller ones if they exceed the given size.
  - Creating a named chunk for Chaise that deriva-webapps will use (instead of including them in the default `vendor` chunk).