### PR TITLE
Properly handle array inputs in iframe-field-modal

### DIFF
--- a/src/components/modals/iframe-field-modal.tsx
+++ b/src/components/modals/iframe-field-modal.tsx
@@ -191,6 +191,18 @@ const IframeFieldModal = ({
                 filesize: colData.size
               };
 
+            }
+            else if (col.type?.isArray) {
+              try {
+                // the iframe will send the array value in a string, so we have to turn it into a proper array
+                const arrayValue = JSON.parse(colData);
+                if (Array.isArray(arrayValue)) {
+                  // mimic the same structure that we have in array fields (the value is stored inside the .val prop)
+                  values[`c_${formNumber}-${col.RID}`] = arrayValue.map((v: any) => ({val: v}));
+                }
+              } catch (exp) {
+                values[`c_${formNumber}-${col.RID}`] = [];
+              }
             } else {
               values[`c_${formNumber}-${col.RID}`] = colData;
             }

--- a/test/e2e/data_setup/schema/recordedit/input-iframe.json
+++ b/test/e2e/data_setup/schema/recordedit/input-iframe.json
@@ -54,7 +54,13 @@
         {
           "name": "notes",
           "nullok": true,
-          "type": {"typename": "text"}
+          "type": {
+            "is_array": true,
+            "typename": "text[]",
+            "base_type": {
+                "typename": "text"
+            }
+          }
         }
       ],
       "annotations": {

--- a/test/e2e/specs/all-features/recordedit/input-iframe.spec.ts
+++ b/test/e2e/specs/all-features/recordedit/input-iframe.spec.ts
@@ -32,12 +32,12 @@ const testParams = {
     secondAttemptValues: {
       creator: 'John Smith II',
       file_content: 'actually the content should be this one.',
-      notes: 'some notes'
+      notes: '["note 1","note 2"]'
     },
     submission: {
       tableDisplayname: 'main',
       resultColumnNames: ['id', 'creator', 'notes'],
-      resultRowValues: [['1', 'John Smith II', 'some notes']]
+      resultRowValues: [['1', 'John Smith II', 'note 1, note 2']]
     }
   },
   edit: {
@@ -46,7 +46,7 @@ const testParams = {
     existingValues: {
       creator: 'John Smith II',
       file_content: 'actually the content should be this one.',
-      notes: 'some notes'
+      notes: '["note 1","note 2"]'
     },
     newValues: {
       creator: 'Kylan Gentry',

--- a/test/e2e/utils/input-iframe-test.html
+++ b/test/e2e/utils/input-iframe-test.html
@@ -21,7 +21,10 @@
     const fetchExistingData = (existingValue) => {
       const fileURL = existingValue[FIELD_NAMES.FILE];
       const creator = existingValue[FIELD_NAMES.CREATOR];
-      const notes = existingValue[FIELD_NAMES.NOTES];
+      let notes = existingValue[FIELD_NAMES.NOTES];
+      if (Array.isArray(notes)) {
+        notes = JSON.stringify(notes);
+      }
 
       fetch(fileURL).then(response => {
         if (response.ok) {
@@ -138,7 +141,7 @@
     <br/>
     <label for="file-content">File content:</label><br/><textarea id="file-content" name="file-content" rows="4" cols="50"></textarea>
     <br/>
-    <label for="notes">Notes:</label><br/><input type="text" id="notes" name="notes">
+    <label for="notes">Notes (array of text):</label><br/><input type="text" id="notes" name="notes">
     <br/>
     <button id='iframe-submit-btn' type="button" onclick="submitData()">submit</button>
   </div>


### PR DESCRIPTION
Prior to merging #2340, array values were stored as strings in react-hook-form. So the `iframe-field-modal.tsx` code wasn't doing anything special for the arrays and `populateSubmissionRow` would eventually turn this string into a proper array.

However, with the new implementation, we expect array values to follow a specific pattern, and this PR will make sure this component also stores array values properly.

Because of this bug, after users select a value using the iframe, as soon as the `populateSubmissionRow` was called (due to opening a foreign key popup or clicking on submit), they would see a terminal error with the following message

```
l.map is not a function
```


P.S. I also changed the test case to have an array column, so we can test this scenario.