### PR TITLE
Optimize position of login popup for multi-monitor setups

### DIFF
--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -175,15 +175,19 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
     const topOffset = 50;
     const popupTop = (topOffset + popupHeight) < screen.availHeight ? topOffset : 0;
 
+   
+    const screenWidth = window.screen.availWidth;
+     
     /*
-      * This is to get the screen left offset using availLeft - It represents the left  position
+      * This is to get the screen left offset using screenLeft - It represents the left  position
       * of the available screen space, excluding areas occupied by other system elements .
       * We need to add those so that it  calculates the centre position and aligns the popup in the centre. 
-      * We add Math.max so that it takes care if the calculation comes to negative. This can happen when screen size
-      * is smaller than popup size.
     */
-    const left = Math.max(0, (screen.availWidth - popupWidth) / 2 + screen.availLeft);
-    const openedWindow = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${left},top=${popupTop}`);
+    const leftOffset = Math.floor((screenWidth - popupWidth) / 2) + window.screenLeft ;
+
+    // Open the popup window to the calculated center position
+    const openedWindow = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${leftOffset},top=${popupTop}`);
+    // Focus the window opened
     if (openedWindow && openedWindow.focus) {
       openedWindow.focus();
     }

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -172,17 +172,20 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
 
     const popupWidth = Math.min(800, screen.availWidth);
     const popupHeight = Math.min(750, screen.availHeight);
+    const topOffset = 50;
+    const popupTop = (topOffset + popupHeight) < screen.availHeight ? topOffset : 0;
 
-    const primaryScreen = window.screen;
-
-    // Calculate the center position based on the primary screen dimensions and popup size
-    const centerLeft = Math.max(0, (primaryScreen.availWidth - popupWidth) / 2 + primaryScreen.availLeft);
-    const centerTop = Math.max(0, (primaryScreen.availHeight - popupHeight) / 2 + primaryScreen.availTop);
-
-    // Open the popup with the calculated position
-    const newWindow = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${centerLeft},top=${centerTop}`);
-    if (newWindow && newWindow.focus) {
-      newWindow.focus();
+    /*
+      * This is to get the screen left offset using availLeft - It represents the left  position
+      * of the available screen space, excluding areas occupied by other system elements .
+      * We need to add those so that it  calculates the centre position and aligns the popup in the centre. 
+      * We add Math.max so that it takes care if the calculation comes to negative. This can happen when screen size
+      * is smaller than popup size.
+    */
+    const left = Math.max(0, (screen.availWidth - popupWidth) / 2 + screen.availLeft);
+    const openedWindow = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${left},top=${popupTop}`);
+    if (openedWindow && openedWindow.focus) {
+      openedWindow.focus();
     }
     // close the existing popup (if any)
     if (popupWindowRef.current) {
@@ -190,9 +193,9 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
     }
 
     // keep track of the window, so we ensure only one is opened at a time.
-    popupWindowRef.current = newWindow;
+    popupWindowRef.current = openedWindow;
 
-    _logInHelper(newWindow, postLoginCB, 'popUp', null, logAction);
+    _logInHelper(openedWindow, postLoginCB, 'popUp', null, logAction);
   };
 
   // NOTE: sessionParam attached so it can be passed back to callbacks for comparisons since functions execute synchronously

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -170,31 +170,29 @@ export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Ele
       };
     }
 
-    // make sure the width and height are not bigger than the screen
     const popupWidth = Math.min(800, screen.availWidth);
-    const popupHeight = Math.min(750, screen.availHeight)
-    const topOffset = 50;
+    const popupHeight = Math.min(750, screen.availHeight);
 
-    // left should be in the middle of the screen
-    const popupLeft = (screen.availWidth - popupWidth) / 2;
-    // top should just have some small offset if there's available space
-    const popupTop = (topOffset + popupHeight) < screen.availHeight ? topOffset : 0;
+    const primaryScreen = window.screen;
 
+    // Calculate the center position based on the primary screen dimensions and popup size
+    const centerLeft = Math.max(0, (primaryScreen.availWidth - popupWidth) / 2 + primaryScreen.availLeft);
+    const centerTop = Math.max(0, (primaryScreen.availHeight - popupHeight) / 2 + primaryScreen.availTop);
+
+    // Open the popup with the calculated position
+    const newWindow = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${centerLeft},top=${centerTop}`);
+    if (newWindow && newWindow.focus) {
+      newWindow.focus();
+    }
     // close the existing popup (if any)
     if (popupWindowRef.current) {
       popupWindowRef.current.close();
     }
 
-    // open a window with proper position and width and height
-    const win = window.open('', '_blank', `width=${popupWidth},height=${popupHeight},left=${popupLeft},top=${popupTop}`);
-
-    // focus on the opened window
-    win?.focus();
-
     // keep track of the window, so we ensure only one is opened at a time.
-    popupWindowRef.current = win;
+    popupWindowRef.current = newWindow;
 
-    _logInHelper(win, postLoginCB, 'popUp', null, logAction);
+    _logInHelper(newWindow, postLoginCB, 'popUp', null, logAction);
   };
 
   // NOTE: sessionParam attached so it can be passed back to callbacks for comparisons since functions execute synchronously


### PR DESCRIPTION
This PR is to optimize position of login popup for multi-monitor setups. It centre aligns the popup in chrome and firefox also opens the pop up in the right screen.

The solution for this is to calculate the left and top positions of the popup from the screen resolutions. The solution I referred to: https://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen