### PR TITLE
Improve Navbar UX in static sites

### DIFF
--- a/docs/user-docs/navbar-app.md
+++ b/docs/user-docs/navbar-app.md
@@ -136,12 +136,23 @@ With the current HTML structure, it is possible to apply different styles to cus
 
 1. Preserve space for navbar while its loading (to reduce the page shift):
     ```css
+    /* set a static height for navbar */
     navbar {
-      height: YOUR_VALUE;
-      background-color: YOUR_VALUE;
       display: block;
+      height: YOUR_VALUE;
     }
     ```
+
+    If we detect that you've assigned a height to the `navbar`, we will show a spinner while navbar data is loading. The size of this spinner is calcuated based on the available space. You can modify it by doing the following:
+    ```css
+    /* change the spinner displayed on the navbar during load */
+    .chaise-app-wrapper-sm-spinner .spinner-border {
+      height: YOUR_VALUE !important;
+      width: YOUR_VALUE !important;
+      border-width: YOUR_VALUE !important;
+    }
+    ```
+    > Adding `!important` is necessary to ensure overriding the rules that Chaise is going to add with JavaScript.
 
 2. Change the navbar background color:
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -23,7 +23,7 @@
  * the spinner that will be showed in some apps/libs (navbar) during configuration
  * these rules are making sure the spinner is displayed in the middle of the container
  */
-.chaise-app-small-spinner-container {
+.chaise-app-wrapper-sm-spinner {
   display: flex;
   height: 100%;
   .spinner-border {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -19,6 +19,18 @@
   visibility: visible;
 }
 
+/**
+ * the spinner that will be showed in some apps/libs (navbar) during configuration
+ * these rules are making sure the spinner is displayed in the middle of the container
+ */
+.chaise-app-small-spinner-container {
+  display: flex;
+  height: 100%;
+  .spinner-border {
+    margin: auto;
+  }
+}
+
 html {
   font-size: variables.$font-size;
 }

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -107,14 +107,17 @@ const AppWrapperInner = ({
     windowRef.addEventListener('hashchange', onHashChange);
 
     new Promise((resolve, reject) => {
+      console.log('fecthing session');
       if (dontFetchSession) {
         resolve(null);
       } else {
         getSession('').then((response) => resolve(response)).catch((err) => reject(err));
       }
     }).then((response: any) => {
+      console.log('configuring chaise');
       return ConfigService.configure(appSettings, response);
     }).then(() => {
+      console.log('config done!');
       setConfigDone(true);
     }).catch((err: any) => {
       dispatchError({ error: err });

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -237,44 +237,50 @@ const AppWrapperInner = ({
         }
       }
     });
-  }
+  };
 
-  /**
-   * in some cases (navbar app), we want to show a small spinner that fits the container
-   */
-  const renderSmallSpinner = () => {
-    const containerHeight = smallSpinnerContainer && smallSpinnerContainer.offsetHeight !== 0 ? smallSpinnerContainer.offsetHeight : 0;
-    if (containerHeight === 0) {
-      return <></>;
-    }
+  const renderSpinner = () => {
+    if (!displaySpinner && !smallSpinnerContainer) return <></>;
 
     /**
-     * the height/width of spinner is half of the container so we have enough padding
-     * above and below.
-     * I added the max and minimum to make sure we're not showing a very small or very
-     * large spinner.
-     * NOTE: we might want to be more smarter about this
+     * in some cases (navbar app), we want to show a small spinner that fits the container
      */
-    const minHeight = 15, maxHeight = 40, minBorderWidth = 2, maxBorderWidth = 5;
-    let height = containerHeight / 2, borderWidth = minBorderWidth;
-    if (height > maxHeight) {
-      height = maxHeight;
-      borderWidth = maxBorderWidth;
-    } else if (height < minHeight) {
-      height = minHeight;
-    }
-    const spinnerStyles = {
-      height: `${height}px`,
-      width: `${height}px`,
-      borderWidth: `${borderWidth}px`
-    }
-    return (
-      <div className='chaise-app-small-spinner-container'>
-        <div className='spinner-border text-light' role='status' style={spinnerStyles}>
-          <span className='sr-only'>Loading...</span>
+    if (smallSpinnerContainer) {
+      const containerHeight = smallSpinnerContainer && smallSpinnerContainer.offsetHeight !== 0 ? smallSpinnerContainer.offsetHeight : 0;
+      if (containerHeight === 0) {
+        return <></>;
+      }
+
+      /**
+       * the height/width of spinner is half of the container so we have enough padding
+       * above and below.
+       * I added the max and minimum to make sure we're not showing a very small or very
+       * large spinner.
+       * NOTE: we might want to be more smarter about this
+       */
+      const minHeight = 15, maxHeight = 40, minBorderWidth = 2, maxBorderWidth = 5;
+      let height = containerHeight / 2, borderWidth = minBorderWidth;
+      if (height > maxHeight) {
+        height = maxHeight;
+        borderWidth = maxBorderWidth;
+      } else if (height < minHeight) {
+        height = minHeight;
+      }
+      const spinnerStyles = {
+        height: `${height}px`,
+        width: `${height}px`,
+        borderWidth: `${borderWidth}px`
+      }
+      return (
+        <div className='chaise-app-small-spinner-container'>
+          <div className='spinner-border text-light' role='status' style={spinnerStyles}>
+            <span className='sr-only'>Loading...</span>
+          </div>
         </div>
-      </div>
-    )
+      )
+    }
+
+    return <ChaiseSpinner />;
   }
 
   return (
@@ -283,8 +289,7 @@ const AppWrapperInner = ({
         FallbackComponent={errorFallback}
       >
         {/* show spinner if we're waiting for configuration and there are no error during configuration */}
-        {(!smallSpinnerContainer && displaySpinner && !configDone && errors.length === 0) && <ChaiseSpinner />}
-        {(smallSpinnerContainer && !configDone && errors.length === 0) && renderSmallSpinner()}
+        {errors.length === 0 && !configDone && renderSpinner()}
         {configDone &&
           <div className='app-container'>
             {(includeNavbar || includeAlerts) &&

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -252,27 +252,42 @@ const AppWrapperInner = ({
       }
 
       /**
-       * the height/width of spinner is half of the container so we have enough padding
+       * - the height/width of spinner is half of the container so we have enough padding
        * above and below.
-       * I added the max and minimum to make sure we're not showing a very small or very
+       * - I added the max and minimum to make sure we're not showing a very small or very
        * large spinner.
-       * NOTE: we might want to be more smarter about this
+       * - the border-width is calculated by interpolating based on the min and max values.
        */
       const minHeight = 15, maxHeight = 40, minBorderWidth = 2, maxBorderWidth = 5;
-      let height = containerHeight / 2, borderWidth = minBorderWidth;
-      if (height > maxHeight) {
+
+      let height = containerHeight / 2, borderWidth;
+
+      // we don't have enough space to show a proper spinner (do we want to try anyways?)
+      // realisticly this won't happen. the only way that we fall into this case
+      // is if data-modelers chose a very small height which means not preserving
+      // enough space for the text that is going to be displayed on the navbar.
+      if (height < minHeight) {
+        return <></>;
+      }
+
+      // we don't want to show a giant spinner
+      if (height >= maxHeight) {
         height = maxHeight;
         borderWidth = maxBorderWidth;
-      } else if (height < minHeight) {
-        height = minHeight;
       }
+      // bw = ((max_bw-min_bw)/(max_h - min_h)) * (h - min_h)) + min_bw
+      else {
+        borderWidth = ((maxBorderWidth-minBorderWidth)/(maxHeight-minHeight)) * (height-minHeight);
+        borderWidth += minBorderWidth;
+      }
+
       const spinnerStyles = {
         height: `${height}px`,
         width: `${height}px`,
         borderWidth: `${borderWidth}px`
       }
       return (
-        <div className='chaise-app-small-spinner-container'>
+        <div className='chaise-app-wrapper-sm-spinner'>
           <div className='spinner-border text-light' role='status' style={spinnerStyles}>
             <span className='sr-only'>Loading...</span>
           </div>

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -114,17 +114,14 @@ const AppWrapperInner = ({
     windowRef.addEventListener('hashchange', onHashChange);
 
     new Promise((resolve, reject) => {
-      console.log('fecthing session');
       if (dontFetchSession) {
         resolve(null);
       } else {
         getSession('').then((response) => resolve(response)).catch((err) => reject(err));
       }
     }).then((response: any) => {
-      console.log('configuring chaise');
       return ConfigService.configure(appSettings, response);
     }).then(() => {
-      console.log('config done!');
       setConfigDone(true);
     }).catch((err: any) => {
       dispatchError({ error: err });

--- a/src/libs/login.tsx
+++ b/src/libs/login.tsx
@@ -9,8 +9,7 @@ import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 const loginLibSettings = {
-  appName: APP_NAMES.LOGIN,
-  isLib: true
+  appName: APP_NAMES.LOGIN
 };
 
 /**

--- a/src/libs/login.tsx
+++ b/src/libs/login.tsx
@@ -6,18 +6,24 @@ import ChaiseLogin from '@isrd-isi-edu/chaise/src/components/navbar/login';
 
 // utilities
 import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 const loginLibSettings = {
-  appName: APP_NAMES.LOGIN
+  appName: APP_NAMES.LOGIN,
+  isLib: true
 };
 
 /**
  * since angularjs implementation relies on "login" tag, I decided to
  * keep it the same to reduce the amount of needed changes.
  */
-const root = createRoot(document.querySelector('login') as HTMLElement);
-root.render(
-  <AppWrapper appSettings={loginLibSettings} ignoreHashChange>
-    <ChaiseLogin />
-  </AppWrapper>
-);
+const LOGIN_SELECTOR = 'login';
+
+waitForElementToLoad(LOGIN_SELECTOR).then(() => {
+  const root = createRoot(document.querySelector(LOGIN_SELECTOR) as HTMLElement);
+  root.render(
+    <AppWrapper appSettings={loginLibSettings} ignoreHashChange>
+      <ChaiseLogin />
+    </AppWrapper>
+  );
+});

--- a/src/libs/navbar.tsx
+++ b/src/libs/navbar.tsx
@@ -18,13 +18,14 @@ const navbarLibSettings = {
  */
 const NAVBAR_SELECTOR = 'navbar';
 
-console.log('waiting for <navbar>')
 waitForElementToLoad(NAVBAR_SELECTOR).then(() => {
-  console.log('<navbar> present');
+  const navbar = document.querySelector(NAVBAR_SELECTOR) as HTMLElement;
 
-  const root = createRoot(document.querySelector(NAVBAR_SELECTOR) as HTMLElement);
-  root.render(
-    <AppWrapper appSettings={navbarLibSettings} includeNavbar ignoreHashChange>
+  createRoot(navbar).render(
+    <AppWrapper
+      appSettings={navbarLibSettings} smallSpinnerContainer={navbar}
+      includeNavbar ignoreHashChange
+    >
       {/* navbar is already included and we don't want anything else */}
       {/* (this comment is needed since appwrapper expects children) */}
     </AppWrapper>

--- a/src/libs/navbar.tsx
+++ b/src/libs/navbar.tsx
@@ -8,8 +8,7 @@ import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 const navbarLibSettings = {
-  appName: APP_NAMES.NAVBAR,
-  isLib: true
+  appName: APP_NAMES.NAVBAR
 };
 
 /**

--- a/src/libs/navbar.tsx
+++ b/src/libs/navbar.tsx
@@ -5,19 +5,29 @@ import AppWrapper from '@isrd-isi-edu/chaise/src/components/app-wrapper';
 
 // utilities
 import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 const navbarLibSettings = {
-  appName: APP_NAMES.NAVBAR
+  appName: APP_NAMES.NAVBAR,
+  isLib: true
 };
 
 /**
- * since angularjs implementation relies on "navbar" tag, I decided to
+ * since angularjs implementation relies on 'navbar' tag, I decided to
  * keep it the same to reduce the amount of needed changes.
  */
-const root = createRoot(document.querySelector('navbar') as HTMLElement);
-root.render(
-  <AppWrapper appSettings={navbarLibSettings} includeNavbar ignoreHashChange>
-    {/* navbar is already included and we don't want anything else */}
-    {/* (this comment is needed since appwrapper expects children) */}
-  </AppWrapper>
-);
+const NAVBAR_SELECTOR = 'navbar';
+
+console.log('waiting for <navbar>')
+waitForElementToLoad(NAVBAR_SELECTOR).then(() => {
+  console.log('<navbar> present');
+
+  const root = createRoot(document.querySelector(NAVBAR_SELECTOR) as HTMLElement);
+  root.render(
+    <AppWrapper appSettings={navbarLibSettings} includeNavbar ignoreHashChange>
+      {/* navbar is already included and we don't want anything else */}
+      {/* (this comment is needed since appwrapper expects children) */}
+    </AppWrapper>
+  );
+
+});

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -49,7 +49,9 @@ export interface ConfigServiceSettings {
   overrideImagePreviewBehavior?: boolean,
   overrideDownloadClickBehavior?: boolean,
   overrideExternalLinkBehavior?: boolean,
-  openIframeLinksInTab?: boolean
+  openIframeLinksInTab?: boolean,
+  // TODO isLib can be used for gradually showing content
+  isLib?: boolean
 }
 
 export interface ContextHeaderParams {
@@ -144,6 +146,7 @@ export class ConfigService {
       // the server object that can be used in other places
       ConfigService._server = ERMrest.ermrestFactory.getServer(service, ConfigService._contextHeaderParams);
 
+      console.log('asking for catalog!');
       const response = await ConfigService._server.catalogs.get(catalogId, true);
       // we already setup the defaults and the configuration based on chaise-config.js
       if (response && response.chaiseConfig) {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -144,7 +144,6 @@ export class ConfigService {
       // the server object that can be used in other places
       ConfigService._server = ERMrest.ermrestFactory.getServer(service, ConfigService._contextHeaderParams);
 
-      console.log('asking for catalog!');
       const response = await ConfigService._server.catalogs.get(catalogId, true);
       // we already setup the defaults and the configuration based on chaise-config.js
       if (response && response.chaiseConfig) {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -49,9 +49,7 @@ export interface ConfigServiceSettings {
   overrideImagePreviewBehavior?: boolean,
   overrideDownloadClickBehavior?: boolean,
   overrideExternalLinkBehavior?: boolean,
-  openIframeLinksInTab?: boolean,
-  // TODO isLib can be used for gradually showing content
-  isLib?: boolean
+  openIframeLinksInTab?: boolean
 }
 
 export interface ContextHeaderParams {

--- a/src/utils/ui-utils.ts
+++ b/src/utils/ui-utils.ts
@@ -338,3 +338,30 @@ export function clickHref(href: string) {
   downloadLink.click();
   document.body.removeChild(downloadLink);
 }
+
+/**
+ * wait for an element to load
+ * NOTE: this might have some affects on the element, so use it with caution.
+ *
+ * based on https://stackoverflow.com/a/61511955/1662057
+ * @param selector the selector of the element
+ */
+export function waitForElementToLoad(selector: string) {
+  return new Promise(resolve => {
+    if (document.querySelector(selector)) {
+      return resolve(document.querySelector(selector));
+    }
+
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        resolve(document.querySelector(selector));
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body ? document.body : document, {
+      childList: true,
+      subtree: true
+    });
+  });
+}

--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -81,6 +81,7 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
     // create the html plugin
     appHTMLPlugins.push(
       new HtmlWebpackPlugin({
+        scriptLoading: ac.isLib ? 'blocking' : 'defer',
         chunks: [bundleName],
         template: path.join(__dirname, 'templates', ac.isLib ? 'lib.html' : 'app.html'),
         // the filename path is relative to the "output" define below which is the "bundles" folder.

--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -81,6 +81,11 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
     // create the html plugin
     appHTMLPlugins.push(
       new HtmlWebpackPlugin({
+        /**
+         * in case of libraries (navbar, login), we want to make sure the library
+         * dependencies are blocking the content so the navbar/login shows up
+         * right away instead of being delayed with the rest of the content.
+         */
         scriptLoading: ac.isLib ? 'blocking' : 'defer',
         chunks: [bundleName],
         template: path.join(__dirname, 'templates', ac.isLib ? 'lib.html' : 'app.html'),


### PR DESCRIPTION
This PR will improve the Navbar UX in static sites by applying most of the changes I described [here](https://github.com/informatics-isi-edu/chaise/issues/1978#issuecomment-1613632197). The changes are:

- Ensure navbar dependencies are not using `defer` and, therefore, have priority over the static content. 
- Show a spinner while waiting for the session and catalog if the navbar has some preserved space.