### PR TITLE
Range picker bugs

### DIFF
--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -84,7 +84,7 @@ const FacetRangePicker = ({
 
   const [compState, setCompState] = useState<RangePickerState>(() => {
     const defaultPlotLayout: PlotlyLayout = {
-      autosize: true,
+      // autosize: true,
       height: 150,
       margin: {
         l: 40,
@@ -107,7 +107,8 @@ const FacetRangePicker = ({
       yaxis: {
         fixedrange: true,
         zeroline: true,
-        tickformat: ',d'
+        tickformat: ',d',
+        tickmode: 'linear'
       },
       bargap: 0
     }
@@ -460,7 +461,10 @@ const FacetRangePicker = ({
         plotData[0].y = response.y;
 
         const plotLayout = { ...compState.plot.layout };
-        if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') plotLayout.xaxis.range = updateHistogramRange(min, max);
+        // set xaxis range
+        if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
+          plotLayout.xaxis.range = updateHistogramXRange(min, max);
+        }
 
         response.min = requestMin;
         response.max = requestMax;
@@ -476,7 +480,8 @@ const FacetRangePicker = ({
           plot: {
             ...compState.plot,
             data: plotData,
-            layout: plotLayout
+            layout: plotLayout,
+            labels: response.labels
           },
           relayout: shouldRelayout,
           rangeOptions: {
@@ -647,7 +652,7 @@ const FacetRangePicker = ({
     return windowRef.moment(ts).format(format);
   }
 
-  const updateHistogramRange = (min: RangeOptions['absMin'], max: RangeOptions['absMax']) => {
+  const updateHistogramXRange = (min: RangeOptions['absMin'], max: RangeOptions['absMax']) => {
     if (isColumnOfType('timestamp')) {
       return [dateTimeToTimestamp(min as TimeStamp), dateTimeToTimestamp(max as TimeStamp)];
     } else {
@@ -752,7 +757,7 @@ const FacetRangePicker = ({
 
     const rangeOptions = updateRangeMinMax(data.min, data.max);
     if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
-      plotLayout.xaxis.range = updateHistogramRange(rangeOptions.absMin, rangeOptions.absMax);
+      plotLayout.xaxis.range = updateHistogramXRange(rangeOptions.absMin, rangeOptions.absMax);
     }
 
     setCompState({
@@ -839,7 +844,7 @@ const FacetRangePicker = ({
     } catch (err) {
       const plotLayout = { ...compState.plot.layout }
       if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
-        plotLayout.xaxis.range = updateHistogramRange(compState.rangeOptions.absMin, compState.rangeOptions.absMax);
+        plotLayout.xaxis.range = updateHistogramXRange(compState.rangeOptions.absMin, compState.rangeOptions.absMax);
       }
 
       setCompState({
@@ -885,6 +890,7 @@ const FacetRangePicker = ({
       config={compState.plot.config}
       data={compState.plot.data}
       layout={compState.plot.layout ? compState.plot.layout : {}}
+      labels={compState.plot.labels}
       onRelayout={(event: any) => plotlyRelayout(event)}
       ref={plotlyRef}
       style={{ 'width': '100%' }}

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -651,6 +651,8 @@ const FacetRangePicker = ({
     return windowRef.moment(ts).format(format);
   }
 
+  // if the date range is very small, the labels on the plot are repeated and the bars stretch across a few dates
+  // pad either side of min/max with 2 extra labels being shown so the content is centered
   const updateHistogramXRange = (min: RangeOptions['absMin'], max: RangeOptions['absMax']) => {
     if (isColumnOfType('timestamp')) {
       return [dateTimeToTimestamp(min as TimeStamp), dateTimeToTimestamp(max as TimeStamp)];

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -99,6 +99,7 @@ const FacetRangePicker = ({
         tickangle: 45,
         // set to "linear" for int/float graphs
         // set to "date" for date/timestamp graphs
+        // when set to `-`, plotly tries to figure out the type of data and automatically set the type
         type: '-'
         // NOTE: setting the range currently to unzoom the graph because auto-range wasn't working it seemed
         // autorange: true // default is true. if range is provided, set to false.
@@ -464,6 +465,7 @@ const FacetRangePicker = ({
         // set xaxis range
         if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
           plotLayout.xaxis.range = updateHistogramXRange(min, max);
+          plotLayout.xaxis.fixedrange = disableZoomIn(min, max);
         }
 
         response.min = requestMin;
@@ -758,6 +760,7 @@ const FacetRangePicker = ({
     const rangeOptions = updateRangeMinMax(data.min, data.max);
     if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
       plotLayout.xaxis.range = updateHistogramXRange(rangeOptions.absMin, rangeOptions.absMax);
+      plotLayout.xaxis.fixedrange = disableZoomIn(rangeOptions.absMin, rangeOptions.absMax)
     }
 
     setCompState({
@@ -845,6 +848,7 @@ const FacetRangePicker = ({
       const plotLayout = { ...compState.plot.layout }
       if (plotLayout.xaxis && typeof plotLayout.xaxis === 'object') {
         plotLayout.xaxis.range = updateHistogramXRange(compState.rangeOptions.absMin, compState.rangeOptions.absMax);
+        plotLayout.xaxis.fixedrange = disableZoomIn(compState.rangeOptions.absMin, compState.rangeOptions.absMax);
       }
 
       setCompState({

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -84,7 +84,7 @@ const FacetRangePicker = ({
 
   const [compState, setCompState] = useState<RangePickerState>(() => {
     const defaultPlotLayout: PlotlyLayout = {
-      // autosize: true,
+      autosize: true,
       height: 150,
       margin: {
         l: 40,

--- a/src/components/range-inputs.tsx
+++ b/src/components/range-inputs.tsx
@@ -187,9 +187,9 @@ const RangeInputs = ({
 
     /**type is either date or timestamp */
     const formatString = type === 'date' ? DATE_FORMAT : TIMESTAMP_FORMAT;
-    const fromDate = windowRef.moment(fromVal, formatString, true);
-    const toDate = windowRef.moment(toVal, formatString, true);
-    return toDate.diff(fromDate) > 0
+    const minDate = windowRef.moment(fromVal, formatString, true);
+    const maxDate = windowRef.moment(toVal, formatString, true); 
+    return !maxDate.isBefore(minDate);
   }
 
   const validateValues = (fromVal: string, toVal: string) => {


### PR DESCRIPTION
This PR fixes issue #2306. 

Adding `tickmode: 'linear'` to the `yaxis` communicates to plotly that the values displayed for `yaxis` should be a linear relation. the other bug in this PR was checking the difference between min and max incorrectly by doing a conversation and diff instead of using  the moment API, `isBefore`.

Another bug was found while trying to fix the other bugs, we were allowing users to "zoom" in the plot using the builtin plotly functionality when the plot couldn't be zoomed anymore (providing a confusing UX).