### PR TITLE
Change behavior of some chaise-config properties (ermrestLocation, defaultCatalog, defaultTables)

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -6,7 +6,7 @@
     .constant("chaiseConfigPropertyNames", [
         "ermrestLocation", "showAllAttributes", "headTitle", "customCSS", "navbarBrand", "navbarBrandText",
         "navbarBrandImage", "logoutURL", "maxRecordsetRowHeight", "dataBrowser",
-        "confirmDelete", "hideSearchTextFacet", "editRecord", "deleteRecord", "defaultCatalog", "defaultTables",
+        "confirmDelete", "hideSearchTextFacet", "editRecord", "deleteRecord", "defaultCatalog", "defaultTable",
         "signUpURL", "navbarBanner", "navbarMenu", "sidebarPosition", "attributesSidebarHeading",
         "allowErrorDismissal", "footerMarkdown", "showFaceting", "hideTableOfContents",
         "resolverImplicitCatalog", "disableDefaultExport", "exportServicePath", "assetDownloadPolicyURL",
@@ -373,10 +373,10 @@
             // If the hash is empty, check for defaults
             if (hash == '' || hash === null || hash.length == 1) {
                 if (chaiseConfig.defaultCatalog) {
-                    if (chaiseConfig.defaultTables) {
+                    if (chaiseConfig.defaultTable) {
                         catalogId = chaiseConfig.defaultCatalog;
 
-                        var tableConfig = chaiseConfig.defaultTables[catalogId];
+                        var tableConfig = chaiseConfig.defaultTable;
                         if (tableConfig) {
                             hash = '/' + fixedEncodeURIComponent(tableConfig.schema) + ':' + fixedEncodeURIComponent(tableConfig.table);
                         } else {
@@ -426,8 +426,8 @@
                 // there is no '/' character (only a catalog id) or a trailing '/' after the id
                 if (hash.indexOf('/') === -1 || hash.substring(hash.indexOf('/')).length === 1) {
                     // check for default Table
-                    if (chaiseConfig.defaultTables) {
-                        var tableConfig = chaiseConfig.defaultTables[catalogId];
+                    if (chaiseConfig.defaultTable) {
+                        var tableConfig = chaiseConfig.defaultTable;
                         if (tableConfig) {
                             hash = '/' + fixedEncodeURIComponent(tableConfig.schema) + ':' + fixedEncodeURIComponent(tableConfig.table);
                         } else {

--- a/docs/user-docs/chaise-config-change-logs.md
+++ b/docs/user-docs/chaise-config-change-logs.md
@@ -2,6 +2,17 @@ The file contains changes made to chaise-config parameters.
 - Refer to [chaise-config.d](chaise-config.md) for currently supported parameters
 - Refer to [chaise-config-deprecated.md](chaise-config-deprecated.md) for deprecated parameters
 
+#### 06/23/2023 ####
+
+###### PR Link
+  - [chaise](https://github.com/informatics-isi-edu/chaise/pull/2324)
+
+###### Removed
+  - `defaultTables` property was deprecated as it doesn't make sense to encode catalog number in it.
+
+###### Added
+  - `defaultTable` property which is similar to the deprecated `defaultTables` property and is defined for the existing catalog.
+
 #### 11/17/2022 ####
 
 ###### PR Link

--- a/docs/user-docs/chaise-config-deprecated.md
+++ b/docs/user-docs/chaise-config-deprecated.md
@@ -6,6 +6,7 @@ This document contains deprecated chaise-config parameters.
 
 ## Table of Contents
 
+* [General Configuration:](#general-configuration)
 * [Login Configuration:](#login-configuration)
    * [profileURL](#profileURL)
 * [Display Configuration:](#display-configuration)
@@ -17,6 +18,34 @@ This document contains deprecated chaise-config parameters.
 * [Viewer Configuration:](#viewer-configuration)
    * [defaultAnnotationColor](#defaultannotationcolor)
    * [userGroups](#usergroups)
+
+
+### General Configuration:
+
+ #### defaultTables
+
+ > Replaced by [`defaultTable`](chaise-config.md#defaulttable) property.
+
+ Use this parameter to specify for each catalog `N`, which table Chaise shows by default.
+   - Type: Object
+   - General syntax:
+     ```
+     defaultTables: {
+       N: {
+         schema: <schema name>,
+         table: <table name>
+       }
+     }
+     ```
+   - Sample syntax:
+     ```
+     defaultTables: {
+       1: {
+         schema: "isa",
+         table: "dataset"
+       }, ...
+     }
+     ```
 
 
 ### Login Configuration:

--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -18,7 +18,7 @@ If a property appears in the same configuration twice, the property defined late
  * [General Configuration:](#general-configuration)
    * [ermrestLocation](#ermrestlocation)
    * [defaultCatalog](#defaultcatalog)
-   * [defaultTables](#defaulttables)
+   * [defaultTable](#defaulttable)
  * [Navbar Configuration:](#navbar-configuration)
    * [headTitle](#headtitle)
    * [navbarBanner](#navbarbanner)
@@ -70,6 +70,8 @@ If a property appears in the same configuration twice, the property defined late
 ### General Configuration:
  #### ermrestLocation
  The location of the ERMrest service.
+
+ > :warning: This property is only allowed in `chaise-config.js` file. Defining this on the catalog annotation has no effect.
    - Type: String - URL
    - Default value:	`window.location.protocol + // + window.location.host + /ermrest`
    - Sample syntax:
@@ -78,32 +80,35 @@ If a property appears in the same configuration twice, the property defined late
      ```
 
  #### defaultCatalog
- Use this parameter to specify which catalog Chaise shows by default. When a user navigates to “/chaise/recordset” and omits the rest of the path, the `defaultCatalog` paired with `defaultTables` are used to generate a valid recordset link for the user. It is strongly recommended defining this in your `chaise-config.js` file. This property is used to fetch the catalog annotation information for pages that rely on `chaise-config.js` but don’t have a catalog id in the path. For example, the navbar on static pages uses this property to try to fetch a catalog annotation for configuring the navbar.
+ Use this parameter to specify which catalog Chaise shows by default.
+
+ > :warning: This property is only allowed in `chaise-config.js` file. Defining this on the catalog annotation has no effect.
+
+ It is strongly recommended defining this in your `chaise-config.js` file. This property is used to fetch the catalog annotation information for pages that rely on `chaise-config.js` but don’t have a catalog id in the path. For example, the navbar on static pages uses this property to try to fetch a catalog annotation for configuring the navbar.
+
+ When a user navigates to “/chaise/recordset” and omits the rest of the path, the `defaultCatalog` paired with `defaultTable` are used to generate a valid recordset link for the user.
+
    - Type: String - Catalog ID
    - Sample syntax:
      ```
      defaultCatalog: "1"
      ```
 
- #### defaultTables
- Use this parameter to specify for each catalog `N`, which table Chaise shows by default.
+ #### defaultTable
+ Use this parameter to specify which table Chaise shows by default for the current catalog.
    - Type: Object
    - General syntax:
      ```
-     defaultTables: {
-       N: {
-         schema: <schema name>,
-         table: <table name>
-       }
+     defaultTable: {
+        schema: <schema name>,
+        table: <table name>
      }
      ```
    - Sample syntax:
      ```
-     defaultTables: {
-       1: {
-         schema: "isa",
-         table: "dataset"
-       }, ...
+     defaultTable: {
+        schema: "isa",
+        table: "dataset"
      }
      ```
 

--- a/src/providers/authn.tsx
+++ b/src/providers/authn.tsx
@@ -51,8 +51,13 @@ type AuthnProviderProps = {
 }
 
 export default function AuthnProvider({ children }: AuthnProviderProps): JSX.Element {
-  // authn API no longer communicates through ermrest, removing the need to check for ermrest location
-  const serviceURL: string = windowRef.location.origin;
+  /**
+   * we can assume that ermrest and authn are in the same server
+   *
+   * (we're doing something similar in hatrac )
+   */
+  const serviceURL: string = ConfigService.ERMrestLocation.replace(/\/ermrest\/?/, '');
+
   const LOCAL_STORAGE_KEY = 'session'; // name of object session information is stored under
   const PROMPT_EXPIRATION_KEY = 'promptExpiration'; // name of key for prompt expiration value
   const PREVIOUS_SESSION_KEY = 'previousSession'; // name of key for previous session boolean

--- a/src/providers/error.tsx
+++ b/src/providers/error.tsx
@@ -120,7 +120,7 @@ export default function ErrorProvider({ children }: ErrorProviderProps): JSX.Ele
    */
   const logTerminalError = (error: any) => {
     if (!windowRef.ERMrest) return;
-    const ermrestUri = ConfigService.chaiseConfig.ermrestLocation;
+    const ermrestUri = ConfigService.ERMrestLocation;
     windowRef.ERMrest.logError(error, ermrestUri, ConfigService.contextHeaderParams).then(() => {
       $log.log('logged the error');
     }).catch((err: any) => {

--- a/src/services/log.ts
+++ b/src/services/log.ts
@@ -47,7 +47,7 @@ export class LogService {
       logObj[key] = contextHeaderParams[key];
     }
     headers[ConfigService.ERMrest.contextHeaderName] = logObj;
-    ConfigService.http.head(`${cc.ermrestLocation}/client_action`, {headers}).catch(() => {
+    ConfigService.http.head(`${ConfigService.ERMrestLocation}/client_action`, {headers}).catch(() => {
       // we expect to get a server error, so just catch it her
     });
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -21,7 +21,7 @@ export const APP_CONTEXT_MAPPING = {
 export const CHAISE_CONFIG_PROPERTY_NAMES = [
   'ermrestLocation', 'showAllAttributes', 'headTitle', 'customCSS', 'navbarBrand', 'navbarBrandText',
   'navbarBrandImage', 'logoutURL', 'maxRecordsetRowHeight', 'dataBrowser', 'defaultAnnotationColor',
-  'confirmDelete', 'hideSearchTextFacet', 'editRecord', 'deleteRecord', 'defaultCatalog', 'defaultTables',
+  'confirmDelete', 'hideSearchTextFacet', 'editRecord', 'deleteRecord', 'defaultCatalog', 'defaultTable',
   'signUpURL', 'navbarBanner', 'navbarMenu', 'sidebarPosition', 'attributesSidebarHeading', 'userGroups',
   'allowErrorDismissal', 'footerMarkdown', 'showFaceting', 'hideTableOfContents',
   'resolverImplicitCatalog', 'disableDefaultExport', 'exportServicePath', 'assetDownloadPolicyURL',
@@ -35,7 +35,7 @@ export const CHAISE_CONFIG_PROPERTY_NAMES = [
  * The properties that are only allowed in chaise-config.js file
  */
 export const CHAISE_CONFIG_STATIC_PROPERTIES = [
-  'ermrestLocation'
+  'ermrestLocation', 'defaultCatalog'
 ];
 
 export const DEFAULT_CHAISE_CONFIG = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -31,6 +31,13 @@ export const CHAISE_CONFIG_PROPERTY_NAMES = [
   'debug', 'templating', 'hideRecordeditLeaveAlert'
 ];
 
+/**
+ * The properties that are only allowed in chaise-config.js file
+ */
+export const CHAISE_CONFIG_STATIC_PROPERTIES = [
+  'ermrestLocation'
+];
+
 export const DEFAULT_CHAISE_CONFIG = {
   internalHosts: [window.location.host],
   ermrestLocation: `${window.location.origin}/ermrest`,

--- a/src/utils/uri-utils.ts
+++ b/src/utils/uri-utils.ts
@@ -164,6 +164,18 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
 
     // there is no '/' character (only a catalog id) or a trailing '/' after the id
     if (hash.indexOf('/') === -1 || hash.substring(hash.indexOf('/')).length === 1) {
+      /**
+       * if the hash was actually just query parameter, don't even attempt the default logic
+       *
+       * this function is used in every react app as part of config.ts. in some cases (like help app),
+       * the url doesn't have any hash fragment and has only query parameter. therefore we should
+       * throw an error here since the combination of chaise-config properties might accidently
+       * cause side effects.
+       */
+      if (isQueryParameter) {
+        throw new ConfigService.ERMrest.MalformedURIError(catalogMissing);
+      }
+
       // check for default Table
       if (chaiseConfig.defaultTable) {
         const tableConfig = chaiseConfig.defaultTable;

--- a/src/utils/uri-utils.ts
+++ b/src/utils/uri-utils.ts
@@ -183,7 +183,7 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
     }
   }
 
-  const baseUri = chaiseConfig.ermrestLocation;
+  const baseUri = ConfigService.ERMrestLocation;
   const path = `/catalog/${catalogId}/entity${hash}`;
 
   return {

--- a/src/utils/uri-utils.ts
+++ b/src/utils/uri-utils.ts
@@ -129,10 +129,10 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
   // If the hash is empty, check for defaults
   if (!hash || hash.length === 1) {
     if (chaiseConfig.defaultCatalog) {
-      if (chaiseConfig.defaultTables) {
+      if (chaiseConfig.defaultTable) {
         catalogId = chaiseConfig.defaultCatalog;
 
-        const tableConfig = chaiseConfig.defaultTables[catalogId];
+        const tableConfig = chaiseConfig.defaultTable
         if (tableConfig) {
           hash = `/${fixedEncodeURIComponent(tableConfig.schema)}:${fixedEncodeURIComponent(tableConfig.table)}`;
         } else {
@@ -165,8 +165,8 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
     // there is no '/' character (only a catalog id) or a trailing '/' after the id
     if (hash.indexOf('/') === -1 || hash.substring(hash.indexOf('/')).length === 1) {
       // check for default Table
-      if (chaiseConfig.defaultTables) {
-        const tableConfig = chaiseConfig.defaultTables[catalogId];
+      if (chaiseConfig.defaultTable) {
+        const tableConfig = chaiseConfig.defaultTable;
         if (tableConfig) {
           hash = `/${fixedEncodeURIComponent(tableConfig.schema)}:${fixedEncodeURIComponent(tableConfig.table)}`;
         } else {

--- a/test/e2e/specs/all-features-confirmation/chaise-config.js
+++ b/test/e2e/specs/all-features-confirmation/chaise-config.js
@@ -19,11 +19,9 @@ var chaiseConfig = {
     logClientActions: false,
     hideRecordeditLeaveAlert: true,
     footerMarkdown:"**Please check** [Privacy Policy](/privacy-policy/){target='_blank'}",
-    defaultTables: {
-        "1": {
-            "schema": "isa",
-            "table": "dataset"
-        }
+    defaultTable: {
+        "schema": "isa",
+        "table": "dataset"
     },
     templating: {
       engine: 'handlebars'

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -1155,8 +1155,8 @@ describe('View recordset,', function () {
                 expect(chaiseConfig.confirmDelete).toBeTruthy();
                 // use "deFAuLtCaTAlog" since we are grabbing the property directly from chaise config. The application will use the right value
                 expect(chaiseConfig.deFAuLtCaTAlog).toBe(1);
-                expect(chaiseConfig.defaultTables['1'].schema).toBe("isa");
-                expect(chaiseConfig.defaultTables['1'].table).toBe("dataset");
+                expect(chaiseConfig.defaultTable.schema).toBe("isa");
+                expect(chaiseConfig.defaultTable.table).toBe("dataset");
             }).catch(function (error) {
                 console.log('ERROR:', error);
                 // Fail the test
@@ -1187,17 +1187,6 @@ describe('View recordset,', function () {
                     });
                 });
 
-                it("should throw a malformed URI error when no default schema:table is set for a catalog.", function () {
-                    chaisePage.navigate(process.env.CHAISE_BASE_URL + "/recordset/#" + browser.params.catalogId);
-
-                    var modalTitle = chaisePage.recordEditPage.getModalTitle();
-
-                    chaisePage.waitForElement(modalTitle, browser.params.defaultTimeout).then(function () {
-                        return modalTitle.getText();
-                    }).then(function (title) {
-                        expect(title).toBe("Invalid URI");
-                    });
-                });
             });
 
             describe("should load chaise-config.js with system columns heuristic properties", function () {

--- a/test/e2e/utils/recordedit-helpers.js
+++ b/test/e2e/utils/recordedit-helpers.js
@@ -260,11 +260,12 @@ exports.testPresentationAndBasicValidation = function(tableParams, isEditMode) {
             if (recordIndex > 0) {
                 it("should click add record button", function(done) {
                     chaisePage.clickButton(chaisePage.recordEditPage.getMultiFormInputSubmitButton()).then(function(button) {
-                        browser.wait(function() {
+                        return browser.wait(function() {
                             return chaisePage.recordEditPage.getRecordeditForms().count().then(function(ct) {
-                                return (ct == recordIndex);
+                                return (ct == recordIndex + 1);
                             });
                         }, browser.params.defaultTimeout);
+                    }).then(() => {
                         done();
                     }).catch(chaisePage.catchTestError(done));
                 });


### PR DESCRIPTION
This PR was initially created to change the behavior of `ermrestLocation`. 

We're using `ermestLocation` to find where ermrest is, so allowing it on the `chaise-config` annotation doesn't make sense. We should only honor it when it's part of `chaise-config.js`. After discussing it, we decided to do the same thing with `defaultCatalog`.

We also didn't like how in `defaultTables` we're supposed to encode the catalog numbers and decided to deprecate it and replace it with `defaultTable`. It's more or less the same property. The only difference is that now the catalog number is implied. 

Summary of code changes:

- Added a concept of `CHAISE_CONFIG_STATIC_PROPERTIES` properties. These properties will only be allowed on the `chaise-config.js` file (`ermestLocation` and `defaultCatalog`). 
- Modified `_setChaiseConfig` to ignore the "static" properties from the annotation.
- Added a new `ConfigService.ERMrestLocation` API and used it in different places in chaise that need the ermrest location.
- Modified `authn`'s `serviceURL` to use `ConfigService.ERMrestLocation` similar to how we're doing this for hatrac in ermrestjs.
- Changed usage of `defaultTables` to use `defaulTable` instead.


Closes #2317 