### PR TITLE
Make related table actions responsive

### DIFF
--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -114,7 +114,7 @@
     .related-table-actions {
       float: right;
       display: flex;
-      align-items: baseline;
+      align-items: center;
 
       // make sure the content is not touching the buttons
       padding-left: 2px;
@@ -148,6 +148,10 @@
         top: -15px;
       }
 
+      .dropdown {
+        min-width: 50px;
+      }
+
       .dropdown-item {
         padding: 0;
 
@@ -166,7 +170,20 @@
     .table-header-actions {
       width: 100%;
       justify-content: end;
+      margin-top: -34px;
     }
+
+    .chaise-accordion-header {
+      display: block !important;
+
+      .chaise-accordion-header-buttons {
+        display: flex;
+        margin-top: auto !important;
+        margin-left: 75px;
+        box-sizing: border-box;
+      }
+    }
+
 
     .chaise-table-top-scroll-wrapper {
       z-index: 1;
@@ -183,7 +200,7 @@
     .chaise-accordion-header {
       .chaise-accordion-displayname {
         white-space: nowrap;
-        min-width: 25%
+        max-width: 25%
       }
 
       white-space: unset !important;

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -145,6 +145,13 @@
         border-color: #4674a7;
       }
 
+      .dropdown-toggle-table-mobile {
+        position: absolute;
+        right: 0;
+        top: -15px;
+        margin-right: 2rem;
+      }
+
       .dropdown-item {
         padding: 0;
 

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -11,7 +11,7 @@
           height: variables.$btn-height;
           margin: 0;
 
-          > div {
+          >div {
             display: flex;
           }
 
@@ -33,6 +33,7 @@
             .page-title-container {
               width: 100%;
               display: inline-block;
+
               #page-title {
                 margin: 0px;
               }
@@ -43,15 +44,21 @@
               padding-top: 7px;
               width: 330px;
             }
-          } // end .entity-display-header
-        } // end .title
+          }
+
+          // end .entity-display-header
+        }
+
+        // end .title
 
         .show-toc-btn {
           margin-top: 10px;
           padding-left: 2px;
           padding-bottom: 0px;
         }
-      } // end .top-right-panel
+      }
+
+      // end .top-right-panel
     }
   }
 
@@ -61,7 +68,7 @@
     }
 
     /** bottom left panel **/
-    > .side-panel-resizable {
+    >.side-panel-resizable {
 
       .side-panel-container {
         height: 100%;
@@ -84,7 +91,7 @@
           cursor: pointer;
           font-size: variables.$h4-font-size;
 
-          & > a.empty-toc-heading {
+          &>a.empty-toc-heading {
             opacity: 0.55;
           }
 
@@ -119,44 +126,51 @@
         text-decoration: none;
       }
     }
+
     .related-table-actions {
       display: flex;
       align-items: baseline;
+
       .button-wrapper {
         height: 30px;
         overflow: hidden;
         position: relative;
         text-align: right;
       }
+
       .dropdown-toggle-table {
         color: #4674a7;
         background-color: #fff;
         cursor: pointer;
         border-color: #4674a7;
       }
+
       .dropdown-item {
         padding: 0;
+
         .dropdown-button {
           .dropdown-button-text {
             margin-left: 4px;
           }
         }
       }
-   }
-   
+    }
+
     .table-header-actions {
       width: 100%;
       justify-content: end;
     }
+
     .chaise-accordion-header {
       .chaise-accordion-displayname {
         white-space: nowrap;
         min-width: 25%
       }
+
       white-space: unset !important;
       align-items: center;
     }
-   
+
     /******Related Entities in record **************/
 
     .row-focus {
@@ -198,6 +212,7 @@
     }
 
     .top-right-panel {
+
       //Action button top right corner
       .page-action-btns {
         display: none;
@@ -292,12 +307,12 @@
         border-bottom: none;
       }
 
-      > thead > tr > th,
-      > tbody > tr > th,
-      > tfoot > tr > th,
-      > thead > tr > td,
-      > tbody > tr > td,
-      > tfoot > tr > td {
+      >thead>tr>th,
+      >tbody>tr>th,
+      >tfoot>tr>th,
+      >thead>tr>td,
+      >tbody>tr>td,
+      >tfoot>tr>td {
         border-top: none;
         border-right: 1px solid #bbbbbb;
       }
@@ -342,7 +357,7 @@
 
     //Removes bubbles and represents the vocab as a dot separated list
     .related-section-container {
-      .vocab + .vocab::before {
+      .vocab+.vocab::before {
         content: "\2022" !important;
         padding-right: 6px;
       }

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -131,7 +131,6 @@
       .button-wrapper {
         height: 30px;
         overflow: hidden;
-        position: relative;
         text-align: right;
       }
 
@@ -167,23 +166,14 @@
       }
     }
 
+    .main-section-actions {
+      position: static;
+    }
+
     .table-header-actions {
       width: 100%;
       justify-content: end;
-      margin-top: -34px;
     }
-
-    .chaise-accordion-header {
-      display: block !important;
-
-      .chaise-accordion-header-buttons {
-        display: flex;
-        margin-top: auto !important;
-        margin-left: 75px;
-        box-sizing: border-box;
-      }
-    }
-
 
     .chaise-table-top-scroll-wrapper {
       z-index: 1;
@@ -200,7 +190,6 @@
     .chaise-accordion-header {
       .chaise-accordion-displayname {
         white-space: nowrap;
-        max-width: 25%
       }
 
       white-space: unset !important;

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -167,6 +167,7 @@
     }
 
     .main-section-actions {
+      // We are adding this for the spinner to come above the buttons
       position: static;
     }
 

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -113,6 +113,8 @@
 
     .related-table-actions {
       float: right;
+      display: flex;
+      align-items: baseline;
 
       // make sure the content is not touching the buttons
       padding-left: 2px;
@@ -125,11 +127,6 @@
       a.chaise-btn {
         text-decoration: none;
       }
-    }
-
-    .related-table-actions {
-      display: flex;
-      align-items: baseline;
 
       .button-wrapper {
         height: 30px;
@@ -175,8 +172,12 @@
       z-index: 1;
     }
 
-    .chaise-table-header {
-      min-width: 250px;
+    /*
+    * This will make sure the Displaying.. text has a preserved space, and
+    * avoids the related action buttons to overlap it.
+    */
+    .entity-value .chaise-table-header {
+      display: inline-block;
     }
 
     .chaise-accordion-header {

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -145,17 +145,20 @@
         border-color: #4674a7;
       }
 
-      .dropdown-toggle-table-mobile {
+      .show-all-actions-as-dropdown {
         position: absolute;
         right: 0;
         top: -15px;
-        margin-right: 2rem;
       }
 
       .dropdown-item {
         padding: 0;
 
         .dropdown-button {
+          width: 100%;
+          text-align: left;
+          padding: 4px 18px;
+
           .dropdown-button-text {
             margin-left: 4px;
           }
@@ -166,6 +169,14 @@
     .table-header-actions {
       width: 100%;
       justify-content: end;
+    }
+
+    .chaise-table-top-scroll-wrapper {
+      z-index: 1;
+    }
+
+    .chaise-table-header {
+      min-width: 250px;
     }
 
     .chaise-accordion-header {

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -119,7 +119,44 @@
         text-decoration: none;
       }
     }
-
+    .related-table-actions {
+      display: flex;
+      align-items: baseline;
+      .button-wrapper {
+        height: 30px;
+        overflow: hidden;
+        position: relative;
+        text-align: right;
+      }
+      .dropdown-toggle-table {
+        color: #4674a7;
+        background-color: #fff;
+        cursor: pointer;
+        border-color: #4674a7;
+      }
+      .dropdown-item {
+        padding: 0;
+        .dropdown-button {
+          .dropdown-button-text {
+            margin-left: 4px;
+          }
+        }
+      }
+   }
+   
+    .table-header-actions {
+      width: 100%;
+      justify-content: end;
+    }
+    .chaise-accordion-header {
+      .chaise-accordion-displayname {
+        white-space: nowrap;
+        min-width: 25%
+      }
+      white-space: unset !important;
+      align-items: center;
+    }
+   
     /******Related Entities in record **************/
 
     .row-focus {

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -819,7 +819,7 @@ const RelatedTableActions = ({
           placement='top'
           tooltip={
             <span>
-              {`${showAllActionsAsDropdown ? 'Click here to view the available actions.' : 'Click here to view the extra available actions.'}`}
+              {`${showAllActionsAsDropdown ? 'View the available actions.' : 'View the extra available actions.'}`}
             </span>
           }
         >

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -108,7 +108,7 @@ const RelatedTableActions = ({
    */
   useLayoutEffect(() => {
     if (!containerRef.current) return;
-
+    const mainContainer:any = document.querySelector('.related-section-container');
     const calculateButtons = () => {
 
       let buttons: any = [];
@@ -121,7 +121,7 @@ const RelatedTableActions = ({
          * If there aren't any enough space to show even one button, just switch to showing all as dropdown.
          * 200 is based on the width of the container containing dropdown and last visible button.
          */
-        setShowAllActionsAsDropdown(containerRef.current.getBoundingClientRect().width < 200);
+        setShowAllActionsAsDropdown(mainContainer?.offsetWidth < 320);
         const tableHeaderButtonsToAddToDropdown: any = [];
         let buttonLeftOffset = 0;
         let totalWidth = 0;

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -108,7 +108,7 @@ const RelatedTableActions = ({
    */
   useLayoutEffect(() => {
     if (!containerRef.current) return;
-    const mainContainer:any = document.querySelector('.related-section-container');
+    const mainContainer:any = document.querySelector('.main-container');
     const calculateButtons = () => {
 
       let buttons: any = [];
@@ -121,7 +121,7 @@ const RelatedTableActions = ({
          * If there aren't any enough space to show even one button, just switch to showing all as dropdown.
          * 200 is based on the width of the container containing dropdown and last visible button.
          */
-        setShowAllActionsAsDropdown(mainContainer?.offsetWidth < 320);
+        setShowAllActionsAsDropdown(mainContainer?.offsetWidth < 350);
         const tableHeaderButtonsToAddToDropdown: any = [];
         let buttonLeftOffset = 0;
         let totalWidth = 0;
@@ -158,8 +158,8 @@ const RelatedTableActions = ({
     };
     calculateButtons();
 
-    const mainResizeSensor = new ResizeSensor(containerRef.current as Element, () => {
-      calculateButtons();
+    const mainResizeSensor = new ResizeSensor(mainContainer as Element, () => {
+      calculateButtons()
     });
 
     return () => {

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -729,14 +729,14 @@ const RelatedTableActions = ({
         let totalWidth = 0;
 
         //This condition is to push all the buttons to the dropdown when the container width is below 200
-        if (isMobile) {
-          setButtonsInDropdown(buttons);
-          containerRef.current.style.float = 'none';
-          return;
-        } else {
+          if (isMobile) {
+            buttonContainer.style.height = '0';
+          } else {
+            buttonContainer.style.height = '30px';
+          }
           // Loop through the buttons and calculate if the current button width plus the width of all visible buttons
           // is overflowing the container width. If yes, push the button to the dropdown
-          containerRef.current.style.float = 'right';
+          
           buttons.forEach((button: any, index: number) => {
             const buttonWidth = button.getBoundingClientRect().width;
             if (index === 0) {
@@ -747,6 +747,9 @@ const RelatedTableActions = ({
             if (totalWidth + buttonLeftOffset + buttonWidth <= containerWidth) {
               // calculate the total button container width if it doesn't overflow
               totalWidth += buttonWidth;
+              if(buttonContainer.getBoundingClientRect().height === 0){
+                tableHeaderButtonsToAddToDropdown.push(button);
+              }
             } else {
               // Push to dropdown if it overflowa
               tableHeaderButtonsToAddToDropdown.push(button);
@@ -754,7 +757,6 @@ const RelatedTableActions = ({
           });
           setButtonsInDropdown(tableHeaderButtonsToAddToDropdown);
         }
-      }
     };
     calculateButtons();
 
@@ -813,7 +815,8 @@ const RelatedTableActions = ({
           <Dropdown onToggle={(isOpen: boolean, event: any) => toggleDropdown(isOpen, event)}>
             <Dropdown.Toggle
               disabled={false}
-              className='chaise-btn chaise-btn-primary dropdown-toggle-table'
+              className={`chaise-btn chaise-btn-primary dropdown-toggle-table ${isMobile
+                && !relatedModel.isInline ? 'dropdown-toggle-table-mobile' : ''}`}
             >
               <span className='fa fa-angle-double-right'></span>
             </Dropdown.Toggle>

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -713,8 +713,7 @@ const RelatedTableActions = ({
    * We are using ResizeSensor to listen to the resize event.
    */
   useLayoutEffect(() => {
-    const mainContainer = document.querySelector('.main-container') as HTMLElement;
-    if (!buttonRef.current) return;
+    if (!containerRef.current) return;
 
     const calculateButtons = () => {
       
@@ -732,13 +731,12 @@ const RelatedTableActions = ({
         //This condition is to push all the buttons to the dropdown when the container width is below 200
         if (isMobile) {
           setButtonsInDropdown(buttons);
-          buttonContainer.style.display = 'none';
+          containerRef.current.style.float = 'none';
           return;
         } else {
-          buttonContainer.style.display = 'block';
-          setButtonsInDropdown([]);
           // Loop through the buttons and calculate if the current button width plus the width of all visible buttons
           // is overflowing the container width. If yes, push the button to the dropdown
+          containerRef.current.style.float = 'right';
           buttons.forEach((button: any, index: number) => {
             const buttonWidth = button.getBoundingClientRect().width;
             if (index === 0) {
@@ -755,12 +753,12 @@ const RelatedTableActions = ({
             }
           });
           setButtonsInDropdown(tableHeaderButtonsToAddToDropdown);
-         }
+        }
       }
     };
     calculateButtons();
 
-    const mainResizeSensor = new ResizeSensor(mainContainer as Element, () => {
+    const mainResizeSensor = new ResizeSensor(containerRef.current as Element, () => {
       calculateButtons();
     });
 

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -51,12 +51,10 @@ import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 
 type RelatedTableActionsProps = {
   relatedModel: RecordRelatedModel;
-  istableHeader?: boolean;
 };
 
 const RelatedTableActions = ({
-  relatedModel,
-  istableHeader,
+  relatedModel
 }: RelatedTableActionsProps): JSX.Element => {
   const {
     reference: recordReference,
@@ -507,6 +505,7 @@ const RelatedTableActions = ({
   const exploreLink = addQueryParamsToURL(usedRef.appLink, {
     paction: LogParentActions.EXPLORE,
   });
+  const editLink = usedRef.contextualize.entryEdit.appLink;
 
   const renderCustomModeBtn = (tertiary?: boolean) => {
     let tooltip: string | JSX.Element = '',
@@ -584,7 +583,10 @@ const RelatedTableActions = ({
       </span>
     );
   };
-
+  /*
+    * This function is to render each button. We call the renderButton function with button text,
+    * inner element classname and boolean flag to show tertiary class(for the dropdown buttons) or not
+  */
   const renderButtons = () => {
     return (
       <div
@@ -592,100 +594,34 @@ const RelatedTableActions = ({
         className='button-wrapper'
         style={{ marginRight: `${buttonsInDropdown.length > 0 ? '5px' : '0px'}` }}
       >
-        {relatedModel.canCreate && (
-          <ChaiseTooltip placement='top' tooltip={renderCreateBtnTooltip()}>
-            <button
-              className='chaise-btn chaise-btn-secondary add-records-link'
-              onClick={onCreate}
-              disabled={relatedModel.canCreateDisabled}
-            >
-              <span className='chaise-btn-icon fa-solid fa-plus'></span>
-              <span>{relatedModel.isPureBinary ? 'Link' : 'Add'} records</span>
-            </button>
-          </ChaiseTooltip>
-        )}
+        {relatedModel.canCreate && renderButton(`${relatedModel.isPureBinary ? 'Link' : 'Add'} records`,
+        'chaise-btn-icon fa-solid fa-plus', false)}
+       
 
-        {relatedModel.isPureBinary && relatedModel.canDelete && (
-          <ChaiseTooltip
-            placement='top'
-            tooltip={
-              <span>
-                Disconnect {currentTable} records from this {mainTable}.
-              </span>
-            }
-          >
-            <button
-              className='chaise-btn chaise-btn-secondary unlink-records-link'
-              onClick={onUnlink}
-            >
-              <span className='chaise-btn-icon fa-regular fa-circle-xmark'></span>
-              <span>Unlink records</span>
-            </button>
-          </ChaiseTooltip>
-        )}
+        {relatedModel.isPureBinary && relatedModel.canDelete && 
+        renderButton('Unlink records', 'chaise-btn-icon fa-regular fa-circle-xmark', false)
+        }
 
         {renderCustomModeBtn()}
 
-        {relatedModel.canEdit && (
-          <ChaiseTooltip
-            placement='top'
-            tooltip={
-              <span>
-                Explore more {currentTable} records related to this {mainTable}.
-              </span>
-            }
-          >
-            <button
-              className='chaise-btn chaise-btn-secondary edit-records-link'
-              onClick={onUnlink}
-            >
-              <span className='chaise-btn-icon fa fa-pencil'></span>
-              <span>Bulk Edit</span>
-            </button>
-          </ChaiseTooltip>
-        )}
+        {relatedModel.canEdit && 
+        renderButton('Bulk Edit', 'chaise-btn-icon fa fa-pencil', false)
+        }
 
-        <ChaiseTooltip
-          placement='top'
-          tooltip={
-            <span>
-              Explore more {currentTable} records related to this {mainTable}.
-            </span>
-          }
-        >
-          <a
-            className='chaise-btn chaise-btn-secondary more-results-link'
-            href={exploreLink}
-            onClick={onExplore}
-          >
-            <span className='chaise-btn-icon fa-solid fa-magnifying-glass'></span>
-            <span>Explore</span>
-          </a>
-        </ChaiseTooltip>
+        {renderButton('Explore', 'chaise-btn-icon fa-solid fa-magnifying-glass', false)}
       </div>
     );
   };
-  /*
+  /** 
    * This function is to render the button in the dropdown with the tooltip.
-   */
-  const renderButton = (button: any, index: number) => {
-    const buttonText = button.textContent;
-    const spanClass = button.children[0].className;
-    const createBtnTooltip = renderCreateBtnTooltip();
-    const unlinkBtnTooltip = (
-      <span>
-        Disconnect {currentTable} records from this {mainTable}.
-      </span>
-    );
-    const exploreBtnTooltip = (
-      <span>
-        Explore more {currentTable} records related to this {mainTable}.
-      </span>
-    );
-    let tooltip: any;
+   * @param  {string}   buttonText title of button
+   * @param  {string}   spanClass classname of inner span        
+   * @param  {boolean}   tertiary boolean to differentiate dropdown button and outside button
+   * @param  {number} index
+  */
+  const renderButton = (buttonText: string, spanClass: string, tertiary?: boolean, index?: number) => {
     switch (buttonText) {
       case 'Explore':
-        tooltip = exploreBtnTooltip;
         return (
           <ChaiseTooltip
             placement='top'
@@ -696,7 +632,9 @@ const RelatedTableActions = ({
             }
           >
             <a
-              className='chaise-btn chaise-btn-tertiary more-results-link dropdown-button'
+              className={`chaise-btn more-results-link ${
+                tertiary ? 'chaise-btn-tertiary dropdown-button' : 'chaise-btn-secondary'
+              }`}
               href={exploreLink}
               onClick={onExplore}
             >
@@ -706,19 +644,20 @@ const RelatedTableActions = ({
           </ChaiseTooltip>
         );
       case 'Bulk Edit':
-        tooltip = exploreBtnTooltip;
         return (
           <ChaiseTooltip
             placement='top'
             tooltip={
               <span>
-                Explore more {currentTable} records related to this {mainTable}.
+                Edit this page of {currentTable} records related to this {mainTable}.
               </span>
             }
           >
             <a
-              className='chaise-btn chaise-btn-tertiary more-results-link dropdown-button'
-              href={exploreLink}
+            className={`chaise-btn more-results-link ${
+              tertiary ? 'chaise-btn-tertiary dropdown-button' : 'chaise-btn-secondary'
+            }`}
+              href={editLink}
               onClick={onExplore}
             >
               <span className='chaise-btn-icon fa fa-pencil'></span>
@@ -726,52 +665,71 @@ const RelatedTableActions = ({
             </a>
           </ChaiseTooltip>
         );
-      case 'Link Records':
-      case 'Add Records':
-        tooltip = createBtnTooltip;
-        break;
+      case 'Link records':
+      case 'Add records':
+        return (
+          <ChaiseTooltip placement='top' tooltip={renderCreateBtnTooltip()}>
+          <button
+          className={`chaise-btn add-records-link ${
+            tertiary ? 'chaise-btn-tertiary dropdown-button' : 'chaise-btn-secondary'
+          }`}
+            onClick={tertiary ? undefined : onCreate}
+            disabled={relatedModel.canCreateDisabled}
+          >
+            <span className='chaise-btn-icon fa-solid fa-plus'></span>
+            <span>{relatedModel.isPureBinary ? 'Link' : 'Add'} records</span>
+          </button>
+        </ChaiseTooltip>
+        )
       case 'Unlink records':
-        tooltip = unlinkBtnTooltip;
-        break;
+        return (
+          <ChaiseTooltip
+            placement='top'
+            tooltip={
+              <span>
+                Disconnect {currentTable} records from this {mainTable}.
+              </span>
+            }
+          >
+            <button
+            className={`chaise-btn unlink-records-link ${
+              tertiary ? 'chaise-btn-tertiary dropdown-button' : 'chaise-btn-secondary'
+            }`}
+              onClick={tertiary ? undefined : onUnlink}
+            >
+              <span className='chaise-btn-icon fa-regular fa-circle-xmark'></span>
+              <span>Unlink records</span>
+            </button>
+          </ChaiseTooltip>
+        )
       case 'Edit mode':
       case 'Custom mode':
       case 'Table mode':
         return renderCustomModeBtn(true);
     }
-
-    return (
-      <ChaiseTooltip placement='top' tooltip={tooltip}>
-        <button
-          key={`button-${index}`}
-          className={'chaise-btn chaise-btn-tertiary dropdown-button'}
-        >
-          <span className={spanClass}></span>
-          <span className='dropdown-button-text'>{buttonText}</span>
-        </button>
-      </ChaiseTooltip>
-    );
   };
   /*
    * This hook is to push the buttons to the dropdown if it exceeds the container width.
    * We are using ResizeSensor to listen to the resize event.
    */
   useLayoutEffect(() => {
-    const mainnav = document.querySelector('#navheader') as HTMLElement;
+    const mainContainer = document.querySelector('.main-container') as HTMLElement;
     if (!buttonRef.current) return;
 
     const calculateButtons = () => {
-      setIsMobile(window.innerWidth < 600);
+      
       let buttons: any = [];
       if (containerRef.current) {
         const buttonContainer = buttonRef.current;
 
         const containerWidth = buttonContainer.getBoundingClientRect().width;
         buttons = Array.from(buttonContainer.getElementsByClassName('chaise-btn'));
-
+        setIsMobile(containerRef.current.getBoundingClientRect().width < 200);
         const tableHeaderButtonsToAddToDropdown: any = [];
         let buttonLeftOffset = 0;
         let totalWidth = 0;
 
+        //This condition is to push all the buttons to the dropdown when the container width is below 200
         if (isMobile) {
           setButtonsInDropdown(buttons);
           buttonContainer.style.display = 'none';
@@ -779,6 +737,8 @@ const RelatedTableActions = ({
         } else {
           buttonContainer.style.display = 'block';
           setButtonsInDropdown([]);
+          // Loop through the buttons and calculate if the current button width plus the width of all visible buttons
+          // is overflowing the container width. If yes, push the button to the dropdown
           buttons.forEach((button: any, index: number) => {
             const buttonWidth = button.getBoundingClientRect().width;
             if (index === 0) {
@@ -787,32 +747,37 @@ const RelatedTableActions = ({
             }
 
             if (totalWidth + buttonLeftOffset + buttonWidth <= containerWidth) {
+              // calculate the total button container width if it doesn't overflow
               totalWidth += buttonWidth;
             } else {
+              // Push to dropdown if it overflowa
               tableHeaderButtonsToAddToDropdown.push(button);
             }
           });
           setButtonsInDropdown(tableHeaderButtonsToAddToDropdown);
-        }
+         }
       }
     };
     calculateButtons();
 
-    const mainNavResizeSensor = new ResizeSensor(mainnav as Element, () => {
+    const mainResizeSensor = new ResizeSensor(mainContainer as Element, () => {
       calculateButtons();
     });
 
     return () => {
-      mainNavResizeSensor.detach();
+      mainResizeSensor.detach();
     };
   }, [isMobile]);
 
+  // This function is to toggle the dropdown to show or hide with options
   const toggleDropdown = (bool: boolean, evt: any) => {
     evt.originalEvent.stopPropagation();
     setIsDropdownOpen(!isDropdownOpen);
   };
+
+  // Adding different classname for table header and main section to apply styles
   const containerClassName = `related-table-actions ${isMobile ? 'is-mobile ' : ''}${
-    istableHeader ? 'table-header-actions' : 'main-section-actions'
+    !relatedModel.isInline ? 'table-header-actions' : 'main-section-actions'
   }`;
 
   /*
@@ -825,8 +790,8 @@ const RelatedTableActions = ({
       case 'Explore':
         onExplore(evt);
         break;
-      case 'Link Records':
-      case 'Add Records':
+      case 'Link records':
+      case 'Add records':
         onCreate(evt);
         break;
       case 'Edit Records':
@@ -857,11 +822,11 @@ const RelatedTableActions = ({
             <Dropdown.Menu>
               {buttonsInDropdown.map((button: any, index) => (
                 <Dropdown.Item
-                  className={''}
+                  as={'li'}
                   key={`dropdown-button-${index}`}
-                  onClick={(e: any) => handleDropDownClick(e, button)}
+                   onClick={(e: any) => handleDropDownClick(e, button)}
                 >
-                  {renderButton(button, index)}
+                  {renderButton(button.textContent, button.children[0].className, true, index)}
                 </Dropdown.Item>
               ))}
             </Dropdown.Menu>

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -633,7 +633,7 @@ const RelatedTableActions = ({
         label = 'Table mode';
       }
     } else {
-      icon = 'fa-solid fa-grip';
+      icon = 'fa-solid fa-layer-group';
       tooltip = 'Switch back to the custom display mode.';
       label = 'Custom mode';
     }

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -108,6 +108,13 @@ const RelatedTableActions = ({
    */
   useLayoutEffect(() => {
     if (!containerRef.current) return;
+    /*
+   * We choose main-container for the resize sensor because we we were encountering bugs:
+   * 1) All buttons pushing to dropdown if we have just one button in the table header section
+   * 2) Resize sensor not getting called if there is no change in width of the button container even if we resize
+   * So we should put resize sensor on a container that won’t be affected by the logic inside it.
+   * We are using ResizeSensor to listen to the resize event. 
+   */
     const mainContainer:any = document.querySelector('.main-container');
     const calculateButtons = () => {
 
@@ -119,7 +126,8 @@ const RelatedTableActions = ({
         buttons = Array.from(buttonContainer.getElementsByClassName('chaise-btn'));
         /**
          * If there aren't any enough space to show even one button, just switch to showing all as dropdown.
-         * 200 is based on the width of the container containing dropdown and last visible button.
+         * 350 is based on the width of the container containing dropdown and last visible button. We choose 350 
+         * because that is when the space gets more congested and we need to push all buttons to the dropdown
          */
         setShowAllActionsAsDropdown(mainContainer?.offsetWidth < 350);
         const tableHeaderButtonsToAddToDropdown: any = [];

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -93,7 +93,7 @@ const RelatedTableHeader = ({ relatedModel }: RelatedTableHeaderProps): JSX.Elem
             </ChaiseTooltip>
           )}
         </div>
-        <RelatedTableActions istableHeader={true} relatedModel={relatedModel} />
+        <RelatedTableActions relatedModel={relatedModel} />
       </div>
     </div>
   );

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -17,12 +17,10 @@ import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 
 type RelatedTableHeaderProps = {
-  relatedModel: RecordRelatedModel
+  relatedModel: RecordRelatedModel;
 };
 
-const RelatedTableHeader = ({
-  relatedModel
-}: RelatedTableHeaderProps): JSX.Element => {
+const RelatedTableHeader = ({ relatedModel }: RelatedTableHeaderProps): JSX.Element => {
   /**
    * variable to store ref of header text
    */
@@ -49,7 +47,11 @@ const RelatedTableHeader = ({
 
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && hasTooltip) {
-      return <>{renderedDisplayname}: {usedRef.comment}</>;
+      return (
+        <>
+          {renderedDisplayname}: {usedRef.comment}
+        </>
+      );
     } else if (hasTooltip) {
       return usedRef.comment;
     } else {
@@ -81,19 +83,17 @@ const RelatedTableHeader = ({
 
       <div className='chaise-accordion-header-buttons'>
         <div className='chaise-accordion-header-icons'>
-          {relatedModel.recordsetState.isLoading && !relatedModel.recordsetState.hasTimeoutError &&
-            <Spinner animation='border' size='sm' />
-          }
-          {relatedModel.recordsetState.hasTimeoutError &&
-            <ChaiseTooltip
-              placement='bottom'
-              tooltip={MESSAGE_MAP.queryTimeoutTooltip}
-            >
+          {relatedModel.recordsetState.isLoading &&
+            !relatedModel.recordsetState.hasTimeoutError && (
+              <Spinner animation='border' size='sm' />
+            )}
+          {relatedModel.recordsetState.hasTimeoutError && (
+            <ChaiseTooltip placement='bottom' tooltip={MESSAGE_MAP.queryTimeoutTooltip}>
               <span className='fa-solid fa-triangle-exclamation'></span>
             </ChaiseTooltip>
-          }
+          )}
         </div>
-        <RelatedTableActions relatedModel={relatedModel} />
+        <RelatedTableActions istableHeader={true} relatedModel={relatedModel} />
       </div>
     </div>
   );

--- a/src/components/recordedit/resultset-table-header.tsx
+++ b/src/components/recordedit/resultset-table-header.tsx
@@ -74,7 +74,7 @@ const ResultsetTableHeader = ({
             placement='top'
             tooltip={<span>Edit the {adj} records.</span>}
           >
-            <a className='chaise-btn chaise-btn-secondary more-results-link' href={editLink} onClick={avoidClick}>
+            <a className='chaise-btn chaise-btn-secondary bulk-edit-link' href={editLink} onClick={avoidClick}>
               <span className='chaise-btn-icon fa-solid fa-pen'></span>
               <span>Bulk Edit</span>
             </a>

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -116,7 +116,9 @@ describe ("Viewing exisiting record with related entities, ", function () {
         bulkEditLink: [
           browser.params.url, 'recordedit', `#${browser.params.catalogId}`,
           'product-unordered-related-tables-links:booking',
-          '*::facets::N4IghgdgJiBcDaoDOB7ArgJwMYFM6JHQBcAjdafEABwxSjSyIFo0IUMocMconuAbMER5MiYEvxxIm-AJYQA1khAAaEADMFAfTIoF8gOZawWLCgC25ukNkoIIALoBfNQCUAkgBFHarAAsUWVxlBBAAJgA5AGFHJ2cgA'
+          // we cannot test the actual facet blob since it's based on RID
+          // and we also don't have access to ermrestjs here to encode it for us
+          '*::facets::'
         ].join('/'),
         viewMore: {
             displayname: "booking",

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -113,6 +113,11 @@ describe ("Viewing exisiting record with related entities, ", function () {
         canEdit: true,
         inlineComment: true,
         comment: "booking inline comment",
+        bulkEditLink: [
+          browser.params.url, 'recordedit', `#${browser.params.catalogId}`,
+          'product-unordered-related-tables-links:booking',
+          '*::facets::N4IghgdgJiBcDaoDOB7ArgJwMYFM6JHQBcAjdafEABwxSjSyIFo0IUMocMconuAbMER5MiYEvxxIm-AJYQA1khAAaEADMFAfTIoF8gOZawWLCgC25ukNkoIIALoBfNQCUAkgBFHarAAsUWVxlBBAAJgA5AGFHJ2cgA'
+        ].join('/'),
         viewMore: {
             displayname: "booking",
             filter: "Accommodations\nSuper 8 North Hollywood Motel"

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -543,6 +543,12 @@ var recordPage = function() {
         return el.element(by.css(".more-results-link"));
     };
 
+    this.getBulkEditLink = function(displayName, isInline) {
+      var el = isInline ? this.getEntityRelatedTable(displayName) : this.getRelatedTableAccordion(displayName);
+      // the link is not a child of the table, rather one of the accordion group
+      return el.element(by.css(".bulk-edit-link"));
+  };
+
     this.getAddRecordLink = function(displayName, isInline) {
         var el = isInline ? this.getEntityRelatedTable(displayName) : this.getRelatedTableAccordion(displayName);
         // the link is not a child of the table, rather one of the accordion group
@@ -767,7 +773,7 @@ var recordsetPage = function() {
     this.waitForInverseModalSpinner = function () {
         var locator = element(by.css(".modal-body .recordest-main-spinner"));
         return browser.wait(protractor.ExpectedConditions.invisibilityOf(locator), browser.params.defaultTimeout);
-    };    
+    };
 
     this.getNoResultsRow = function() {
         return element(by.id("no-results-row"));

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -719,6 +719,24 @@ exports.testRelatedTable = function (params, pageReadyCondition) {
             }
         });
 
+        if (typeof params.canEdit === "boolean") {
+          if (params.canEdit) {
+            it ('`Bulk Edit` button should be visible with correct link', function () {
+              const btn = chaisePage.recordPage.getBulkEditLink(params.displayname, params.isInline);
+              expect(btn.isPresent()).toBeTruthy();
+
+              if (params.bulkEditLink) {
+                expect(btn.getAttribute('href')).toContain(params.bulkEditLink);
+              }
+            });
+          } else {
+            it ('`Bulk Edit` button should not be offered.', function () {
+              const btn = chaisePage.recordPage.getBulkEditLink(params.displayname, params.isInline);
+              expect(btn.isPresent()).not.toBeTruthy();
+            });
+          }
+        }
+
         // Display Mode
         describe("view mode and rows, ", function () {
 


### PR DESCRIPTION
This PR focuses on making the related main section and table section buttons responsive based on available space. 

Other changes:
- Add a Bulk edit button to related entities.
- Change the icon of "custom mode"