### PR TITLE
Inject defaultCatalog property to chaise-config and remove catalog alias creation step

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,6 +56,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-function-type': 'warn',
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/no-inferrable-types': 'warn',
+    '@typescript-eslint/no-require-imports': 'warn',
 
     // ------------------ testing ------------------
     '@typescript-eslint/no-floating-promises': 'warn'

--- a/Makefile
+++ b/Makefile
@@ -502,6 +502,10 @@ lint: $(SOURCE)
 lint-w-warn: $(SOURCE)
 	@npx eslint src --ext .ts,.tsx
 
+.PHONY: lint-tests
+lint-tests:
+	npx eslint test/e2e --ext .ts,.tsx --quiet
+
 # Rule to create the package.
 .PHONY: dist-wo-deps
 dist-wo-deps: print-variables run-webpack $(SASS) $(MIN) $(HTML) gitversion

--- a/test/e2e/setup/playwright.model.ts
+++ b/test/e2e/setup/playwright.model.ts
@@ -23,6 +23,14 @@ export type TestOptions = {
    */
   chaiseConfigFilePath?: string,
 
+  /**
+   * if set to to true, we will inject the "defaultCatalog" property
+   * into the chaise-config.js file.
+   *
+   * the id of the catalog created for the chrome project will be used for this.
+   */
+  addDefaultCatalogToChaiseConfig?: boolean,
+
   manualTestConfig?: boolean,
 
   /**

--- a/test/e2e/setup/playwright.setup.ts
+++ b/test/e2e/setup/playwright.setup.ts
@@ -2,10 +2,11 @@ import { FullConfig } from '@playwright/test';
 import axios from 'axios';
 import { execSync } from 'child_process';
 import fs from 'fs';
+import path from 'path';
 
 import { TestOptions } from '@isrd-isi-edu/chaise/test/e2e/setup/playwright.model';
-import { removeAllCatalogs, setupCatalog } from '@isrd-isi-edu/chaise/test/e2e/utils/catalog-utils';
-import { ENTITIES_PATH, PW_PROJECT_NAMES } from '@isrd-isi-edu/chaise/test/e2e/utils/constants';
+import { getCatalogID, removeAllCatalogs, setupCatalog } from '@isrd-isi-edu/chaise/test/e2e/utils/catalog-utils';
+import { ENTITIES_PATH, PW_PROJECT_NAMES, UPLOAD_FOLDER } from '@isrd-isi-edu/chaise/test/e2e/utils/constants';
 import { setCatalogID } from '@isrd-isi-edu/chaise/test/e2e/utils/catalog-utils';
 
 /**
@@ -80,7 +81,7 @@ export default async function globalSetup(config: FullConfig) {
     chaiseConfigFilePath = `test/e2e/specs/${options.mainSpecName}/chaise-config.js`;
   }
 
-  copyChaiseConfig(chaiseConfigFilePath);
+  copyChaiseConfig(chaiseConfigFilePath, options.addDefaultCatalogToChaiseConfig);
 
   registerCallbacks(testConfiguration);
 }
@@ -180,9 +181,7 @@ async function createCatalog(testConfiguration: any, projectNames: string[], mai
 
     for (const p of projectNames) {
       try {
-        // add alias to the catalog based on the config and project name
-        const alias = `${mainSpecName}-${p}`;
-        const res = await setupCatalog({ catalog: { ...catalog, alias }, schemas });
+        const res = await setupCatalog({ catalog: { ...catalog }, schemas });
         console.log(`catalog with id ${res.catalogId} created for project ${p}`);
         setCatalogID(p, res.catalogId);
 
@@ -292,7 +291,7 @@ async function getSessionByUserPass(username: string, password: string, authCook
 /**
  * copy the chaise config into desired location
  */
-function copyChaiseConfig(chaiseConfigFilePath?: string) {
+function copyChaiseConfig(chaiseConfigFilePath?: string, addDefaultCatalogToChaiseConfig?: boolean) {
   let chaiseFilePath = 'chaise-config-sample.js';
   if (typeof chaiseConfigFilePath === 'string') {
     try {
@@ -301,6 +300,23 @@ function copyChaiseConfig(chaiseConfigFilePath?: string) {
     } catch (e) {
       console.log(`Config file ${chaiseConfigFilePath} doesn't exists`);
     }
+  }
+
+  if (addDefaultCatalogToChaiseConfig) {
+    // grab the catalog id
+    const catId = getCatalogID(PW_PROJECT_NAMES.CHROME);
+    if (catId === null) {
+      throw new Error('unable to find catalog id for chrome project while adding defaultCatalog');
+    }
+
+    // grab the content of chaise-config file and add the defaultCatalog to it
+    let content = fs.readFileSync(chaiseFilePath, 'utf8');
+    content += `\nchaiseConfig.defaultCatalog = '${catId}'`;
+
+    // write the new content into the temporary location
+    execSync(`mkdir -p ${UPLOAD_FOLDER}`);
+    chaiseFilePath = path.resolve(UPLOAD_FOLDER, 'chaise-config.js');
+    fs.writeFileSync(chaiseFilePath, content);
   }
 
   const remoteChaiseDirPath = process.env.REMOTE_CHAISE_DIR_PATH;

--- a/test/e2e/specs/delete-prohibited/chaise-config.js
+++ b/test/e2e/specs/delete-prohibited/chaise-config.js
@@ -2,7 +2,6 @@
 
 var chaiseConfig = {
     name: "Delete Prohibited",
-    defaultCatalog: 'delete-prohibited-chrome',
     editRecord: true,
     deleteRecord: false,
     showFaceting: true,

--- a/test/e2e/specs/delete-prohibited/navbar/playwright.config.ts
+++ b/test/e2e/specs/delete-prohibited/navbar/playwright.config.ts
@@ -4,4 +4,5 @@ export default getConfig({
   testName: 'delete-prohibited/navbar',
   configFileName: 'navbar/catalog-chaise-config.dev.json',
   mainSpecName: 'delete-prohibited',
+  addDefaultCatalogToChaiseConfig: true
 });

--- a/test/e2e/specs/delete-prohibited/playwright.config.ts
+++ b/test/e2e/specs/delete-prohibited/playwright.config.ts
@@ -4,4 +4,5 @@ export default getConfig({
   testName: 'delete-prohibited',
   configFileName: 'parallel-configs/delete-prohibited.dev.json',
   mainSpecName: 'delete-prohibited',
+  addDefaultCatalogToChaiseConfig: true
 });


### PR DESCRIPTION
# Summary

A while ago, I modified the catalog creation step of our test framework to add aliases to the created catalog. This allowed us to test the `defaultCatalog` property since we could hardcode the alias inside the `chaise-config.js` files.

This worked properly while I was testing it on my own. However, since then, we have found that the alias creation has limitations when multiple users use the same alias or if multiple users want to run test cases simultaneously.

So this PR will remove the alias creation step and instead will inject a line into the `chaise-config.js` like the following:

```
chaiseConfig.defaultCatalog = 'id_of_the_newly_created_catalog';
```

Since we don't need this for all the test cases, I added a new `addDefaultCatalogToChaiseConfig` to our test options.

# Details

The following are the issues that we found with the alias method:

1. Since an alias can be associated with just one catalog at a time, running multiple instances of our test framework simultaneously could result in unpredicted behavior. For example, assume user1 runs the test cases and assigns `my-alias` to a catalog. At the same time, user2 runs the test case and assigns `my-alias` to their own newly created catalog. In this case, using the `my-alias` will refer to one of these catalogs, so one of the users is using the wrong catalog.
2. If we don't provide the `owner` property while creating the alias, whoever creates it first will be its sole owner. So, if someone else attempts to use the same alias for a different catalog, they will get an error. To solve this, we would have to provide the `isrd-testers` as the `owner` of the alias. But that means that we have to hardcode this as part of chaise.