### PR TITLE
Make sure defaultTable chaise-config is properly supported

### DIFF
--- a/src/utils/head-injector.ts
+++ b/src/utils/head-injector.ts
@@ -139,7 +139,7 @@ function addCanonicalTag() {
     canonicalTag.setAttribute('rel', 'canonical');
 
     // the hash returned from this function handles the case when '#' is switched with '?'
-    const hash = getURLHashFragment(windowRef.location);
+    const { hash } = getURLHashFragment(windowRef.location);
     const canonicalURL = windowRef.location.origin + windowRef.location.pathname + stripSortAndQueryParams(hash);
     canonicalTag.setAttribute('href', canonicalURL);
     document.getElementsByTagName('head')[0].appendChild(canonicalTag);

--- a/src/utils/uri-utils.ts
+++ b/src/utils/uri-utils.ts
@@ -3,9 +3,10 @@
  */
 
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
-import { BUILD_VARIABLES, HELP_PAGES, URL_PATH_LENGTH_LIMIT } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { BUILD_VARIABLES, HELP_PAGES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { isStringAndNotEmpty } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 
 /**
 * @function
@@ -211,13 +212,26 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
   };
 }
 
+/**
+ * return the catalog id that should be used.
+ * if the url has catalog id, it will return that. otherwise will return the chaise-config's defaultCatalog
+ */
 export function getCatalogId() {
   let catalogId = '';
-  try {
-    catalogId += chaiseURItoErmrestURI(windowRef.location).catalogId;
-  } catch (err) {
-    const cc = ConfigService.chaiseConfig;
-    if (cc.defaultCatalog) catalogId += cc.defaultCatalog;
+  const location = windowRef.location;
+
+  let hash = location.hash;
+  // allow ? to be used in place of #
+  if (!hash && location.href.indexOf('?') !== -1) {
+    hash = `#${location.href.substring(location.href.indexOf('?') + 1)}`;
+  }
+
+  if (isStringAndNotEmpty(hash)) {
+    catalogId = hash.substring(1).split('/')[0];
+  }
+
+  if (!isStringAndNotEmpty(catalogId) && ConfigService.chaiseConfig.defaultCatalog) {
+    catalogId = ConfigService.chaiseConfig.defaultCatalog;
   }
 
   return catalogId;

--- a/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
+++ b/test/e2e/specs/all-features-confirmation/recordset/presentation.spec.js
@@ -1118,7 +1118,13 @@ describe('View recordset,', function () {
         });
 
         it("clicking view action should change current window with the same window ID and a new page ID.", function (done) {
-            chaisePage.recordsetPage.getViewActionButtons().then(function (viewButtons) {
+            browser.wait(function () {
+                return chaisePage.recordsetPage.getViewActionButtons().count().then(function (ct) {
+                    return ct > 0;
+                });
+            }).then(() => {
+                return chaisePage.recordsetPage.getViewActionButtons()
+            }).then(function (viewButtons) {
                 return chaisePage.clickButton(viewButtons[0]);
             }).then(function () {
                 return chaisePage.recordPageReady();
@@ -1134,9 +1140,14 @@ describe('View recordset,', function () {
 
         it("clicking edit action should open a new window with a new window ID and a new page ID.", function (done) {
             var allWindows;
-
-            chaisePage.recordsetPage.getEditActionButtons().then(function (editButtons) {
-                return editButtons[0].click();
+            browser.wait(function () {
+              return chaisePage.recordsetPage.getEditActionButtons().count().then(function (ct) {
+                  return ct > 0;
+              });
+            }).then(() => {
+                return chaisePage.recordsetPage.getEditActionButtons();
+            }).then(function (editButtons) {
+                return chaisePage.clickButton(editButtons[0]);
             }).then(function () {
                 return browser.getAllWindowHandles();
             }).then(function (handles) {
@@ -1144,11 +1155,12 @@ describe('View recordset,', function () {
                 return browser.switchTo().window(allWindows[1]);
             }).then(function () {
                 return chaisePage.recordeditPageReady();
-            }).finally(function () {
+            }).then(function () {
                 expect(chaisePage.getWindowName()).not.toBe(windowId);
                 // pageId should change when a new window is opened
                 expect(chaisePage.getPageId()).not.toBe(pageId);
-                browser.close();
+                return browser.close();
+            }).then(() => {
                 return browser.switchTo().window(allWindows[0]);
             }).then(function () {
                 expect(chaisePage.getWindowName()).toBe(windowId);
@@ -1196,7 +1208,15 @@ describe('View recordset,', function () {
                     }).then(function (title) {
                         expect(title).toBe("Dataset");
                     });
-                });
+                })
+                /**
+                 * TODO we should fix this when we migrate to playwright
+                 * originally we had defaultCatalog:1 in the chaise-config.js for this test. there are two issues with this:
+                 * - we assumed catalog:1 is always on the dev.derivacloud server. this is not a big deal though as it's a safe assumption.
+                 * - we assumed assuming that catalog=1 is created by CI. this is not the case anymore for the playwright test cases as we
+                 *   change the order of specs and also we want to make sure we can run test cases on multiple borwsers.
+                 */
+                .pend('removed because we cannot assume the catalog number anymore')
 
                 it("should use the default schema:table defined in chaise config if no schema:table is present in the uri.", function () {
                     chaisePage.navigate(process.env.CHAISE_BASE_URL + "/recordset/#1");


### PR DESCRIPTION
As the title suggests, this PR will make sure we're properly using the `defaulTable` when users navigate to pages like `/chaise/recordset/#1`. The actual change in this PR is fixing the implementation of `getCatalogId` so that it does not rely on the `chaiseURItoErmrestURI` and finds the ID by itself.

Assume we don't have any `defaultCatalog` defined on `chaise-config.js` and that the following catalog annotation is used on catalog with id `1`:

```
"tag:isrd.isi.edu,2019:chaise-config": {
  "defaultTable": {
    "schema": "isa",
    "table": "dataset"
  }
}
```

If users navigate to the `/chaise/recordset/#1` location, we expect chaise to use the default table. Instead, they would see an error saying that the default table is not defined.

This is because in `ConfigService.configure` we call `getCatalogId` to find the catalog we have to fetch and use its annotation. But the old implementation of `getCatalogId` was trying to parse the whole URL and since the table name is missing and `defaultTable` is not part of the `chaise-config.js`, it would throw an error.

The new implementation is not going to parse the whole URL, and it will only try to find the catalog ID.