### PR TITLE
Introduce a make target to remove unused files during deploy

### DIFF
--- a/docs/user-docs/installation.md
+++ b/docs/user-docs/installation.md
@@ -72,6 +72,7 @@ ERMrestJS tests, which will also instruct you to get shared dependencies needed 
     Notes:
       - Before bundling and deploying Chaise packages, this command will install the node modules. You can also use alternative commands to modify this behavior. For more information please refer to the [developer guide](../dev-docs/dev-guide.md#building-and-installation).
       - If the given directory does not exist, it will first create it. So you may need to run `make deploy` with _super user_ privileges depending on the installation directory you choose.
+      - If the given directory already exists and you want to make sure any extra files that Chaise doesn't need are removed, use the `make deploy-clean` command instead.
 
 ## Configuration
 


### PR DESCRIPTION
When `make deploy` is called, we're not doing any cleanup in the remote location. Also, deployments usually do not clean up the `var/www/chaise/` folder and just fetch the new Chaise code and run `make deploy`. As a result, these deployments now have the old unused AngularJS code and the new React code under the `/var/www/chaise` folder.

While we shouldn't automatically remove the files in a remote location, in this PR, we decided to offer an alternative target that will do the cleanup. To achieve this, I'm simply adding a `--delete` to our `rsync` command to ensure the extra files in the remote location are deleted.

Pending:
- In this command, I'm skipping the config files, so it would be up to the data modeler to clean them up. We should discuss whether this is what we want or we should delete everything.

- I named the new target `deploy-clean`, but we should discuss if this name makes sense or not.


