### PR TITLE
Use the new comment API of ermrestjs to allow markdown comments

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout comment-changes
           sudo make root-install
       - name: Install chaise
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,6 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          git checkout comment-changes
           sudo make root-install
       - name: Install chaise
         run: |

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -239,6 +239,12 @@ html {
     // (this is a predefined class in bootstrap)
     text-align: left;
     max-width: none;
+    // honor any whitespace in the tooltips
+    white-space: pre-wrap;
+    // chaise comments could be html and therefore we shouldn't mess with their whitespace rendering
+    .chaise-comment.chaise-comment-html {
+      white-space: normal;
+    }
   }
   .tooltip code,
   .tooltip-inner code {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -239,7 +239,6 @@ html {
     // (this is a predefined class in bootstrap)
     text-align: left;
     max-width: none;
-    white-space: pre-wrap;
   }
   .tooltip code,
   .tooltip-inner code {

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -241,8 +241,8 @@ html {
     max-width: none;
     // honor any whitespace in the tooltips
     white-space: pre-wrap;
-    // chaise comments could be html and therefore we shouldn't mess with their whitespace rendering
-    .chaise-comment.chaise-comment-html {
+    // when html content is displayed, we shouldn't mess with the whitespace rendering
+    .markdown-container {
       white-space: normal;
     }
   }

--- a/src/components/display-comment-value.tsx
+++ b/src/components/display-comment-value.tsx
@@ -1,0 +1,28 @@
+// components
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+
+// models
+import { CommentType } from '@isrd-isi-edu/chaise/src/models/displayname';
+
+// utils
+import { CLASS_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
+
+type DisplayCommentValueProps = {
+  comment: CommentType
+};
+
+/**
+ * should be used for showing the .comment API coming rom the Reference API of ERMrest
+ */
+const DisplayCommentValue = ({ comment }: DisplayCommentValueProps): JSX.Element => {
+  if (!comment) {
+    return <></>;
+  }
+
+  const className = [CLASS_NAMES.COMMENT];
+  if (comment && comment.isHTML) className.push(CLASS_NAMES.COMMENT_IS_HTML);
+
+  return <DisplayValue value={comment} addClass={comment.isHTML} className={className.join(' ')} />
+};
+
+export default DisplayCommentValue;

--- a/src/components/display-value.tsx
+++ b/src/components/display-value.tsx
@@ -1,8 +1,9 @@
-// components
-import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
-
 // hooks
 import { useEffect, useRef } from 'react';
+
+// models
+import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
+
 
 // utils
 import { DEFAULT_DISPLAYNAME } from '@isrd-isi-edu/chaise/src/utils/constants';

--- a/src/components/faceting/facet-header.tsx
+++ b/src/components/faceting/facet-header.tsx
@@ -7,7 +7,7 @@ import Spinner from 'react-bootstrap/Spinner';
 import { useRef, useState } from 'react';
 
 // models
-import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
+import { CommentType, Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 type FacetHeaderProps = {
   /**
@@ -21,7 +21,7 @@ type FacetHeaderProps = {
   /**
    * Optional text to be shown on hover of displayname
    */
-  comment?: string;
+  comment?: CommentType;
   /**
    * whether we should show the spinner or not
    */
@@ -74,9 +74,9 @@ const FacetHeader = ({
    */
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && comment) {
-      return <><DisplayValue value={displayname} />: {comment}</>;
+      return <><DisplayValue value={displayname} />: <DisplayValue addClass value={comment} /></>;
     } else if (comment) {
-      return comment;
+      return <DisplayValue addClass value={comment} />;
     } else {
       return <DisplayValue value={displayname} />;
     }

--- a/src/components/faceting/facet-header.tsx
+++ b/src/components/faceting/facet-header.tsx
@@ -1,5 +1,6 @@
 // Components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import Spinner from 'react-bootstrap/Spinner';
 
@@ -74,9 +75,9 @@ const FacetHeader = ({
    */
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && comment) {
-      return <><DisplayValue value={displayname} />: <DisplayValue addClass value={comment} /></>;
+      return <><DisplayValue value={displayname} />: <DisplayCommentValue comment={comment} /></>;
     } else if (comment) {
-      return <DisplayValue addClass value={comment} />;
+      return <DisplayCommentValue comment={comment} />;
     } else {
       return <DisplayValue value={displayname} />;
     }

--- a/src/components/modals/recordset-modal.tsx
+++ b/src/components/modals/recordset-modal.tsx
@@ -14,7 +14,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { RecordsetDisplayMode, RecordsetSelectMode, SelectedRow } from '@isrd-isi-edu/chaise/src/models/recordset';
 import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
 import { RecordsetProps } from '@isrd-isi-edu/chaise/src/models/recordset';
-import { Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
+import { CommentType, Displayname } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 // services
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
@@ -42,7 +42,7 @@ export type RecordestModalProps = {
   /**
    * The comment used for the title
    */
-  comment?: string,
+  comment?: CommentType,
   /**
    * The function that will be called on each row change.
    * NOTE The actual callback that we're sending to recordset is not this one,

--- a/src/components/record/record-main-section.tsx
+++ b/src/components/record/record-main-section.tsx
@@ -14,13 +14,13 @@ import useError from '@isrd-isi-edu/chaise/src/hooks/error';
 
 // models
 import { RecordColumnModel } from '@isrd-isi-edu/chaise/src/models/record';
+import { CommentDisplayModes } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 // utils
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { canShowInlineRelated } from '@isrd-isi-edu/chaise/src/utils/record-utils';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { CLASS_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
-
 
 /**
  * Returns Main Section of the record page.
@@ -56,7 +56,7 @@ const RecordMainSection = (): JSX.Element => {
     const hideAllHeaders = reference.display.hideColumnHeaders;
     return columnModels.map((cm: RecordColumnModel, index: number) => {
       const hideHeader = hideAllHeaders || cm.column.hideColumnHeader;
-      const hasTooltip = !!cm.column.comment && cm.column.commentDisplay === 'tooltip';
+      const hasTooltip = !!cm.column.comment && cm.column.comment.displayMode === CommentDisplayModes.TOOLTIP;
       const hasError = showError(cm);
       const hasInitialized = !!cm.relatedModel && cm.relatedModel.tableMarkdownContentInitialized &&
         cm.relatedModel.recordsetState.isInitialized;
@@ -98,7 +98,7 @@ const RecordMainSection = (): JSX.Element => {
           {/* --------- entity key ---------- */}
           <td className={entityKeyClassName.join(' ')}>
             {hasTooltip ?
-              <ChaiseTooltip placement='right' tooltip={cm.column.comment}>
+              <ChaiseTooltip placement='right' tooltip={<DisplayValue addClass value={cm.column.comment} />}>
                 {columnDisplayname}
               </ChaiseTooltip> : columnDisplayname
             }
@@ -118,8 +118,8 @@ const RecordMainSection = (): JSX.Element => {
               <span id={`entity-${cm.index}-table`}>
                 {!hasError && <RelatedTableActions relatedModel={cm.relatedModel} />}
                 <div className={`inline-table-display ${hasError || !hasInitialized ? CLASS_NAMES.HIDDEN : ''}`}>
-                  {cm.column.commentDisplay === 'inline' && cm.column.comment &&
-                    <div className='inline-tooltip'>{cm.column.comment}</div>
+                  {cm.column.comment && cm.column.comment.displayMode === CommentDisplayModes.INLINE &&
+                    <div className='inline-tooltip'><DisplayValue addClass value={cm.column.comment} /></div>
                   }
                   <RelatedTable
                     relatedModel={cm.relatedModel}

--- a/src/components/record/record-main-section.tsx
+++ b/src/components/record/record-main-section.tsx
@@ -2,6 +2,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_record-main-section.scss';
 
 // components
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import RelatedTableActions from '@isrd-isi-edu/chaise/src/components/record/related-table-actions';
 import RelatedTable from '@isrd-isi-edu/chaise/src/components/record/related-table';
@@ -98,7 +99,7 @@ const RecordMainSection = (): JSX.Element => {
           {/* --------- entity key ---------- */}
           <td className={entityKeyClassName.join(' ')}>
             {hasTooltip ?
-              <ChaiseTooltip placement='right' tooltip={<DisplayValue addClass value={cm.column.comment} />}>
+              <ChaiseTooltip placement='right' tooltip={<DisplayCommentValue comment={cm.column.comment} />}>
                 {columnDisplayname}
               </ChaiseTooltip> : columnDisplayname
             }
@@ -112,14 +113,14 @@ const RecordMainSection = (): JSX.Element => {
             id={`entity-${idSafeDisplayname}`}
           >
             {!cm.relatedModel && !hasError &&
-              <DisplayValue addClass={true} value={recordValues[cm.index]} />
+              <DisplayValue addClass value={recordValues[cm.index]} />
             }
             {cm.relatedModel &&
               <span id={`entity-${cm.index}-table`}>
                 {!hasError && <RelatedTableActions relatedModel={cm.relatedModel} />}
                 <div className={`inline-table-display ${hasError || !hasInitialized ? CLASS_NAMES.HIDDEN : ''}`}>
                   {cm.column.comment && cm.column.comment.displayMode === CommentDisplayModes.INLINE &&
-                    <div className='inline-tooltip'><DisplayValue addClass value={cm.column.comment} /></div>
+                    <div className='inline-tooltip'><DisplayCommentValue comment={cm.column.comment} /></div>
                   }
                   <RelatedTable
                     relatedModel={cm.relatedModel}

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -9,9 +9,7 @@ import { useRef, useState } from 'react';
 
 // models
 import { RecordRelatedModel } from '@isrd-isi-edu/chaise/src/models/record';
-
-// services
-import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
+import { CommentDisplayModes } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 // utils
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
@@ -41,19 +39,20 @@ const RelatedTableHeader = ({ relatedModel }: RelatedTableHeaderProps): JSX.Elem
   };
 
   const usedRef = relatedModel.initialReference;
-  const hasTooltip = usedRef.comment && usedRef.commentDisplay === 'tooltip';
+  const hasTooltip = usedRef.comment && usedRef.comment.displayMode === CommentDisplayModes.TOOLTIP;
 
   const renderedDisplayname = <DisplayValue value={usedRef.displayname} />;
+  const renderedTooltip = hasTooltip ? <DisplayValue addClass value={usedRef.comment} /> : <></>;
 
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && hasTooltip) {
       return (
         <>
-          {renderedDisplayname}: {usedRef.comment}
+          {renderedDisplayname}: renderedTooltip
         </>
       );
     } else if (hasTooltip) {
-      return usedRef.comment;
+      return renderedTooltip;
     } else {
       return renderedDisplayname;
     }

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -48,7 +48,7 @@ const RelatedTableHeader = ({ relatedModel }: RelatedTableHeaderProps): JSX.Elem
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && hasTooltip) {
       return (
         <>
-          {renderedDisplayname}: renderedTooltip
+          {renderedDisplayname}: {renderedTooltip}
         </>
       );
     } else if (hasTooltip) {

--- a/src/components/record/related-table-header.tsx
+++ b/src/components/record/related-table-header.tsx
@@ -1,5 +1,6 @@
 // components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import RelatedTableActions from '@isrd-isi-edu/chaise/src/components/record/related-table-actions';
 import Spinner from 'react-bootstrap/Spinner';
@@ -42,7 +43,7 @@ const RelatedTableHeader = ({ relatedModel }: RelatedTableHeaderProps): JSX.Elem
   const hasTooltip = usedRef.comment && usedRef.comment.displayMode === CommentDisplayModes.TOOLTIP;
 
   const renderedDisplayname = <DisplayValue value={usedRef.displayname} />;
-  const renderedTooltip = hasTooltip ? <DisplayValue addClass value={usedRef.comment} /> : <></>;
+  const renderedTooltip = hasTooltip ? <DisplayCommentValue comment={usedRef.comment} /> : <></>;
 
   const renderTooltipContent = () => {
     if (contentRef && contentRef.current && isTextOverflow(contentRef.current) && hasTooltip) {

--- a/src/components/record/related-table.tsx
+++ b/src/components/record/related-table.tsx
@@ -11,6 +11,7 @@ import useRecord from '@isrd-isi-edu/chaise/src/hooks/record';
 
 // models
 import { RecordRelatedModel } from '@isrd-isi-edu/chaise/src/models/record';
+import { CommentDisplayModes } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 // providers
 import RecordsetProvider from '@isrd-isi-edu/chaise/src/providers/recordset';
@@ -85,8 +86,8 @@ const RelatedTableInner = ({
   return (
     <div>
       {/* in case of inline, the comments are already handled */}
-      {!relatedModel.isInline && usedRef.commentDisplay === 'inline' && usedRef.comment &&
-        <div className='inline-tooltip'>{usedRef.comment}</div>
+      {!relatedModel.isInline && usedRef.comment && usedRef.comment.displayMode === CommentDisplayModes.INLINE &&
+        <div className='inline-tooltip'><DisplayValue addClass value={usedRef.comment} /></div>
       }
       {displayCustomMode &&
         <>

--- a/src/components/record/related-table.tsx
+++ b/src/components/record/related-table.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import RecordsetTable from '@isrd-isi-edu/chaise/src/components/recordset/recordset-table';
 import TableHeader from '@isrd-isi-edu/chaise/src/components/recordset/table-header';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 
 // hooks
 import useRecordset from '@isrd-isi-edu/chaise/src/hooks/recordset';
@@ -87,7 +88,7 @@ const RelatedTableInner = ({
     <div>
       {/* in case of inline, the comments are already handled */}
       {!relatedModel.isInline && usedRef.comment && usedRef.comment.displayMode === CommentDisplayModes.INLINE &&
-        <div className='inline-tooltip'><DisplayValue addClass value={usedRef.comment} /></div>
+        <div className='inline-tooltip'><DisplayCommentValue comment={usedRef.comment} /></div>
       }
       {displayCustomMode &&
         <>

--- a/src/components/record/related-table.tsx
+++ b/src/components/record/related-table.tsx
@@ -99,7 +99,7 @@ const RelatedTableInner = ({
           }
         </>
       }
-      <div className={`related-table-content ${displayCustomMode ? CLASS_NAMES.HIDDEN : ''}`}>
+      <div className={`related-table-content${displayCustomMode ? (' ' + CLASS_NAMES.HIDDEN) : ''}`}>
         <TableHeader config={relatedModel.recordsetProps.config}></TableHeader>
         <div id={tableContainerID}>
           <RecordsetTable

--- a/src/components/recordedit/key-column.tsx
+++ b/src/components/recordedit/key-column.tsx
@@ -1,6 +1,7 @@
 // components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 
 // hooks
 import useRecordedit from '@isrd-isi-edu/chaise/src/hooks/recordedit';
@@ -114,7 +115,7 @@ const KeyColumn = (): JSX.Element => {
             {column.comment ?
               <ChaiseTooltip
                 placement='right'
-                tooltip={<DisplayValue addClass value={column.comment} />}
+                tooltip={<DisplayCommentValue comment={column.comment} />}
               >
                 {renderColumnHeader(column)}
               </ChaiseTooltip> :

--- a/src/components/recordedit/key-column.tsx
+++ b/src/components/recordedit/key-column.tsx
@@ -114,7 +114,7 @@ const KeyColumn = (): JSX.Element => {
             {column.comment ?
               <ChaiseTooltip
                 placement='right'
-                tooltip={column.comment}
+                tooltip={<DisplayValue addClass value={column.comment} />}
               >
                 {renderColumnHeader(column)}
               </ChaiseTooltip> :

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -298,12 +298,12 @@ const RecordeditInner = ({
     }
   }, [formProviderInitialized]);
 
-  /** 
+  /**
    * This useEffect triggers when addFormsEffect is set to true when "clone" is clicked
    * this allows for showCloneSpinner state variable to change separately from callAddForm (which changes the total # of forms)
-   * when showCloneSpinner is changed there is a repaint of the DOM before this useEffect triggers, 
+   * when showCloneSpinner is changed there is a repaint of the DOM before this useEffect triggers,
    *    which shows the spinner before triggering the addForms logic (which can be slow when many forms are added at once)
-   */ 
+   */
   useEffect(() => {
     if (!addFormsEffect) return;
 
@@ -409,7 +409,6 @@ const RecordeditInner = ({
 
       return (<>
         <span>{count} </span>
-        {/* NOTE in Angularjs, in edit mode the link was based on the original link, both now it's always unfiltered */}
         <Title addLink reference={reference}
           link={appMode === appModes.EDIT ? reference.unfilteredReference.contextualize.compact.appLink : undefined} />
         <span> {recordTxt} {appMode === appModes.EDIT ? 'updated' : 'created'} successfully</span>

--- a/src/components/recordedit/viewer-annotation-form-container.tsx
+++ b/src/components/recordedit/viewer-annotation-form-container.tsx
@@ -1,7 +1,8 @@
 // components
-import InputSwitch from '@isrd-isi-edu/chaise/src/components/input-switch/input-switch';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
+import InputSwitch from '@isrd-isi-edu/chaise/src/components/input-switch/input-switch';
 
 // hooks
 import { useFormContext } from 'react-hook-form';
@@ -110,7 +111,7 @@ const ViewerAnnotationFormContainer = (): JSX.Element => {
             {cm.column.comment ?
               <ChaiseTooltip
                 placement='right'
-                tooltip={<DisplayValue addClass value={cm.column.comment} />}
+                tooltip={<DisplayCommentValue comment={cm.column.comment} />}
               >
                 {renderColumnHeader(cm.column)}
               </ChaiseTooltip> :

--- a/src/components/recordedit/viewer-annotation-form-container.tsx
+++ b/src/components/recordedit/viewer-annotation-form-container.tsx
@@ -110,7 +110,7 @@ const ViewerAnnotationFormContainer = (): JSX.Element => {
             {cm.column.comment ?
               <ChaiseTooltip
                 placement='right'
-                tooltip={cm.column.comment}
+                tooltip={<DisplayValue addClass value={cm.column.comment} />}
               >
                 {renderColumnHeader(cm.column)}
               </ChaiseTooltip> :

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -51,7 +51,7 @@ const RecordsetTable = ({
     Array.isArray(initialSortObject) ? initialSortObject[0] : null
   );
 
-  const [ showAllRows, setShowAllRows ] = useState(!(config.maxDisplayedRows && config.maxDisplayedRows > 0));
+  const [showAllRows, setShowAllRows] = useState(!(config.maxDisplayedRows && config.maxDisplayedRows > 0));
 
   /**
    * capture the state of selected and disabled of rows in here so
@@ -253,7 +253,7 @@ const RecordsetTable = ({
         break;
     }
     return (
-      <th className={`actions-header${headerClassName ? ` ${headerClassName}`: ''}`}>{inner}</th>
+      <th className={`actions-header${headerClassName ? ` ${headerClassName}` : ''}`}>{inner}</th>
     )
   }
 
@@ -291,7 +291,7 @@ const RecordsetTable = ({
             // if comment, show tooltip
             <ChaiseTooltip
               placement='top'
-              tooltip={col.column.comment}
+              tooltip={<DisplayValue addClass value={col.column.comment} />}
             >
               {renderDisplayValue(col.column)}
             </ChaiseTooltip> :
@@ -330,7 +330,7 @@ const RecordsetTable = ({
                 placement='bottom'
                 tooltip={MESSAGE_MAP.queryTimeoutTooltip}
               >
-                <span className='fa-solid fa-triangle-exclamation' style={{paddingLeft: '4px'}} />
+                <span className='fa-solid fa-triangle-exclamation' style={{ paddingLeft: '4px' }} />
               </ChaiseTooltip>
             </span>
           </td>

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -2,10 +2,11 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_recordset-table.scss';
 import React from 'react';
 
 // components
-import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
-import TableRow from '@isrd-isi-edu/chaise/src/components/recordset/table-row';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import Spinner from 'react-bootstrap/Spinner';
+import TableRow from '@isrd-isi-edu/chaise/src/components/recordset/table-row';
 
 // hooks
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
@@ -291,7 +292,7 @@ const RecordsetTable = ({
             // if comment, show tooltip
             <ChaiseTooltip
               placement='top'
-              tooltip={<DisplayValue addClass value={col.column.comment} />}
+              tooltip={<DisplayCommentValue comment={col.column.comment} />}
             >
               {renderDisplayValue(col.column)}
             </ChaiseTooltip> :

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -867,8 +867,8 @@ const RecordsetInner = ({
                       <small className='h3-class'>({versionInfo.humanized})</small>
                     </ChaiseTooltip>
                   }
-                  {reference.commentDisplay === 'inline' && reference.comment &&
-                    <span className='inline-tooltip'>{reference.comment}</span>
+                  {reference.comment && reference.comment.displayMode === 'inline' &&
+                    <span className='inline-tooltip'><DisplayValue addClass value={reference.comment} /></span>
                   }
                 </h1>
               </div>

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -25,6 +25,7 @@ import useRecordset from '@isrd-isi-edu/chaise/src/hooks/recordset';
 // models
 import { LogActions, LogReloadCauses, LogStackPaths, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
 import { RecordsetProps, RecordsetConfig, RecordsetDisplayMode, RecordsetSelectMode, SelectedRow } from '@isrd-isi-edu/chaise/src/models/recordset';
+import { CommentDisplayModes } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 // providers
 import AlertsProvider from '@isrd-isi-edu/chaise/src/providers/alerts';
@@ -867,7 +868,7 @@ const RecordsetInner = ({
                       <small className='h3-class'>({versionInfo.humanized})</small>
                     </ChaiseTooltip>
                   }
-                  {reference.comment && reference.comment.displayMode === 'inline' &&
+                  {reference.comment && reference.comment.displayMode === CommentDisplayModes.INLINE &&
                     <span className='inline-tooltip'><DisplayValue addClass value={reference.comment} /></span>
                   }
                 </h1>

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -4,6 +4,7 @@ import '@isrd-isi-edu/chaise/src/assets/scss/_recordset.scss';
 import Alerts from '@isrd-isi-edu/chaise/src/components/alerts';
 import ChaiseSpinner from '@isrd-isi-edu/chaise/src/components/spinner';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import Export from '@isrd-isi-edu/chaise/src/components/export';
 import Faceting from '@isrd-isi-edu/chaise/src/components/faceting/faceting';
@@ -869,7 +870,7 @@ const RecordsetInner = ({
                     </ChaiseTooltip>
                   }
                   {reference.comment && reference.comment.displayMode === CommentDisplayModes.INLINE &&
-                    <span className='inline-tooltip'><DisplayValue addClass value={reference.comment} /></span>
+                    <span className='inline-tooltip'><DisplayCommentValue comment={reference.comment} /></span>
                   }
                 </h1>
               </div>

--- a/src/components/search-input.tsx
+++ b/src/components/search-input.tsx
@@ -213,12 +213,12 @@ const SearchInput = ({
           <ChaiseTooltip
             placement='bottom-start'
             tooltip={
-              <>
+              <span className='markdown-container'>
                 <p>Use space to separate between conjunctive terms, | (no spaces) to separate disjunctive terms and quotations for exact phrases.</p>
                 <p>For example, <i><b>usc 1234</b></i> returns all records containing &ldquo;usc&rdquo; and &ldquo;1234&rdquo;.</p>
                 <p><i><b>usc|1234</b></i> returns all records containing &ldquo;usc&rdquo; or &ldquo;1234&rdquo;.</p>
                 <p><i><b>&ldquo;usc 1234&rdquo;</b></i> returns all records containing &ldquo;usc 1234&rdquo;.</p>
-              </>
+              </span>
             }
           >
             <button

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -60,7 +60,7 @@ const Title = ({
       displayname = reference.displayname;
     }
 
-    if (!comment && reference.comment) {
+    if (comment !== false && !comment && reference.comment) {
       comment = reference.comment;
     }
 

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -1,6 +1,7 @@
 // components
-import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
+import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 
 // models
 import { CommentDisplayModes, CommentType, Displayname as DisplaynameType } from '@isrd-isi-edu/chaise/src/models/displayname';
@@ -85,7 +86,7 @@ const Title = ({
     return (
       <ChaiseTooltip
         placement='bottom-start'
-        tooltip={<DisplayValue addClass value={comment} />}
+        tooltip={<DisplayCommentValue comment={comment} />}
       >
         {renderLinkOrContainer()}
       </ChaiseTooltip>

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -3,7 +3,7 @@ import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 
 // models
-import { Displayname as DisplaynameType } from '@isrd-isi-edu/chaise/src/models/displayname';
+import { CommentDisplayModes, CommentType, Displayname as DisplaynameType } from '@isrd-isi-edu/chaise/src/models/displayname';
 
 
 
@@ -21,7 +21,7 @@ type TitleProps = {
    * if defined, we will use this instead of getting it from the reference
    * - use `false` to suppress adding the comment
    */
-  comment?: string | false,
+  comment?: CommentType,
   /**
    * whether we should add a link or not.
    * - if `link` is passed, we will add the link regardless of this property.
@@ -51,7 +51,7 @@ const Title = ({
   if (typeof link === 'string') {
     addLink = true;
   }
-  else if (reference){
+  else if (reference) {
     link = reference.unfilteredReference.contextualize.compact.appLink;
   }
 
@@ -60,13 +60,12 @@ const Title = ({
       displayname = reference.displayname;
     }
 
-    if (comment !== false && !comment && reference.comment) {
+    if (!comment && reference.comment) {
       comment = reference.comment;
     }
 
-    showTooltip = reference.commentDisplay === 'tooltip' && (comment || reference.comment);
+    showTooltip = comment || (reference.comment && reference.comment.displayMode === CommentDisplayModes.TOOLTIP);
   }
-
 
   const renderDisplayname = <DisplayValue value={displayname} />;
 
@@ -86,7 +85,7 @@ const Title = ({
     return (
       <ChaiseTooltip
         placement='bottom-start'
-        tooltip={comment}
+        tooltip={<DisplayValue addClass value={comment} />}
       >
         {renderLinkOrContainer()}
       </ChaiseTooltip>

--- a/src/models/displayname.ts
+++ b/src/models/displayname.ts
@@ -9,7 +9,7 @@ export type CommentType = {
   isHTML: boolean,
   unformatted?: string,
   displayMode: CommentDisplayModes
-} | null;
+} | false | null;
 
 export enum CommentDisplayModes {
   INLINE = 'inline',

--- a/src/models/displayname.ts
+++ b/src/models/displayname.ts
@@ -3,3 +3,15 @@ export type Displayname = {
   isHTML: boolean,
   unformatted?: string
 };
+
+export type CommentType = {
+  value: string,
+  isHTML: boolean,
+  unformatted?: string,
+  displayMode: CommentDisplayModes
+} | null;
+
+export enum CommentDisplayModes {
+  INLINE = 'inline',
+  TOOLTIP = 'tooltip'
+}

--- a/src/models/displayname.ts
+++ b/src/models/displayname.ts
@@ -4,6 +4,9 @@ export type Displayname = {
   unformatted?: string
 };
 
+/**
+ * what the comment coming from ermrestjs might look like
+ */
 export type CommentType = {
   value: string,
   isHTML: boolean,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -163,7 +163,9 @@ export const APP_NAMES = {
 export const CLASS_NAMES = {
   HIDDEN: 'forced-hidden',
   IMAGE_PREVIEW: 'chaise-image-preview',
-  IMAGE_PREVIEW_ZOOMED_IN: 'zoomed-in'
+  IMAGE_PREVIEW_ZOOMED_IN: 'zoomed-in',
+  COMMENT: 'chaise-comment',
+  COMMENT_IS_HTML: 'chaise-comment-html'
 };
 
 export const ID_NAMES = {

--- a/test/e2e/data_setup/schema/product-navbar.json
+++ b/test/e2e/data_setup/schema/product-navbar.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/product-search.json
+++ b/test/e2e/data_setup/schema/product-search.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/product.json
+++ b/test/e2e/data_setup/schema/product.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/record/product-create-btn.json
+++ b/test/e2e/data_setup/schema/record/product-create-btn.json
@@ -150,7 +150,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/record/product-delete-btn.json
+++ b/test/e2e/data_setup/schema/record/product-delete-btn.json
@@ -150,7 +150,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/record/product-edit-btn.json
+++ b/test/e2e/data_setup/schema/record/product-edit-btn.json
@@ -150,7 +150,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/record/product-max-RT.json
+++ b/test/e2e/data_setup/schema/record/product-max-RT.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
+++ b/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
@@ -431,7 +431,9 @@
                                 "template_engine": "handlebars",
                                 "wait_for": ["entity_set_accommodation_inbound2"],
                                 "markdown_pattern": "{{#each $self}}{{{this.rowName}}}{{#unless @last}}, {{/unless}}{{/each}} ({{#each entity_set_accommodation_inbound2}}{{{this.rowName}}}{{#unless @last}}, {{/unless}}{{/each}})"
-                            }
+                            },
+                            "comment": "related table, has waitfor entityset and markdown_pattern (has markdown comment)",
+                            "comment_display": "inline"
                         },
                         {
                             "sourcekey": "entity_set_accommodation_inbound3",
@@ -457,7 +459,8 @@
                                 "RID"
                             ],
                             "markdown_name": "inbound related with filter on main table",
-                            "comment": "inbound related, filter on main"
+                            "comment": "inbound related, filter on main (comment _markdown_ is turned off)",
+                            "comment_render_markdown": false
                         },
                         {
                             "source": [

--- a/test/e2e/data_setup/schema/record/product.json
+++ b/test/e2e/data_setup/schema/record/product.json
@@ -159,7 +159,7 @@
                     }
                 },
                 {
-                    "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+                    "comment": "Type of accommodation (Resort, Hotel, or Motel)",
                     "name": "category",
                     "default": null,
                     "nullok": false,
@@ -175,7 +175,8 @@
                             "2"
                         ],
                         "tag:misd.isi.edu,2015:display": {
-                            "name": "Category"
+                            "name": "Category",
+                            "comment": "can support _markdown_"
                         }
                     }
                 },
@@ -1312,7 +1313,7 @@
                     }
                 },
                 {
-                    "comment": "Type of accommodation_collection ('Resort/Hotel/Motel')",
+                    "comment": "Type of accommodation_collection (Resort/Hotel/Motel)",
                     "name": "category",
                     "default": null,
                     "nullok": false,

--- a/test/e2e/data_setup/schema/recordedit/product-add.json
+++ b/test/e2e/data_setup/schema/recordedit/product-add.json
@@ -146,7 +146,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/recordedit/product-delete.json
+++ b/test/e2e/data_setup/schema/recordedit/product-delete.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/recordedit/product-edit.json
+++ b/test/e2e/data_setup/schema/recordedit/product-edit.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,
@@ -168,7 +168,16 @@
               "2"
             ],
             "tag:misd.isi.edu,2015:display": {
-              "name": "Category"
+              "name": "Category",
+              "comment": {
+                "*": "some other comment",
+                "entry": "_markdown_ comment can be turned off"
+              },
+              "comment_display": {
+                "*": {
+                  "comment_render_markdown": false
+                }
+              }
             }
           }
         },

--- a/test/e2e/data_setup/schema/recordedit/product-no-serial.json
+++ b/test/e2e/data_setup/schema/recordedit/product-no-serial.json
@@ -150,7 +150,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/recordedit/product-person.json
+++ b/test/e2e/data_setup/schema/recordedit/product-person.json
@@ -188,7 +188,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": true,

--- a/test/e2e/data_setup/schema/recordset/product-add.json
+++ b/test/e2e/data_setup/schema/recordset/product-add.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/data_setup/schema/recordset/product-recordset.json
+++ b/test/e2e/data_setup/schema/recordset/product-recordset.json
@@ -1057,7 +1057,7 @@
       }
     },
     "facilities": {
-      "comment": "Type of facilities ('Luxury/Upscale/Basic')",
+      "comment": "Type of facilities (Luxury/Upscale/Basic)",
       "kind": "table",
       "keys": [
         {

--- a/test/e2e/data_setup/schema/recordset/product-recordset.json
+++ b/test/e2e/data_setup/schema/recordset/product-recordset.json
@@ -152,7 +152,7 @@
           }
         },
         {
-          "comment": "Type of accommodation ('Resort/Hotel/Motel')",
+          "comment": "Type of accommodation (Resort, Hotel, or Motel)",
           "name": "category",
           "default": null,
           "nullok": false,

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -52,7 +52,7 @@ var testParams = {
         { title: "Id", value: "2002", type: "serial4"},
         { title: "Name of Accommodation", value: "Sherathon Hotel, accommodation_inbound3 one| accommodation_inbound3 three| accommodation_inbound3 five", type: "text"},
         { title: "Website", value: "<p><a href=\"http://www.starwoodhotels.com/sheraton/index.html\" class=\"external-link-icon\">Link to Website</a></p>\n", type: "text", comment: "A valid url of the accommodation", match:"html" },
-        { title: "Category", value: "Hotel", type: "text", comment: "Type of accommodation ('Resort/Hotel/Motel')", presentation: { type:"url", template: "{{{chaise_url}}}/record/#{{catalog_id}}/product-record:category/", table_name: "category", key_value: [{column: "id", value: "10003"}]} },
+        { title: "Category", value: "Hotel", type: "text", comment: "can support markdown", presentation: { type:"url", template: "{{{chaise_url}}}/record/#{{catalog_id}}/product-record:category/", table_name: "category", key_value: [{column: "id", value: "10003"}]} },
         { title: "booking", value:'<p><strong class="vocab">2</strong> <strong class="vocab">350.0000</strong> <strong class="vocab">2016-04-18 00:00:00</strong> <strong class="vocab">4</strong> <strong class="vocab">200.0000</strong> <strong class="vocab">2016-05-31 00:00:00</strong></p>\n', type: "inline" },
         { title: "User Rating", value: "4.3000", type: "float4", markdown_title: "<strong>User Rating</strong>" },
         { title: "Summary", value: "Sherathon Hotels is an international hotel company with more than 990 locations in 73 countries. The first Radisson Hotel was built in 1909 in Minneapolis, Minnesota, US. It is named after the 17th-century French explorer Pierre-Esprit Radisson.", type: "longtext"},
@@ -336,9 +336,9 @@ describe('View existing record,', function() {
                 tableNames.forEach(function (tableName, idx) {
                     tableName.getText().then(function (name) {
                         expect(name.replace(/ +/g, " ")).toEqual(testParams.sidePanelTest.sidePanelTableOrder[idx], "Order is not maintained for related tables in the side panel");
-                    }); 
+                    });
                 })
-                
+
                 done();
             }).catch( function(err) {
                 console.log(err);

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.spec.js
@@ -18,7 +18,7 @@ var testParams = {
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
             { name: "title", title: "Name of Accommodation", type: "text", nullok: false},
             { name: "website", title: "Website", type: "text", comment: "A valid url of the accommodation"},
-            { name: "category", title: "Category", type: "text", nullok: false, isForeignKey: true,  count: 5, totalCount: 5, comment: "Type of accommodation ('Resort/Hotel/Motel')"}, // the total count is the total number of rows in the category.json data file
+            { name: "category", title: "Category", type: "text", nullok: false, isForeignKey: true,  count: 5, totalCount: 5, comment: "Type of accommodation (Resort, Hotel, or Motel)"}, // the total count is the total number of rows in the category.json data file
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", type: "longtext", nullok: false},
             { name: "description", title: "Description", type: "markdown"},

--- a/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordedit/edit.spec.js
@@ -23,7 +23,7 @@ var testParams = {
             { name: "id", generated: true, immutable: true, title: "Id", type: "serial4", nullok: false},
             { name: "title", title: "<strong>Name of Accommodation</strong>", type: "text", nullok: false},
             { name: "website", title: "Website", type: "text", comment: "A valid url of the accommodation"},
-            { name: "category",  title: "Category", type: "text", isForeignKey: true, count: 5, totalCount: 5, comment: "Type of accommodation ('Resort/Hotel/Motel')", nullok: false}, // the total count is the total number of rows in the category.json data file
+            { name: "category",  title: "Category", type: "text", isForeignKey: true, count: 5, totalCount: 5, comment: "_markdown_ comment can be turned off", nullok: false}, // the total count is the total number of rows in the category.json data file
             { name: "rating", title: "User Rating", type: "float4", nullok: false},
             { name: "summary", title: "Summary", nullok: false, type: "longtext"},
             { name: "description", title: "Description", type: "markdown"},

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -26,7 +26,7 @@ var testParams = {
             { title: "no_of_beds", comment: "test all-outbound + waitfor for normal columns" },
             { title: "no_of_baths", comment: "wait_for normal columns on multiple aggregates" },
             { title: "Category", comment: "Type of accommodation (Resort, Hotel, or Motel)" },
-            { title: "Type of Facilities", comment: "Type of facilities ('Luxury/Upscale/Basic')" },
+            { title: "Type of Facilities", comment: "Type of facilities (Luxury/Upscale/Basic)" },
             { title: "Image Count", comment: "Image Count" },
             { title: "Image Distinct Count", comment: "Image Distinct Count" },
             { title: "Min Image ID", comment: "Min Image ID" },

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -25,7 +25,7 @@ var testParams = {
             { title: "json_col_with_markdown" },
             { title: "no_of_beds", comment: "test all-outbound + waitfor for normal columns" },
             { title: "no_of_baths", comment: "wait_for normal columns on multiple aggregates" },
-            { title: "Category", comment: "Type of accommodation ('Resort/Hotel/Motel')" },
+            { title: "Category", comment: "Type of accommodation (Resort, Hotel, or Motel)" },
             { title: "Type of Facilities", comment: "Type of facilities ('Luxury/Upscale/Basic')" },
             { title: "Image Count", comment: "Image Count" },
             { title: "Image Distinct Count", comment: "Image Distinct Count" },

--- a/test/e2e/specs/all-features/record/related-table.spec.js
+++ b/test/e2e/specs/all-features/record/related-table.spec.js
@@ -433,7 +433,8 @@ describe ("Viewing exisiting record with related entities, ", function () {
     });
 
     var related_w_entityset_waitfor = {
-        comment: "related table, has waitfor entityset and markdown_pattern",
+        comment: "related table, has waitfor entityset and markdown_pattern (has markdown comment)",
+        inlineComment: true,
         schemaName: "product-unordered-related-tables-links",
         displayname: "inbound related with display.wait_for entityset",
         name: "accommodation_inbound1",
@@ -471,7 +472,8 @@ describe ("Viewing exisiting record with related entities, ", function () {
     // since they are basically the same path with just added filters
     describe("regarding usage of filter in source", function () {
         var related_w_filter_on_main = {
-          comment: "inbound related, filter on main",
+          comment: "inbound related, filter on main (comment _markdown_ is turned off)",
+          inlineComment: true,
           schemaName: "product-unordered-related-tables-links",
           displayname: "inbound related with filter on main table",
           name: "booking",

--- a/test/e2e/utils/chaise.page.js
+++ b/test/e2e/utils/chaise.page.js
@@ -522,8 +522,8 @@ var recordPage = function() {
         return el.element(by.css("a"));
     };
 
-    this.getMarkdownContainer = function (el) {
-        return el.all(by.css(".markdown-container")).first();
+    this.getValueMarkdownContainer = function (el) {
+        return el.element(by.css(".markdown-container:not(.chaise-comment)"));
     };
 
     /* related table selectors */

--- a/test/e2e/utils/record-helpers.js
+++ b/test/e2e/utils/record-helpers.js
@@ -200,11 +200,11 @@ exports.testPresentation = function (tableParams) {
             let columnEls;
             if (column.type == 'inline' || column.match === 'html') {
                 columnEls = chaisePage.recordPage.getEntityRelatedTable(columnTitle);
-                expect(chaisePage.recordPage.getMarkdownContainer(columnEls).getAttribute('innerHTML')).toContain(column.value, errMessage);
+                expect(chaisePage.recordPage.getValueMarkdownContainer(columnEls).getAttribute('innerHTML')).toContain(column.value, errMessage);
             }  else {
                 columnEls = chaisePage.recordPage.getEntityRelatedTable(columnTitle);
                 if (column.presentation) {
-                    if (column.presentation.type === "inline") columnEls = chaisePage.recordPage.getMarkdownContainer(columnEls);
+                    if (column.presentation.type === "inline") columnEls = chaisePage.recordPage.getValueMarkdownContainer(columnEls);
 
                     const aTag = chaisePage.recordPage.getLinkChild(columnEls);
                     const dataRow = chaisePage.getEntityRow("product-record", column.presentation.table_name, column.presentation.key_value);
@@ -333,7 +333,7 @@ exports.testPresentation = function (tableParams) {
             // switch the display mode
             return chaisePage.clickButton(chaisePage.recordPage.getToggleDisplayLink(displayname, true));
         }).then(function(){
-            const md = chaisePage.recordPage.getMarkdownContainer(relatedEl);
+            const md = chaisePage.recordPage.getValueMarkdownContainer(relatedEl);
             browser.wait(EC.visibilityOf(md), browser.params.defaultTimeout);
             expect(md.getText()).toBe('None',"Incorrect text for empty markdown!");
             done();
@@ -742,8 +742,8 @@ exports.testRelatedTable = function (params, pageReadyCondition) {
 
             if (params.isMarkdown || (params.isInline && !params.isTableMode)) {
                 it ("markdown container must be visible.", function (done) {
-                    chaisePage.waitForElement(chaisePage.recordPage.getMarkdownContainer(currentEl)).then(function () {
-                        expect(chaisePage.recordPage.getMarkdownContainer(currentEl).isDisplayed()).toBeTruthy("didn't have markdown");
+                    chaisePage.waitForElement(chaisePage.recordPage.getValueMarkdownContainer(currentEl)).then(function () {
+                        expect(chaisePage.recordPage.getValueMarkdownContainer(currentEl).isDisplayed()).toBeTruthy("didn't have markdown");
                         done();
                     })
 
@@ -751,7 +751,7 @@ exports.testRelatedTable = function (params, pageReadyCondition) {
 
                 if (params.markdownValue) {
                     it ("correct markdown values should be visible.", function (done) {
-                        expect(chaisePage.recordPage.getMarkdownContainer(currentEl).getAttribute('innerHTML')).toEqual(params.markdownValue);
+                        expect(chaisePage.recordPage.getValueMarkdownContainer(currentEl).getAttribute('innerHTML')).toEqual(params.markdownValue);
                         done();
                     });
                 }


### PR DESCRIPTION
This PR is the chaise side of changes for [this PR in ermrestjs](https://github.com/informatics-isi-edu/ermrestjs/pull/1000). 

As part of this,
- I had to make some changes to `white-space` CSS property of tooltips. By default, white spaces are not collapsed, but in tooltips, we want the white space to be preserved. We've already relied on this behavior in different places (profile button tooltip and file input tooltip). But when the tooltip is HTML, we should continue with collapsing whitespace.

- Introduced a new `DisplayCommentValue` component that should be used whenever we want to render a comment. I did this because I needed to be able to attach a special class to all the rendered comments.

Since I completely changed how the `.comment` API works in ermrestjs, we have to merge this at the same time as the ermrestjs one.