### PR TITLE
Add `.` in citation in share and cite popup

### DIFF
--- a/src/components/modals/share-cite-modal.tsx
+++ b/src/components/modals/share-cite-modal.tsx
@@ -17,6 +17,7 @@ import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utils
+import { hasTrailingPeriod } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { resolvePermalink } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { getVersionDate, humanizeTimestamp } from '@isrd-isi-edu/chaise/src/utils/date-time-utils';
 import { copyToClipboard } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
@@ -121,6 +122,12 @@ const ShareCiteModal = ({
       $log.warn('failed to copy with the following error:');
       $log.warn(err);
     })
+  }
+
+  const appendTrailingPeriod = (str: string) => {
+    if (hasTrailingPeriod(str)) return str;
+
+    return str + '.';
   }
 
   const citationReady = !!citation && citation.isReady;
@@ -236,8 +243,8 @@ const ShareCiteModal = ({
             <li className='share-modal-citation'>
               {!hideHeaders && <h2>Data Citation</h2>}
               <div className='share-modal-citation-text'>
-                {citation.value.author && <span>{citation.value.author} </span>}
-                {citation.value.title && <span>{citation.value.title} </span>}
+                {citation.value.author && <span>{appendTrailingPeriod(citation.value.author)} </span>}
+                {citation.value.title && <span>{appendTrailingPeriod(citation.value.title)} </span>}
                 <i>{citation.value.journal}</i> <a href={citation.value.url}>{citation.value.url}</a> ({citation.value.year}).
               </div>
             </li>

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -25,3 +25,7 @@ const ID_SAFE_REGEX = /[^\w-]+/g;
 export function makeSafeIdAttr(string: string) {
     return String(string).replace(ID_SAFE_REGEX, '-');
 }
+
+export function hasTrailingPeriod(str: string) {
+  return str[str.length-1] === '.';
+}

--- a/test/e2e/data_setup/schema/record/product.json
+++ b/test/e2e/data_setup/schema/record/product.json
@@ -545,7 +545,8 @@
                 "tag:isrd.isi.edu,2018:citation": {
                     "template_engine": "handlebars",
                     "author_pattern": "{{#each entity_set_accommodation_inbound1}}{{this.rowName}}{{#unless @last}}, {{/unless}}{{/each}}({{{cnt_d_accommodation_inbound1}}})",
-                    "journal_pattern": "{{title}}, {{{entity_all_outbound_outbound1_outbound3.rowName}}}",
+                    "title_pattern": "{{title}}",
+                    "journal_pattern": "{{{entity_all_outbound_outbound1_outbound3.rowName}}}",
                     "year_pattern": "{{formatDate RCT 'YYYY'}}",
                     "url_pattern": "{{website}}",
                     "id_pattern": "{{id}}",

--- a/test/e2e/data_setup/schema/recordset/saved-query.json
+++ b/test/e2e/data_setup/schema/recordset/saved-query.json
@@ -322,11 +322,11 @@
                 },
                 "tag:isrd.isi.edu,2018:citation" : {
                     "template_engine": "handlebars",
-                    "author_pattern":  "Joshua Chudy, Aref Shafaei",
+                    "author_pattern":  "Joshua Chudy, Aref Shafaei.",
                     "title_pattern":   "{{lgt}}",
                     "journal_pattern": "Journal of Front End Faceting Test Data",
                     "year_pattern":    "{{formatDate RCT 'YYYY'}}",
-                    "url_pattern":     "{{$location.origin}}/chaise/record/#{{$catalog.snapshot}}/faceting:main/RID={{RID}}"
+                    "url_pattern":     "{{$location.origin}}{{$location.chaise_path}}record/#{{$catalog.snapshot}}/saved_query:main/RID={{RID}}"
                 },
                 "tag:misd.isi.edu,2015:display": {
                     "show_saved_query": true

--- a/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/record/presentation.spec.js
@@ -98,7 +98,7 @@ var testParams = {
         // the table has history-capture: true
         hasVersionedLink: true,
         verifyVersionedLink: true,
-        citation: "accommodation_inbound1 one, accommodation_inbound1 three, accommodation_inbound1 five(3) Sherathon Hotel, accommodation_outbound1_outbound3 one http://www.starwoodhotels.com/sheraton/index.html (" + moment().format("YYYY") + ").",
+        citation: "accommodation_inbound1 one, accommodation_inbound1 three, accommodation_inbound1 five(3). Sherathon Hotel. accommodation_outbound1_outbound3 one http://www.starwoodhotels.com/sheraton/index.html (" + moment().format("YYYY") + ").",
         bibtextFile: "accommodation_"+chaisePage.getEntityRow("product-record", "accommodation", [{column: "id",value: "2002"}]).RID+".bib",
         title: "Share and Cite"
     },

--- a/test/e2e/specs/all-features/recordset/saved-query.spec.js
+++ b/test/e2e/specs/all-features/recordset/saved-query.spec.js
@@ -1,5 +1,7 @@
 const chaisePage = require('../../../utils/chaise.page.js');
 const pImport = require('../../../utils/protractor.import.js');
+var recordHelpers = require('../../../utils/record-helpers.js');
+var moment = require('moment');
 const EC = protractor.ExpectedConditions;
 
 const testParams = {
@@ -9,7 +11,12 @@ const testParams = {
   maxInputClass: 'range-max',
   maxInputClearClass: 'max-clear',
   firstSavedQueryName: 'main with int_col ( 11 to 22)',
-  secondSavedQueryName: 'main with int_col ( 11 to 22); one'
+  secondSavedQueryName: 'main with int_col ( 11 to 22); one',
+  key: {
+    name: 'id',
+    operator: '=',
+    value: '1'
+  }
 };
 
 const chaiseConfigAnnotation = {
@@ -301,4 +308,29 @@ describe('View recordset page and form a query,', () => {
       });
     });
   });
+
+  describe('should have proper citation in share cite modal', () => {
+    var RIDLink = browser.params.url + "/record/#" + browser.params.catalogId + '/saved_query:' + testParams.table_name;
+    RIDLink += '/RID=' + chaisePage.getEntityRow('saved_query', testParams.table_name, [{column: testParams.key.name, value: testParams.key.value}]).RID;
+    var rctVal = chaisePage.getEntityRow('saved_query', testParams.table_name, [{column: testParams.key.name, value: testParams.key.value}]).RCT
+
+    var keys = [];
+    keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);
+    beforeAll((done) => {
+      const url = browser.params.url + '/record/#' + browser.params.catalogId + '/saved_query:' + testParams.table_name + '/' + keys.join('');
+      chaisePage.navigate(url);
+
+      done();
+    })
+
+    recordHelpers.testSharePopup({
+        permalink: RIDLink,
+        // the table has history-capture: true
+        hasVersionedLink: true,
+        verifyVersionedLink: false,
+        citation: "Joshua Chudy, Aref Shafaei. This is long text so it can be used in a title. Journal of Front End Faceting Test Data " + RIDLink + " (" + moment(rctVal).format("YYYY") + ").",
+        bibtextFile: false,
+        title: "Share and Cite"
+    });
+  })
 });


### PR DESCRIPTION
This PR will add a `.` after the `author_pattern` and `title_pattern` in the citation shown in the share and cite popup.

Modified an existing test case to verify the `.` is added properly. I used an existing `citation` annotation for the saved_query tests to test the case with a `.` defined in both `author_pattern` and `title_pattern` (the `.` part of `lgt` column used in the `title_pattern`). I don't think this `citation` annotation was used before this so I figured I would use it for this test case.

Relevant issue #1853 

When this is merged, I will update [annotation.md](https://github.com/informatics-isi-edu/ermrestjs/blob/master/docs/user-docs/annotation.md#tag-2018-citation) in ermrestJS.