### PR TITLE
Support chaise tooltips

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout default-asset-bytes
           make dist
           sudo make deploy
       - name: Install chaise

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,6 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          git checkout default-asset-bytes
           make dist
           sudo make deploy
       - name: Install chaise

--- a/docs/dev-docs/dev-guide.md
+++ b/docs/dev-docs/dev-guide.md
@@ -139,6 +139,18 @@ The rules that should be followed while writing code.
   import Button from 'react-bootstrap/Button';
   ```
 
+- Before implementing your special component take a look at `components` folder and see if any of the existing reusable components can satisfy your case. The following are list of more common components that we have:
+ - `AppWrapper`: Wrapper for all the chaise-like application. Refer to [this section](#structure-of-an-app) for more information.
+ - `DisplayValue`: This component can be used to inject HTML content into the DOM. Use this component instead of `dangerouslySetInnerHTML`.
+ - `ChaiseTooltip`: Display toolips for elements.
+ - `ClearInputBtn`: A clear button that should be attached to all inputs on the page.
+ - `CondWrapper`: Can be used to conditionally add wrappers to another component.
+ - `InputSwitch`: Display appropriate input for a given column.
+ - `SearchInput`: Display a search input.
+ - `Spinner`: A spinner to show progress on the page.
+ - `SplitView`: Adds a resizable side panel to the page.
+ - `Title`: Given a `displayname` object will return the proper title to be displayed on the page.
+
 ### Lint
 - Make sure the `ESLint` extension is installed for Visual Studio Code.
 

--- a/src/components/alerts.tsx
+++ b/src/components/alerts.tsx
@@ -3,6 +3,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_alerts.scss';
 // components
 import Alert from 'react-bootstrap/Alert';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // hooks
 import useAlert from '@isrd-isi-edu/chaise/src/hooks/alerts';
@@ -14,6 +15,7 @@ import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
 
 // utils
 import { toTitlecase } from '@isrd-isi-edu/chaise/src/utils/string-utils';
+
 
 export const Alerts = (): JSX.Element => {
   const { alerts, removeAlert } = useAlert();
@@ -48,7 +50,7 @@ export const Alerts = (): JSX.Element => {
           {alert.isSessionExpiredAlert ? renderSessionExpiredAlert(alert) :
             <>
               <strong className='alert-title'>{toTitlecase(alert.type)}</strong>
-              <span dangerouslySetInnerHTML={{ __html: alert.message }}></span>
+              <DisplayValue internal value={{isHTML: true, value: alert.message}} />
             </>
           }
         </Alert>

--- a/src/components/clear-input-btn.tsx
+++ b/src/components/clear-input-btn.tsx
@@ -1,7 +1,13 @@
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 
 type ClearInputBtnProps = {
+  /**
+   * the class name attached to the button.
+   */
   btnClassName?: string,
+  /**
+   * the function that is called when users click on the button
+   */
   clickCallback: Function,
   /**
    * the boolean condition to show it or not

--- a/src/components/display-value.tsx
+++ b/src/components/display-value.tsx
@@ -9,14 +9,29 @@ import { DEFAULT_DISPLAYNAME } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { createChaiseTooltips } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 type DisplayValueProps = {
+  /**
+   * The value that should be displayed.
+   */
   value?: Displayname,
+  /**
+   * whether the component should return a special value for null and empty
+   */
   specialNullEmpty?: boolean,
+  /**
+   * whether we should add the `markdown-container` class
+   */
   addClass?: boolean,
+  /**
+   * class names that should be added
+   */
   className?: string,
+  /**
+   * styels that should be added
+   */
   styles?: object,
   /**
    * Whether this is something that we're doing internally,
-   * or is based on annotation-provided values.
+   * or is based on annotation or user provided values.
   */
   internal?: boolean,
   /**

--- a/src/components/display-value.tsx
+++ b/src/components/display-value.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 import { DEFAULT_DISPLAYNAME } from '@isrd-isi-edu/chaise/src/utils/constants';
+import Tooltip from 'bootstrap/js/dist/tooltip';
 
 type DisplayValueProps = {
   value?: Displayname,
@@ -22,6 +23,39 @@ const DisplayValue = ({
   className,
   styles,
 }: DisplayValueProps): JSX.Element => {
+  /**
+   * see if there's a data-chaise-tooltip in the displayed value, and turn them into proper tooltips.
+   *
+   * NOTE:
+   * I'm using bootstrap.js for this feature. this has added around 30KB to our bundles. I couldn't find a way to do this
+   * directly with react-bootstrap. but there might be a way and we should investigate later
+   */
+  const spanRef = useRef<HTMLSpanElement | null>(null);
+  useEffect(() => {
+    if (!spanRef.current) return;
+
+    const tooltipTriggerList = document.querySelectorAll('[data-chaise-tooltip]');
+    if (tooltipTriggerList && tooltipTriggerList.length > 0) {
+      tooltipTriggerList.forEach((el) => {
+        const title = el.getAttribute('data-chaise-tooltip');
+        const placement = el.getAttribute('data-chaise-tooltip-placement') || 'bottom';
+        const noIcon = el.hasAttribute('data-chaise-tooltip-no-icon');
+        if (!title) return;
+        if (!noIcon) {
+          // adding space between content and the icon is how we're making sure spacing between the two is correct.
+          // should we come up with a better solution instead?
+          el.innerHTML = el.innerHTML + ' ';
+          el.classList.add('chaise-icon-for-tooltip');
+        }
+        new Tooltip(el, {
+          title,
+          // @ts-ignore ts doesn't understand that we're actually sanitizing the value.
+          placement: ['auto', 'top', 'bottom', 'left', 'right'].indexOf(placement) !== -1 ? placement : 'bottom'
+        })
+      });
+    }
+  });
+
   if (specialNullEmpty) {
     if (value?.value === '') {
       return <span dangerouslySetInnerHTML={{ __html: DEFAULT_DISPLAYNAME.empty }} style={styles}></span>;
@@ -41,6 +75,7 @@ const DisplayValue = ({
   if (value?.isHTML && value?.value) {
     return (
       <span
+        ref={spanRef}
         style={styles}
         dangerouslySetInnerHTML={{ __html: value.value }}
         className={usedClassName}

--- a/src/components/display-value.tsx
+++ b/src/components/display-value.tsx
@@ -17,8 +17,17 @@ type DisplayValueProps = {
   /**
    * Whether this is something that we're doing internally,
    * or is based on annotation-provided values.
+  */
+  internal?: boolean,
+  /**
+   * set the wrapper element that should be used.
+   * if not defined, we will use a span.
    */
-  internal?: boolean
+  as?: React.ElementType,
+  /**
+   * the extra props that we should add to the element
+   */
+  props?: any,
 };
 
 const DisplayValue = ({
@@ -27,7 +36,11 @@ const DisplayValue = ({
   specialNullEmpty,
   className,
   styles,
+  as = 'span',
+  props
 }: DisplayValueProps): JSX.Element => {
+
+  const Wrapper = as;
 
   // handle tooltips that might be in the value
   const spanRef = useRef<HTMLSpanElement | null>(null);
@@ -38,11 +51,11 @@ const DisplayValue = ({
 
   if (specialNullEmpty) {
     if (value?.value === '') {
-      return <span dangerouslySetInnerHTML={{ __html: DEFAULT_DISPLAYNAME.empty }} style={styles}></span>;
+      return <Wrapper dangerouslySetInnerHTML={{ __html: DEFAULT_DISPLAYNAME.empty }} style={styles} {...props}></Wrapper>;
     }
 
     if (value?.value == null) {
-      return <span dangerouslySetInnerHTML={{ __html: DEFAULT_DISPLAYNAME.null }} style={styles}></span>;
+      return <Wrapper dangerouslySetInnerHTML={{ __html: DEFAULT_DISPLAYNAME.null }} style={styles} {...props}></Wrapper>;
     }
   }
 
@@ -54,18 +67,19 @@ const DisplayValue = ({
 
   if (value?.isHTML && value?.value) {
     return (
-      <span
+      <Wrapper
         ref={spanRef}
         style={styles}
         dangerouslySetInnerHTML={{ __html: value.value }}
         className={usedClassName}
         // for foreign-key inputs display value
         contentEditable={false}
+        {...props}
       >
-      </span>
+      </Wrapper>
     )
   }
-  return <span style={styles} className={usedClassNames.join(' ')}>{value?.value}</span>
+  return <Wrapper style={styles} className={usedClassNames.join(' ')} {...props}>{value?.value}</Wrapper>
 }
 
 export default DisplayValue;

--- a/src/components/display-value.tsx
+++ b/src/components/display-value.tsx
@@ -1,7 +1,12 @@
-import React, { useEffect, useRef } from 'react';
+// components
 import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
+
+// hooks
+import { useEffect, useRef } from 'react';
+
+// utils
 import { DEFAULT_DISPLAYNAME } from '@isrd-isi-edu/chaise/src/utils/constants';
-import Tooltip from 'bootstrap/js/dist/tooltip';
+import { createChaiseTooltips } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 type DisplayValueProps = {
   value?: Displayname,
@@ -23,38 +28,13 @@ const DisplayValue = ({
   className,
   styles,
 }: DisplayValueProps): JSX.Element => {
-  /**
-   * see if there's a data-chaise-tooltip in the displayed value, and turn them into proper tooltips.
-   *
-   * NOTE:
-   * I'm using bootstrap.js for this feature. this has added around 30KB to our bundles. I couldn't find a way to do this
-   * directly with react-bootstrap. but there might be a way and we should investigate later
-   */
+
+  // handle tooltips that might be in the value
   const spanRef = useRef<HTMLSpanElement | null>(null);
   useEffect(() => {
     if (!spanRef.current) return;
-
-    const tooltipTriggerList = document.querySelectorAll('[data-chaise-tooltip]');
-    if (tooltipTriggerList && tooltipTriggerList.length > 0) {
-      tooltipTriggerList.forEach((el) => {
-        const title = el.getAttribute('data-chaise-tooltip');
-        const placement = el.getAttribute('data-chaise-tooltip-placement') || 'bottom';
-        const noIcon = el.hasAttribute('data-chaise-tooltip-no-icon');
-        if (!title) return;
-        if (!noIcon) {
-          // adding space between content and the icon is how we're making sure spacing between the two is correct.
-          // should we come up with a better solution instead?
-          el.innerHTML = el.innerHTML + ' ';
-          el.classList.add('chaise-icon-for-tooltip');
-        }
-        new Tooltip(el, {
-          title,
-          // @ts-ignore ts doesn't understand that we're actually sanitizing the value.
-          placement: ['auto', 'top', 'bottom', 'left', 'right'].indexOf(placement) !== -1 ? placement : 'bottom'
-        })
-      });
-    }
-  });
+    createChaiseTooltips(spanRef.current);
+  }, []);
 
   if (specialNullEmpty) {
     if (value?.value === '') {

--- a/src/components/input-switch/longtext-field.tsx
+++ b/src/components/input-switch/longtext-field.tsx
@@ -4,6 +4,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_markdown-container.scss';
 import ClearInputBtn from '@isrd-isi-edu/chaise/src/components/clear-input-btn';
 import InputField, { InputFieldProps } from '@isrd-isi-edu/chaise/src/components/input-switch/input-field';
 import MarkdownPreviewModal from '@isrd-isi-edu/chaise/src/components/modals/markdown-preview-modal';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // hooks
 import { useEffect, useState, useRef } from 'react';
@@ -17,7 +18,7 @@ import { hasVerticalScrollbar } from '@isrd-isi-edu/chaise/src/utils/input-utils
 const LongTextField = (props: InputFieldProps): JSX.Element => {
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
- 
+
   const [showPreview, setShowPreview] = useState<boolean>(false);
   const [showModalPreview, setShowModalPreview] = useState<boolean>(false);
   const [previewContent, setPreviewContent] = useState<string>('');
@@ -185,7 +186,7 @@ const LongTextField = (props: InputFieldProps): JSX.Element => {
                 />
               </div>
               : <div className='md-preview chaise-input-control' data-provide='markdown' style={{ 'height': textAreaRef.current?.offsetHeight }}>
-                <div className='disabled-textarea markdown-container' dangerouslySetInnerHTML={{ __html: previewContent }}></div>
+                <div className='disabled-textarea'><DisplayValue addClass value={{value: previewContent, isHTML: true}} /></div>
               </div>
             }
           </div>

--- a/src/components/modals/markdown-preview-modal.tsx
+++ b/src/components/modals/markdown-preview-modal.tsx
@@ -1,5 +1,6 @@
 // components
 import Modal from 'react-bootstrap/Modal';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // utilites
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
@@ -42,11 +43,9 @@ const MarkdownPreviewModal = ({
       </Modal.Header>
       <Modal.Body>
       <div className='outer-table'>
-        <div
-          className='markdown-container'
-          style={{'padding': '10px'}}
-          dangerouslySetInnerHTML={{ __html: markdownContent}}
-        />
+        <div style={{'padding': '10px'}}>
+          <DisplayValue addClass value={{value: markdownContent, isHTML: true}} />
+        </div>
       </div>
       </Modal.Body>
     </Modal >

--- a/src/components/navbar/banner.tsx
+++ b/src/components/navbar/banner.tsx
@@ -1,4 +1,10 @@
+// components
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+
+// hooks
 import { useState } from 'react';
+
+// utils
 import { NavbarBanner } from '@isrd-isi-edu/chaise/src/utils/menu-utils';
 
 interface BannerProps {
@@ -15,7 +21,7 @@ const ChaiseBanner = ({
   const classString = `chaise-navbar-banner-container ${banner.key ? 'chaise-navbar-banner-container-' + banner.key : ''}`;
   return (<div className={classString}>
     {banner.dismissible && <button className='close' onClick={() => setHide(true)}><span aria-hidden='true'>×</span></button>}
-    <div className='markdown-container' dangerouslySetInnerHTML={{ __html: banner.html }} />
+    <DisplayValue value={{isHTML: true, value: banner.html}} addClass />
   </div>)
 };
 

--- a/src/components/navbar/login.tsx
+++ b/src/components/navbar/login.tsx
@@ -7,6 +7,7 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import NavbarDropdown from '@isrd-isi-edu/chaise/src/components/navbar/navbar-dropdown';
 import ProfileModal from '@isrd-isi-edu/chaise/src/components/modals/profile-modal';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // hooks
 import useAuthn from '@isrd-isi-edu/chaise/src/hooks/authn';
@@ -209,34 +210,45 @@ const ChaiseLogin = (): JSX.Element => {
       switch (oneOption.type) {
         case 'header':
           return (
-            <Nav.Item
+            <DisplayValue
               className='chaise-dropdown-header'
-              dangerouslySetInnerHTML={{ __html: renderName(oneOption) }}
+              value={{isHTML: true, value: renderName(oneOption)}}
+              as={Nav.Item}
             />
           );
         case 'url':
           return (
-            <Nav.Link
-              href={oneOption.url}
-              target={oneOption.newTab ? '_blank' : '_self'}
-              onClick={(event) => handleOnLinkClick(event, oneOption)}
-              dangerouslySetInnerHTML={{ __html: renderName(oneOption) }}
+            <DisplayValue
+              className='chaise-dropdown-header'
+              value={{isHTML: true, value: renderName(oneOption)}}
+              as={Nav.Link}
+              props={{
+                href: oneOption.url,
+                target: oneOption.newTab ? '_blank' : '_self',
+                onClick: (event: any) => handleOnLinkClick(event, oneOption)
+              }}
             />
           );
         case 'my_profile':
           return (
-            <Nav.Link
-              id='profile-link'
-              onClick={handleOpenProfileClick}
-              dangerouslySetInnerHTML={{ __html: oneOption.nameMarkdownPattern ? renderName(oneOption) : 'My Profile' }}
+            <DisplayValue
+              as={Nav.Link}
+              value={{isHTML: true, value: oneOption.nameMarkdownPattern ? renderName(oneOption) : 'My Profile'}}
+              props={{
+                onClick: handleOpenProfileClick,
+                id: 'profile-link'
+              }}
             />
           )
         case 'logout':
           return (
-            <Nav.Link
-              id='logout-link'
-              onClick={() => logout(LogActions.LOGOUT_NAVBAR)}
-              dangerouslySetInnerHTML={{ __html: oneOption.nameMarkdownPattern ? renderName(oneOption) : 'Log Out' }}
+            <DisplayValue
+              as={Nav.Link}
+              value={{isHTML: true, value: oneOption.nameMarkdownPattern ? renderName(oneOption) : 'Log Out'}}
+              props={{
+                onClick: () => logout(LogActions.LOGOUT_NAVBAR),
+                id: 'logout-link'
+              }}
             />
           )
         default:

--- a/src/components/navbar/navbar-dropdown.tsx
+++ b/src/components/navbar/navbar-dropdown.tsx
@@ -4,6 +4,7 @@ import useAuthn from '@isrd-isi-edu/chaise/src/hooks/authn';
 // components
 import NavDropdown from 'react-bootstrap/NavDropdown';
 import Dropdown from 'react-bootstrap/Dropdown';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // utilities
 import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
@@ -127,11 +128,14 @@ const NavbarDropdown = ({
     onDropdownToggle(isOpen, event, LogActions.NAVBAR_ACCOUNT_DROPDOWN, item);
   }
 
-  const renderHeader = (item: MenuOption, index: number) => <NavDropdown.Header
-    as='a'
+  const renderHeader = (item: MenuOption, index: number) => <DisplayValue
     key={index}
+    as={NavDropdown.Header}
     className='chaise-dropdown-header'
-    dangerouslySetInnerHTML={{ __html: renderName(item) }}
+    value={{ isHTML: true, value: renderName(item) }}
+    props={{
+      as: 'a'
+    }}
   />
 
   const renderDropdownMenu = (item: MenuOption, index: number) => {
@@ -145,11 +149,14 @@ const NavbarDropdown = ({
         onClick={alignDropDown}
         onToggle={(isOpen, event) => handleNavbarDropdownToggle(isOpen, event, item)}
       >
-        <Dropdown.Toggle
-          as='a'
-          variant='dark'
+        <DisplayValue
+          as={Dropdown.Toggle}
+          value={{ isHTML: true, value: renderName(item) }}
           className={menuItemClasses(item, session, true)}
-          dangerouslySetInnerHTML={{ __html: renderName(item) }}
+          props={{
+            as: 'a',
+            variant: 'dark'
+          }}
         />
         <Dropdown.Menu
           // renderOnMount prop is required to get submenu's width that can be
@@ -172,14 +179,18 @@ const NavbarDropdown = ({
       </Dropdown>)
   }
 
-  const renderUrl = (item: MenuOption, index: number) => <NavDropdown.Item
+  const renderUrl = (item: MenuOption, index: number) => <DisplayValue
     key={index}
-    href={item.url}
-    target={item.newTab ? '_blank' : '_self'}
-    onClick={(event) => handleOnLinkClick(event, item)}
+    as={NavDropdown.Item}
     className={menuItemClasses(item, session, true)}
-    dangerouslySetInnerHTML={{ __html: renderName(item) }}
+    value={{ isHTML: true, value: renderName(item) }}
+    props={{
+      href: item.url,
+      target: item.newTab ? '_blank' : '_self',
+      onClick: (event: MouseEvent<HTMLElement>) => handleOnLinkClick(event, item)
+    }}
   />
+
 
   const renderDropdownOptions = () => menu.map((child: MenuOption, index: number) => {
     if (!canShow(child, session) || !child.isValid) return;
@@ -193,20 +204,26 @@ const NavbarDropdown = ({
         return (renderUrl(child, index));
       case 'my_profile':
         return (
-          <NavDropdown.Item
-            id='profile-link'
+          <DisplayValue
             key={index}
-            onClick={openProfileCb}
-            dangerouslySetInnerHTML={{ __html: child.nameMarkdownPattern ? renderName(child) : 'My Profile' }}
+            as={NavDropdown.Item}
+            value={{isHTML: true, value: child.nameMarkdownPattern ? renderName(child) : 'My Profile'}}
+            props={{
+              id: 'profile-link',
+              onClick: openProfileCb
+            }}
           />
         )
       case 'logout':
         return (
-          <NavDropdown.Item
-            id='logout-link'
+          <DisplayValue
             key={index}
-            onClick={() => logout(LogActions.LOGOUT_NAVBAR)}
-            dangerouslySetInnerHTML={{ __html: child.nameMarkdownPattern ? renderName(child) : 'Log Out' }}
+            as={NavDropdown.Item}
+            value={{isHTML: true, value: child.nameMarkdownPattern ? renderName(child) : 'Log Out'}}
+            props={{
+              id: 'logout-link',
+              onClick: () => logout(LogActions.LOGOUT_NAVBAR)
+            }}
           />
         )
       default:

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -12,6 +12,7 @@ import ChaiseLogin from '@isrd-isi-edu/chaise/src/components/navbar/login';
 import NavbarDropdown from '@isrd-isi-edu/chaise/src/components/navbar/navbar-dropdown';
 import ChaiseBanner from '@isrd-isi-edu/chaise/src/components/navbar/banner';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // hooks
 import useAuthn from '@isrd-isi-edu/chaise/src/hooks/authn';
@@ -315,7 +316,7 @@ const ChaiseNavbar = (): JSX.Element => {
     );
   };
 
-  const renderDropdownName = (item: MenuOption) => (<span dangerouslySetInnerHTML={{ __html: renderName(item) }} />);
+  const renderDropdownName = (item: MenuOption) => (<DisplayValue value={{isHTML: true, value: renderName(item)}} />);
 
   const renderNavbarMenuDropdowns = () => {
     if (!menu) return;
@@ -325,13 +326,16 @@ const ChaiseNavbar = (): JSX.Element => {
 
       if (!item.children || !canEnable(item, session)) {
         return (
-          <Nav.Link
+          <DisplayValue
             key={index}
-            href={item.url}
-            target={item.newTab ? '_blank' : '_self'}
-            onClick={(event) => handleOnLinkClick(event, item)}
+            as={Nav.Link}
+            value={{isHTML: true, value: renderName(item)}}
             className={'chaise-nav-item ' + menuItemClasses(item, session, false)}
-            dangerouslySetInnerHTML={{ __html: renderName(item) }}
+            props={{
+              href: item.url,
+              target: item.newTab ? '_blank' : '_self',
+              onClick: (event: MouseEvent<HTMLElement>) => handleOnLinkClick(event, item)
+            }}
           />
         );
       }

--- a/src/components/spinner.tsx
+++ b/src/components/spinner.tsx
@@ -1,8 +1,19 @@
 import Spinner from 'react-bootstrap/Spinner';
 
 interface SpinnerProps {
+  /**
+   * displayed message
+   * default: Loading...
+   */
   message?: string;
+  /**
+   * added class name to the element.
+   */
   className?: string;
+  /**
+   * size of the spinner
+   * (if missing we will use the default size. use `sm` to make the spinner smaller)
+   */
   spinnerSize?: 'sm';
 }
 

--- a/src/components/split-view.tsx
+++ b/src/components/split-view.tsx
@@ -4,8 +4,17 @@ import { convertVWToPixel } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import useIsFirstRender from '@isrd-isi-edu/chaise/src/hooks/is-first-render';
 
 type LeftPaneProps = {
+  /**
+   * The elements displayed on the left side of the page
+   */
   children: (ref: React.RefObject<HTMLDivElement>) => JSX.Element,
+  /**
+   * default width of the left panel
+   */
   leftWidth: number | undefined,
+  /**
+   * the elements that we should update while updating the width of the left panel.
+   */
   leftPartners?: HTMLElement[]
 };
 

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -8,14 +8,32 @@ import { Displayname as DisplaynameType } from '@isrd-isi-edu/chaise/src/models/
 
 
 type TitleProps = {
+  /**
+   * The reference object.
+   */
   reference?: any,
+  /**
+   * the displayname that should be used
+   * - can be used to override the reference.displayname
+   */
   displayname?: DisplaynameType,
   /**
-   * use `false` to suppress adding the comment
+   * if defined, we will use this instead of getting it from the reference
+   * - use `false` to suppress adding the comment
    */
   comment?: string | false,
+  /**
+   * whether we should add a link or not.
+   * - if `link` is passed, we will add the link regardless of this property.
+   */
   addLink?: boolean,
+  /**
+   * if defined, we will use this instead of getting it from the reference
+   */
   link?: string,
+  /**
+   * the class added to the title element.
+   */
   className?: string
 }
 

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -21,7 +21,17 @@ type ChaiseTooltipProps = {
    * (can be used for applying custom styles to the tooltip)
    */
    className?: string,
+   /**
+    * if you want to manually control the tooltip, use
+    * this property in combination with `onToggle`.
+    * You should make sure `show` is set to proper value in that callback.
+    */
    show?: boolean,
+   /**
+    * if you want to manually control the tooltip, use
+    * this property in combination with `show`.
+    * You should make sure `show` is set to proper value in this callback.
+    */
    onToggle?: (nextShow: boolean) => void
 }
 

--- a/src/utils/menu-utils.ts
+++ b/src/utils/menu-utils.ts
@@ -254,7 +254,10 @@ export function menuItemClasses(option: MenuOption, session: Session | null, che
   return classes;
 }
 
-// make sure to use dangerouslySetInnerHTML when calling renderName
+/**
+ * process markdown pattern defined for a menu option.
+ * use DisplayValue component for rendering it in DOM
+ */
 export function renderName(option: MenuOption): string {
   return ConfigService.ERMrest.renderMarkdown(ConfigService.ERMrest.renderHandlebarsTemplate(option.nameMarkdownPattern, null), { inline: true });
 }

--- a/src/utils/ui-utils.ts
+++ b/src/utils/ui-utils.ts
@@ -6,6 +6,7 @@ import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 import { ID_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
+import Tooltip from 'bootstrap/js/dist/tooltip';
 
 /**
  * @param   {Node=} parentContainer - the parent container. if undefined `body` will be used.
@@ -364,4 +365,34 @@ export function waitForElementToLoad(selector: string) {
       subtree: true
     });
   });
+}
+
+/**
+ * see if there's a data-chaise-tooltip in the chidren of the given element, and turn them into proper tooltips.
+ *
+ * NOTE:
+ * I'm using bootstrap.js for this feature. this has added around 30KB to our bundles. I couldn't find a way to do this
+ * directly with react-bootstrap. but there might be a way and we should investigate later
+ */
+export function createChaiseTooltips(container: Element) {
+  const tooltipTriggerList = container.querySelectorAll('[data-chaise-tooltip]');
+  if (tooltipTriggerList && tooltipTriggerList.length > 0) {
+    tooltipTriggerList.forEach((el) => {
+      const title = el.getAttribute('data-chaise-tooltip');
+      const placement = el.getAttribute('data-chaise-tooltip-placement') || 'bottom';
+      const noIcon = el.hasAttribute('data-chaise-tooltip-no-icon');
+      if (!title) return;
+      if (!noIcon) {
+        // adding space between content and the icon is how we're making sure spacing between the two is correct.
+        // should we come up with a better solution instead?
+        el.innerHTML = el.innerHTML + ' ';
+        el.classList.add('chaise-icon-for-tooltip');
+      }
+      new Tooltip(el, {
+        title,
+        // @ts-ignore ts doesn't understand that we're actually sanitizing the value.
+        placement: ['auto', 'top', 'bottom', 'left', 'right'].indexOf(placement) !== -1 ? placement : 'bottom'
+      })
+    });
+  }
 }

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -104,8 +104,8 @@ var testParams = {
            "fileid", "uri", "filename", "bytes"
        ],
        results: [
-           ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1,024,000"],
-           ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+           ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1.02 MB"],
+           ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512 kB"]
        ],
        files : [{
            name: "testfile1MB.txt",
@@ -152,8 +152,8 @@ var testParams = {
           "fileid", "uri", "filename", "bytes"
       ],
       results: [
-          ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/b5dad28809685d9764dbd08fa23600bc:", "value": "testfile10MB_new.txt"}, "testfile10MB_new.txt", "10,240,000"],
-          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+          ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/b5dad28809685d9764dbd08fa23600bc:", "value": "testfile10MB_new.txt"}, "testfile10MB_new.txt", "10.2 MB"],
+          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512 kB"]
       ],
       files : [{
           name: "testfile10MB_new.txt", // a new file with new md5
@@ -194,8 +194,8 @@ var testParams = {
           "fileid", "uri", "filename", "bytes"
       ],
       results: [
-          ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1,024,000"],
-          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+          ["1", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/1/.txt/3a8c740953a168d9761d0ba2c9800475:", "value": "testfile1MB.txt"}, "testfile1MB.txt", "1.02 MB"],
+          ["2", {"link": "/hatrac/js/chaise/" + currentTimestampTime + "/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:", "value": "testfile500kb.png"}, "testfile500kb.png", "512 kB"]
       ],
       files : [{
           name: "testfile1MB.txt", // using the same file that has been already uploaded

--- a/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
@@ -103,7 +103,7 @@ var testParams = {
            "fileid", "uri", "filename", "bytes"
        ],
        results: [
-           ["4", {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/4/.png/", "value": "testfile500kb.png"}, "testfile500kb.png", "512,000"]
+           ["4", {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/4/.png/", "value": "testfile500kb.png"}, "testfile500kb.png", "512 kB"]
        ],
        files : [{
            name: "testfile500kb.png",

--- a/test/e2e/specs/all-features/record/copy-btn.spec.js
+++ b/test/e2e/specs/all-features/record/copy-btn.spec.js
@@ -35,7 +35,7 @@ var testParams = {
           value: 'saved_filename.png'
         },
         'asset1_filename': 'saved_filename.png',
-        'asset1_bytes': '512,000'
+        'asset1_bytes': '512 kB'
       }
 
     }

--- a/test/e2e/specs/default-config/recordedit/multi-col-types.spec.js
+++ b/test/e2e/specs/default-config/recordedit/multi-col-types.spec.js
@@ -73,7 +73,7 @@ var testParams = {
             json_col: '"89.586"',
             asset_col: {link: "/hatrac/js/chaise/somepath.png", value: "filenamevalue.png"},
             asset_col_filename: "filenamevalue.png",
-            asset_col_bytes: "12,345",
+            asset_col_bytes: "12.3 kB",
             asset_col_md5: "md5value",
             color_rgb_hex_col: "#123456"
         },
@@ -99,7 +99,7 @@ var testParams = {
             timestamp_txt: currentTimestampTime,
             asset_null_col: {ignoreInCI: true, link: "/hatrac/js/chaise/" + currentTimestampTime + "/multi-col-asset-null/", value: "testfile500kb_nulltest.png"},
             asset_null_col_filename: {ignoreInCI: true, value: "testfile500kb_nulltest.png"},
-            asset_null_col_bytes: {ignoreInCI: true, value: "512,000"},
+            asset_null_col_bytes: {ignoreInCI: true, value: "512 kB"},
             color_rgb_hex_null_col: "#123456"
         }
     },

--- a/test/e2e/specs/default-config/recordedit/multi-edit.spec.js
+++ b/test/e2e/specs/default-config/recordedit/multi-edit.spec.js
@@ -86,14 +86,14 @@ var testParams = {
             ],
             results: [
                 [
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/value/","value": "testfile500kb_1.png"}, "testfile500kb_1.png", "512,000",
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated/","value": "testfile500kb_2.png"}, "testfile500kb_2.png", "512,000",
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated_inv/","value": "testfile500kb_3.png"}, "testfile500kb_3.png", "512,000"
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/value/","value": "testfile500kb_1.png"}, "testfile500kb_1.png", "512 kB",
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated/","value": "testfile500kb_2.png"}, "testfile500kb_2.png", "512 kB",
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated_inv/","value": "testfile500kb_3.png"}, "testfile500kb_3.png", "512 kB"
                 ],
                 [
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/value/","value": "testfile500kb_1.png"}, "testfile500kb_1.png", "512,000",
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated/","value": "testfile500kb_2.png"}, "testfile500kb_2.png", "512,000",
-                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated_inv/","value": "testfile500kb_3.png"}, "testfile500kb_3.png", "512,000"
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/value/","value": "testfile500kb_1.png"}, "testfile500kb_1.png", "512 kB",
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated/","value": "testfile500kb_2.png"}, "testfile500kb_2.png", "512 kB",
+                    {"link": "/hatrac/js/chaise/"+currentTimestampTime+"/generated_inv/","value": "testfile500kb_3.png"}, "testfile500kb_3.png", "512 kB"
                 ]
             ],
             files: [{


### PR DESCRIPTION
This RP will modify the `DisplayValue` component to handle chaise tooltips. Since we have to do this in JavaScript and outside of React, I'm [directly using bootstrap's tooltips](https://getbootstrap.com/docs/5.3/components/tooltips/#enable-tooltips) for this.