### PR TITLE
Change order of assets in webpack config

### DIFF
--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -209,35 +209,40 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
         maxSize: 500000,
         hidePathInfo: true,
         name: 'common',
+        /**
+         * the noted priority is also changing the order of include statements in the output html.
+         * we want to make sure chaise is the last css file that is added, that's why it has the lowest priority.
+         * this was mainly an issue in deriva-webapps where the bootstrap rules were overriding our chaise rules.
+         *
+         * TODO we should come up with a better solution. "priority" property is mainly to make sure a rule has
+         * precedence over another one. so if two rules match the given "test", the one with higher priority wins.
+         * but now we're abusing it to dicatet the order of assets.
+         */
         cacheGroups: {
           // this group is useful for deriva-webapps
           chaiseVendor: {
             test: /[\\/]node_modules[\\/]\@isrd-isi-edu[\\/]chaise[\\/]/,
             name: 'vendor-chaise',
             chunks: 'all',
-            priority: 4
+            priority: 1
           },
           reactVendor: {
             test: /[\\/]node_modules[\\/](react|react-dom|react-bootstrap)[\\/]/,
             name: 'vendor-react',
             chunks: 'all',
-            priority: 3
+            priority: 2
           },
           bootstrapVendor: {
             test: /[\\/]node_modules[\\/]bootstrap[\\/]/,
             name: 'vendor-bootstrap',
             chunks: 'all',
-            priority: 2
+            priority: 3
           },
           vendor: {
-            test: /[\\/]node_modules[\\/]/,
+            test: /[\\/]node_modules[\\/](?!(\@isrd-isi-edu[\\/]chaise|bootstrap|react|react-dom|react-bootstrap)[\\/])/,
             name: 'vendor-rest',
             chunks: 'all',
-            /**
-             * we have to make sure priority of this group is less than the rest
-             * so this rule is used when others failed
-             */
-            priority: 1
+            priority: 4
           }
         },
       },


### PR DESCRIPTION
We recently realized that bootstrap rules are overwriting chaise rules in deriva-webapps. Upon looking at it, I realized that the chaise CSS files were added before the bootstrap ones. 

I always assumed that webpack is going to add CSS files based on the `import` statements that we have. But it seems like the `priority` we've set for the `cacheGroups` is dictating the order. Based on webpack's documentation, the `priority` is to ensure which rules should be prioritized when a given `test` matches multiple. That's why I had the default `node_modules` as the lowest priority.

So, to fix this, I rearranged the priorities and ensured the default `vendor-rest` excludes other rules. This way, the `priority` is just for dictating the order of added asset files and not tie-breaking the rules.

While this fixes the CSS issues, it's also rearranging the JS files, so we have to test all apps to make sure nothing is broken before merging this.