### PR TITLE
Avoid parsing url to find the catalog id on static sites

### DIFF
--- a/src/libs/login.tsx
+++ b/src/libs/login.tsx
@@ -6,13 +6,15 @@ import ChaiseLogin from '@isrd-isi-edu/chaise/src/components/navbar/login';
 
 // services
 import { ConfigServiceSettings } from '@isrd-isi-edu/chaise/src/services/config';
+import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utilities
 import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
 const loginLibSettings : ConfigServiceSettings = {
-  appName: APP_NAMES.LOGIN
+  appName: APP_NAMES.LOGIN,
+  skipParsingURLForCatalogID: true
 };
 
 /**
@@ -28,4 +30,7 @@ waitForElementToLoad(LOGIN_SELECTOR).then(() => {
       <ChaiseLogin />
     </AppWrapper>
   );
+}).catch((error) => {
+  $log.error('<login> element is either missing or never loaded.')
+  $log.error(error);
 });

--- a/src/libs/navbar.tsx
+++ b/src/libs/navbar.tsx
@@ -5,13 +5,17 @@ import AppWrapper from '@isrd-isi-edu/chaise/src/components/app-wrapper';
 
 // services
 import { ConfigServiceSettings } from '@isrd-isi-edu/chaise/src/services/config';
+import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utilities
 import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { waitForElementToLoad } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 
+
 const navbarLibSettings: ConfigServiceSettings = {
-  appName: APP_NAMES.NAVBAR
+  appName: APP_NAMES.NAVBAR,
+  // we don't know what the url would look like on static sites that are using this
+  skipParsingURLForCatalogID: true
 };
 
 /**
@@ -32,5 +36,7 @@ waitForElementToLoad(NAVBAR_SELECTOR).then(() => {
       <></>
     </AppWrapper>
   );
-
+}).catch((error) => {
+  $log.error('<navbar> element is either missing or never loaded.')
+  $log.error(error);
 });

--- a/src/pages/help.tsx
+++ b/src/pages/help.tsx
@@ -32,7 +32,9 @@ const helpSettings: ConfigServiceSettings = {
   overrideHeadTitle: true,
   overrideImagePreviewBehavior: true,
   overrideDownloadClickBehavior: true,    // links in navbar might need this
-  overrideExternalLinkBehavior: true      // links in navbar might need this
+  overrideExternalLinkBehavior: true,      // links in navbar might need this
+  // the url for this app doesn't follow other chaise apps.
+  skipParsingURLForCatalogID: true
 };
 
 const HelpApp = (): JSX.Element => {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -30,7 +30,9 @@ const loginSettings : ConfigServiceSettings = {
   overrideHeadTitle: true,
   overrideImagePreviewBehavior: false,
   overrideDownloadClickBehavior: false,
-  overrideExternalLinkBehavior: false
+  overrideExternalLinkBehavior: false,
+  // the url for this app doesn't follow other chaise apps:
+  skipParsingURLForCatalogID: true,
 };
 
 export type loginForm = {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -49,7 +49,16 @@ export interface ConfigServiceSettings {
   overrideImagePreviewBehavior?: boolean,
   overrideDownloadClickBehavior?: boolean,
   overrideExternalLinkBehavior?: boolean,
-  openIframeLinksInTab?: boolean
+  openIframeLinksInTab?: boolean,
+  /**
+   * this can be used to make sure we're not parsing the url to find the catalog id.
+   * for example in static sites we cannot assume the hash fragment has the catalog id,
+   * so we should skip parsing it.
+   *
+   * TODO we might want to come up with a better name. other suggestions were `forceDefaultCatalog`,
+   * and `hasChaiseURLFragment`.
+   */
+  skipParsingURLForCatalogID?: boolean
 }
 
 export interface ContextHeaderParams {
@@ -140,7 +149,7 @@ export class ConfigService {
     // if it already is not populated
     const service = ConfigService.ERMrestLocation;
 
-    const catalogId = getCatalogId();
+    const catalogId = getCatalogId(settings.skipParsingURLForCatalogID);
 
     ConfigService._catalogID = catalogId;
 

--- a/src/utils/uri-utils.ts
+++ b/src/utils/uri-utils.ts
@@ -232,11 +232,16 @@ export function chaiseURItoErmrestURI(location: Location, dontDecodeQueryParams?
 /**
  * return the catalog id that should be used.
  * if the url has catalog id, it will return that. otherwise will return the chaise-config's defaultCatalog
+ * @param dontParseURL pass true if we shouldn't attempt to parse the window.location to find the catalog id
  */
-export function getCatalogId() {
-  const { hash, isQueryParameter } = getURLHashFragment(windowRef.location);
+export function getCatalogId(dontParseURL?: boolean) {
   const defaultValue = isStringAndNotEmpty(ConfigService.chaiseConfig.defaultCatalog) ? ConfigService.chaiseConfig.defaultCatalog : '';
 
+  if (dontParseURL) {
+    return defaultValue;
+  }
+
+  const { hash, isQueryParameter } = getURLHashFragment(windowRef.location);
   /**
    * if there is no '/' character (only a catalog id) or a trailing '/' after the id, we are assuming the whole hash
    * is the catalog id.


### PR DESCRIPTION
As part of our `config` service, we parse the URL to find the catalog id. This is done so we can use the `chaise-config` annotation that might be defined on the catalog.

However, static sites might not follow the same URL pattern as chaise and use hash for other reasons. Because of this, going to a static page like https://staging.atlas-d2k.org/gudmap/citing-gudmap/#creating-citable-data-collections would result in an error because we're assuming `creating-citable-data-collections` is the catalog id. 

So, in this PR, I added a new boolean to skip this logic for the navbar and login libs. I also used this for the help and login apps since they're not following the same URL pattern either.

P.S. The changes are simple and I created this PR mostly to announce and run CI tests. I'll merge it once it's passed. 


