### PR TITLE
Fixing spacing around chaise buttons

### DIFF
--- a/src/assets/scss/_button-group.scss
+++ b/src/assets/scss/_button-group.scss
@@ -9,6 +9,7 @@
   position: relative;
   display: inline-flex;
   vertical-align: middle; // match .chaise-btn alignment given font-size hack above
+  align-items: baseline; // to align it to the same line
 
   > .chaise-btn {
     position: relative;

--- a/src/assets/scss/_buttons.scss
+++ b/src/assets/scss/_buttons.scss
@@ -118,6 +118,13 @@
   @include helpers.chaise-btn-primary();
 }
 
+
+// export menu dropdown
+.export-menu.dropdown {
+  // make sure export button stays in the same line as other buttons
+  display: inline-block;
+}
+
 // export dropdown item
 .dropdown-item.export-menu-item,
 .dropdown-item.saved-query-menu-item {

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -43,11 +43,6 @@
               font-size: 1rem;
               padding-top: 7px;
               width: 330px;
-
-              // overriding the title-button class
-              & > * {
-                display: inline-flex;
-              }
             }
           }
 

--- a/src/assets/scss/_record.scss
+++ b/src/assets/scss/_record.scss
@@ -43,6 +43,11 @@
               font-size: 1rem;
               padding-top: 7px;
               width: 330px;
+
+              // overriding the title-button class
+              & > * {
+                display: inline-flex;
+              }
             }
           }
 

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -158,10 +158,9 @@
   }
 
   .action-btns {
+    // removing the padding since the table cell already has a padding of 5px
     text-align: center;
     font-size: 1.2rem;
-    // since we're increasing the size of icons, we should decrease the padding
-    padding: 5px 0 0 0;
 
     .chaise-btn {
       padding: 0;
@@ -172,6 +171,8 @@
 
     .chaise-view-details {
       font-size: 1.1em;
+      // giving a height to make it center aligned
+      height: 22px;
     }
 
     .disabled {

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -157,10 +157,11 @@
     }
   }
 
+  // Changing the padding for the action button to align with the rest of the columns in the table
   .action-btns {
     text-align: center;
     font-size: 1.2rem;
-    padding: 5px 0 0 0;
+    padding: 3px 0 0 0;
     .chaise-btn {
       padding: 0;
       margin: -3px;
@@ -168,8 +169,9 @@
       min-height: 25px; // make sure the button has default height
     }
 
+    // reducing the font-size to make the alignment of view-details better with other action buttons
     .chaise-view-details {
-      font-size: 1.1em;
+      font-size: 1em;
     }
 
     .disabled {

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -157,11 +157,12 @@
     }
   }
 
-  // Changing the padding for the action button to align with the rest of the columns in the table
+  // Changing the padding and adding line-height for the action button to align with the rest of the columns in the table
   .action-btns {
     text-align: center;
     font-size: 1.2rem;
     padding: 3px 0 0 0;
+    line-height: 1.5;
     .chaise-btn {
       padding: 0;
       margin: -3px;

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -159,32 +159,41 @@
 
   // Changing the padding and adding line-height for the action button to align with the rest of the columns in the table
   .action-btns {
-    $_space-around-buttons: 3px;
+    // the whole row min height is 30px, and buttons are 22px.. so we have to have 4px above and below
+    $_space-around-buttons: 4px;
 
     text-align: center;
     font-size: 1.2rem;
     padding: $_space-around-buttons 0 0 0;
     line-height: 1.5;
 
+    // make sure items stay in the center
+    .action-btns-inner-container {
+      display: flex;
+      align-content: center;
+      justify-content: space-around;
+    }
+
     /**
      * make sure there's similar space below the buttons in the narrow case (when the content is just one line
      * I needed to use three different selectors for our three different modes.
-     * the first one is the default mode, the second is single select and third is multi select
+     * the first one is the default mode, the second is single select, and the last one is for multi-select
      */
     .chaise-btn-group, .chaise-btn.select-action-button, .chaise-checkbox {
       margin-bottom: $_space-around-buttons;
     }
 
-    .chaise-btn {
+    // make the button smaller (only visible for primary buttons. for others won't make a difference in UI and that's fine)
+    .chaise-checkbox, .chaise-btn {
       padding: 0;
-      margin: -3px;
-      height: auto; //override the default button height
-      min-height: 25px; // make sure the button has default height
+      height: 22px;
+      min-width: 22px;
+      width: 22px;
     }
 
-    // reducing the font-size to make the alignment of view-details better with other action buttons
     .chaise-view-details {
-      font-size: 1em;
+      // make the view icon bigger so it looks similar size to the rest of icons
+      font-size: 1.1em;
     }
 
     .disabled {

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -159,10 +159,22 @@
 
   // Changing the padding and adding line-height for the action button to align with the rest of the columns in the table
   .action-btns {
+    $_space-around-buttons: 3px;
+
     text-align: center;
     font-size: 1.2rem;
-    padding: 3px 0 0 0;
+    padding: $_space-around-buttons 0 0 0;
     line-height: 1.5;
+
+    /**
+     * make sure there's similar space below the buttons in the narrow case (when the content is just one line
+     * I needed to use three different selectors for our three different modes.
+     * the first one is the default mode, the second is single select and third is multi select
+     */
+    .chaise-btn-group, .chaise-btn.select-action-button, .chaise-checkbox {
+      margin-bottom: $_space-around-buttons;
+    }
+
     .chaise-btn {
       padding: 0;
       margin: -3px;

--- a/src/assets/scss/_recordset-table.scss
+++ b/src/assets/scss/_recordset-table.scss
@@ -158,10 +158,9 @@
   }
 
   .action-btns {
-    // removing the padding since the table cell already has a padding of 5px
     text-align: center;
     font-size: 1.2rem;
-
+    padding: 5px 0 0 0;
     .chaise-btn {
       padding: 0;
       margin: -3px;
@@ -171,8 +170,6 @@
 
     .chaise-view-details {
       font-size: 1.1em;
-      // giving a height to make it center aligned
-      height: 22px;
     }
 
     .disabled {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -475,8 +475,8 @@ html {
       float: right;
       text-align: right;
 
-      // removing the display property for the chaise-btn display to act on
       & > * {
+        display: inline-block;
         margin-left: 5px;
       }
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -475,6 +475,7 @@ html {
       float: right;
       text-align: right;
 
+      // make sure the buttons show in the same line
       & > * {
         display: inline-block;
         margin-left: 5px;

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -475,9 +475,7 @@ html {
       float: right;
       text-align: right;
 
-      // make sure the buttons show in the same line
       & > * {
-        display: inline-block;
         margin-left: 5px;
       }
 

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -674,7 +674,6 @@ html {
       padding-right: 5px;
       font-weight: 400;
       position: relative;
-      vertical-align: middle;
       min-height: variables.$chaise-checkbox-height;
       margin-bottom: 0;
     }
@@ -683,32 +682,38 @@ html {
     }
 
     input {
+      // turn off the default browser appearance as we're showing the checkmark with :before and :after
+      appearance: none;
+
       position: absolute;
       z-index: map-get(variables.$z-index-map, 'checkbox-input');
       cursor: pointer;
       width: variables.$chaise-checkbox-width;
       height: variables.$chaise-checkbox-height;
       top: 0;
-      margin-top: 2px;
 
       &:disabled {
         cursor: not-allowed;
-        &:before,
-        &:checked:after {
+
+        // we have to attach the checkmark to the label otherwise firefox won't show it.
+        & + label:before,
+        &:checked + label:after {
           color: map-get(variables.$color-map, 'disabled');
           border-color: map-get(variables.$color-map, 'disabled');
         }
       }
 
-      &:before,
-      &:checked:after {
+      // we have to attach the checkmark to the label otherwise firefox won't show it.
+      & + label:before,
+      &:checked + label:after {
         color: map-get(variables.$color-map, 'primary');
         -webkit-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
         -o-transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
         transition: border 0.15s ease-in-out, color 0.15s ease-in-out;
       }
 
-      &:before {
+      // we have to change the the checkmark to the label otherwise firefox won't show it.
+      & + label:before {
         content: "";
         display: inline-block;
         position: absolute;
@@ -721,10 +726,11 @@ html {
         background-color: map-get(variables.$color-map, 'white');
       }
 
-      &:checked:after {
+      // we have to change the the checkmark to the label otherwise firefox won't show it.
+      &:checked + label:after {
         position: absolute;
-        top: -2px;
-        left: 2px;
+        top: -3px;
+        left: 1px;
         font-family: "Font Awesome 6 Free";
         font-weight: 900;
         content: "\f00c"; // fa-solid fa-check

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -475,9 +475,8 @@ html {
       float: right;
       text-align: right;
 
-      // make sure the buttons show in the same line
+      // removing the display property for the chaise-btn display to act on
       & > * {
-        display: inline-block;
         margin-left: 5px;
       }
 

--- a/src/assets/scss/helpers.scss
+++ b/src/assets/scss/helpers.scss
@@ -77,7 +77,6 @@
 @mixin chaise-btn() {
   @include border-radius(variables.$btn-border-radius);
   cursor: pointer;
-  display: inline-block;
   height: variables.$btn-height;
   min-width: variables.$btn-height;
   border: variables.$btn-border-width solid;
@@ -89,6 +88,10 @@
   -moz-user-select: none;
   -ms-user-select: none;
   white-space: nowrap;
+  // ficxing button spacing issue. Fix- center aligning the buttons
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
 }
 
 @mixin chaise-btn-primary() {

--- a/src/assets/scss/helpers.scss
+++ b/src/assets/scss/helpers.scss
@@ -88,10 +88,14 @@
   -moz-user-select: none;
   -ms-user-select: none;
   white-space: nowrap;
-  // ficxing button spacing issue. Fix- center aligning the buttons
-  display: inline-flex !important;
+  /** 
+  * Fixing button spacing issue. Fix- center aligning the buttons. Adding line-height will make the children of button to 
+  * use this property  to override what bootstrap is defining.
+  */
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  line-height: normal;
 }
 
 @mixin chaise-btn-primary() {

--- a/src/components/recordset/table-row.tsx
+++ b/src/components/recordset/table-row.tsx
@@ -526,7 +526,9 @@ const TableRow = ({
       >
         {showActionButtons &&
           <td className={`block action-btns${rowDisabled ? ' disabled-cell' : ''}`}>
-            {renderActionButtons()}
+            <div className='action-btns-inner-container'>
+              {renderActionButtons()}
+            </div>
           </td>
         }
         {renderCells()}


### PR DESCRIPTION
This PR will address [the issue](https://github.com/informatics-isi-edu/chaise/issues/2349)

Summary of changes:

The aim of this PR change is to fix the inconsistency in button spacing issue.

With this PR we have center aligned the buttons using display: 'inline-flex'.

Also for view details action button a height is given and padding is removed to fix the alignment
The deployed version is [here](https://dev.gudmap.org/~povijaya/chaise/record/#2/Common:Collection/RID=14-4KG6)
