### PR TITLE
End-to-end test for "bulk_create_foreign_key" annotation property

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout bulk-foreign-key-annotation
           sudo make root-install
       - name: Install chaise
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,6 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          git checkout bulk-foreign-key-annotation
           sudo make root-install
       - name: Install chaise
         run: |

--- a/test/e2e/data_setup/data/product/association_table_w_three_fks.json
+++ b/test/e2e/data_setup/data/product/association_table_w_three_fks.json
@@ -1,0 +1,1 @@
+[{"main_fk_col": 2004, "leaf_fk_col": 2, "third_fk_col": 2, "static_col1": 2}]

--- a/test/e2e/data_setup/data/product/leaf_table_for_three_fks.json
+++ b/test/e2e/data_setup/data/product/leaf_table_for_three_fks.json
@@ -1,0 +1,10 @@
+[{"id": "1", "details": "Leaf 1"},
+{"id": "2", "details": "Leaf 2"},
+{"id": "3", "details": "Leaf 3"},
+{"id": "4", "details": "Leaf 4"},
+{"id": "5", "details": "Leaf 5"},
+{"id": "6", "details": "Leaf 6"},
+{"id": "7", "details": "Leaf 7"},
+{"id": "8", "details": "Leaf 8"},
+{"id": "9", "details": "Leaf 9"},
+{"id": "10", "details": "Leaf 10"}]

--- a/test/e2e/data_setup/data/product/third_table_for_three_fks.json
+++ b/test/e2e/data_setup/data/product/third_table_for_three_fks.json
@@ -1,0 +1,10 @@
+[{"id": "1", "details": "Other Leaf 1"},
+{"id": "2", "details": "Other Leaf 2"},
+{"id": "3", "details": "Other Leaf 3"},
+{"id": "4", "details": "Other Leaf 4"},
+{"id": "5", "details": "Other Leaf 5"},
+{"id": "6", "details": "Other Leaf 6"},
+{"id": "7", "details": "Other Leaf 7"},
+{"id": "8", "details": "Other Leaf 8"},
+{"id": "9", "details": "Other Leaf 9"},
+{"id": "10", "details": "Other Leaf 10"}]

--- a/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
+++ b/test/e2e/data_setup/schema/record/product-unordered-related-tables-links.json
@@ -781,6 +781,10 @@
                         [
                             "product-unordered-related-tables-links",
                             "static_to_accommodation_w_dropdown_fkey"
+                        ],
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_accommodation_fkey"
                         ]
                     ]
                 },
@@ -3223,6 +3227,237 @@
                     "entry": {
                         "selector_ux_mode": "simple-search-dropdown"
                     },
+                    "row_name": {
+                        "row_markdown_pattern": "{{{details}}}"
+                    }
+                },
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "compact": [
+                        "id",
+                        "details"
+                    ]
+                }
+            }
+        },
+        "association_table_w_three_fks": {
+            "comment": "For testing 'add records' prefill and using bulk create foreign key features with an annnotation defined since there are 3 foreign key relationships",
+            "kind": "table",
+            "schema_name": "product-unordered-related-tables-links",
+            "table_name": "association_table_w_three_fks",
+            "column_definitions": [
+                {
+                    "name": "static_col1",
+                    "type": {
+                        "typename": "int4"
+                    }
+                },
+                {
+                    "name": "main_fk_col",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int4"
+                    }
+                },
+                {
+                    "name": "leaf_fk_col",
+                    "nullok": false,
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "third_fk_col",
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "keys": [
+                {
+                    "unique_columns": [
+                        "RID"
+                    ]
+                },
+                {
+                    "unique_columns": [
+                        "main_fk_col",
+                        "leaf_fk_col"
+                    ]
+                }
+            ],
+            "foreign_keys": [
+                {
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "association_table_w_three_fks",
+                            "column_name": "leaf_fk_col"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "leaf_table_for_three_fks",
+                            "column_name": "id"
+                        }
+                    ],
+                    "names": [
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_leaf_fkey"
+                        ]
+                    ]
+                },
+                {
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "association_table_w_three_fks",
+                            "column_name": "main_fk_col"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "accommodation",
+                            "column_name": "id"
+                        }
+                    ],
+                    "names": [
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_accommodation_fkey"
+                        ]
+                    ]
+                },
+                {
+                    "foreign_key_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "association_table_w_three_fks",
+                            "column_name": "third_fk_col"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "schema_name": "product-unordered-related-tables-links",
+                            "table_name": "third_table_for_three_fks",
+                            "column_name": "id"
+                        }
+                    ],
+                    "names": [
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_third_fkey"
+                        ]
+                    ]
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "entry": [
+                        "static_col1",
+                        {
+                            "source": [
+                                {
+                                    "outbound": [
+                                        "product-unordered-related-tables-links",
+                                        "three_fks_to_accommodation_fkey"
+                                    ]
+                                },
+                                "RID"
+                            ],
+                            "display": {
+                                "bulk_create_foreign_key": [
+                                    "product-unordered-related-tables-links",
+                                    "three_fks_to_leaf_fkey"
+                                ]
+                            }
+                        },
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_leaf_fkey"
+                        ],
+                        [
+                            "product-unordered-related-tables-links",
+                            "three_fks_to_third_fkey"
+                        ]
+                    ],
+                    "compact": "entry",
+                    "detailed": "entry"
+                }
+            }
+        },
+        "leaf_table_for_three_fks": {
+            "comment": "leaf table for testing an association with 3 foreign keys and a bulk_create_foreign_key property in visible columns annotation",
+            "kind": "table",
+            "table_name": "leaf_table_for_three_fks",
+            "schema_name": "product-unordered-related-tables-links",
+            "keys": [
+                {
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "details",
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
+                    "row_name": {
+                        "row_markdown_pattern": "{{{details}}}"
+                    }
+                },
+                "tag:isrd.isi.edu,2016:visible-columns": {
+                    "compact": [
+                        "id",
+                        "details"
+                    ]
+                }
+            }
+        },
+        "third_table_for_three_fks": {
+            "comment": "third table for testing an association with 3 foreign keys and a bulk_create_foreign_key property in visible columns annotation",
+            "kind": "table",
+            "table_name": "third_table_for_three_fks",
+            "schema_name": "product-unordered-related-tables-links",
+            "keys": [
+                {
+                    "unique_columns": [
+                        "id"
+                    ]
+                }
+            ],
+            "foreign_keys": [],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "details",
+                    "type": {
+                        "typename": "text"
+                    }
+                }
+            ],
+            "annotations": {
+                "tag:isrd.isi.edu,2016:table-display": {
                     "row_name": {
                         "row_markdown_pattern": "{{{details}}}"
                     }

--- a/test/e2e/specs/all-features/record/related-table.spec.ts
+++ b/test/e2e/specs/all-features/record/related-table.spec.ts
@@ -44,8 +44,9 @@ const testParams = {
     'association with filter on main table',
     'association with filter on related table', // association with filter on related table
     'path of length 3 with filters', // path of length 3 with filters
-    'association_table_w_static_column', // "almost" pure and binary multi create foreig key with fk input modals
-    'association_table_w_static_column_dropdown' // "almost" pure and binary multi create foreig key with fk input dropdowns
+    'association_table_w_static_column', // "almost" pure and binary multi create foreign key with fk input modals
+    'association_table_w_static_column_dropdown', // "almost" pure and binary multi create foreign key with fk input dropdowns
+    'association_table_w_three_fks' // association table with 3 foreign keys and multi create foreign key with annotation
   ],
   tocHeaders: [
     'Summary', 'booking (6)', 'schedule (2)', 'media (1)', 'association_table (1)',
@@ -59,7 +60,8 @@ const testParams = {
     'association with filter on related table (1)',
     'path of length 3 with filters (1)',
     'association_table_w_static_column (1)',
-    'association_table_w_static_column_dropdown (1)'
+    'association_table_w_static_column_dropdown (1)',
+    'association_table_w_three_fks (1)'
   ],
   scrollToDisplayname: 'table_w_aggregates'
 };
@@ -837,9 +839,12 @@ test.describe('Related tables', () => {
   });
 
   /**
-   * The following 2 tests are for testing the prefill functionality when the inbound foreign key is part of a table that is "almost" pure and binary
+   * The following tests are for testing the prefill functionality when the inbound foreign key is part of a table that is "almost" pure and binary
    *
-   * This means there are 2 foreign keys that are part of the same key (making the pair unique) and there are other columns that are not foreign keys
+   * For the first 3 tests, this means there are 2 foreign keys that are part of the same key (making the pair unique) and there are other columns that are not foreign keys
+   *
+   * For the 4th test, there are still 2 foreign keys that are part of the same key but there is another foreign key on this table. This means the heuristics won't trigger
+   *   for the bulk create foreign key functionality requiring an annotation to be defined instead.
    */
   test.describe('for a table that is almost pure and binary and the foreign keys are a unique key', async () => {
     const params = {
@@ -959,6 +964,17 @@ test.describe('Related tables', () => {
       params.bulk_modal_title = 'Select a set of leaf_fk_col for association_table_w_static_column_dropdown'
 
       await testAddRelatedWithForeignKeyMultiPicker(page, params, RecordeditInputType.FK_DROPDOWN);
+    });
+
+    test('with a third foreign key and an annotation on main_fk_col', async ({ page }) => {
+      params.table_name = 'association_table_w_three_fks';
+      params.leaf_fk_name = 'leaf_fk_col';
+      params.bulk_modal_title = 'Select a set of leaf_fk_col for association_table_w_three_fks'
+
+      params.column_names = ['static1', 'main_fk_col', 'leaf_fk_col', 'third_fk_col'];
+      params.resultset_values = [['', '2004', '10', ''], ['', '2004', '7', '']];
+      params.related_table_values = [['2', 'Leaf 2', 'Other Leaf 2'], ['', 'Leaf 10', ''], ['', 'Leaf 7', '']];
+      await testAddRelatedWithForeignKeyMultiPicker(page, params, RecordeditInputType.FK_POPUP);
     });
   });
 });


### PR DESCRIPTION
This PR adds a test case to make sure defining the annotation will still properly trigger the bulk create foreign key UI in recordedit app with a prefill value.

These changes should be merged with [this PR](https://github.com/informatics-isi-edu/ermrestjs/pull/1018) in ermrestJS.