### PR TITLE
Recordedit column headers text overflow

### DIFF
--- a/src/assets/scss/_recordedit.scss
+++ b/src/assets/scss/_recordedit.scss
@@ -59,7 +59,6 @@
         padding: 8px;
 
         min-height: 47px;
-        height: 47px;
 
         flex: none;
         position: relative;
@@ -121,6 +120,11 @@
 
         &.highlighted-row {
           background-color: map-get(variables.$color-map, 'recordedit-highlighted-row');
+
+          // reset the changed height when the multi form input row is open
+          .inputs-row {
+            min-height: unset;
+          }
         }
 
         &.highlighted-row, &.with-inline-tooltip {
@@ -129,6 +133,7 @@
         }
 
         .inputs-row {
+          min-height: inherit; // the min-height of the parent row element can be changed if the key column has a taller height than the form row. We want to inherit that changed element's height value
           display: flex;
           flex-direction: row;
 
@@ -171,6 +176,7 @@
         }
 
         .multi-form-input-row {
+          flex-grow: 1; // fill the space in case of a really tall row because the column name is long in the KeyColumn element (entity-key)
           flex-direction: column;
           align-items: center;
 

--- a/src/components/recordedit/multi-form-input-row.tsx
+++ b/src/components/recordedit/multi-form-input-row.tsx
@@ -58,7 +58,7 @@ const MultiFormInputRow = ({
 
   const colName = cm.column.name;
   const colRID = cm.column.RID;
-  
+
   const inputName = `c_${MULTI_FORM_INPUT_FORM_VALUE}-${colRID}`;
 
   const { formState: { errors }, getValues, setValue, setError, clearErrors } = useFormContext();
@@ -196,7 +196,7 @@ const MultiFormInputRow = ({
     if (textareaArrayField) {
       const addButton = document.querySelector('.multi-form-input .array-input-field-container-longtext .add-element-container .add-button') as HTMLElement
       const addButtonWidth = addButton.getBoundingClientRect().width + addButton.offsetWidth;
-      
+
       let newContainerWidth;
       if (windowRef.innerWidth < 1800) {
         newContainerWidth = nonScrollableDiv.offsetWidth - addButtonWidth;


### PR DESCRIPTION
This PR changes how the styles for the key column are defined in recordedit so that the key column will be taller than the form inputs when the column displayname text is long. 

I'm using `height` to adjust the height for the key column. The entity value has a similar adjustment made when the header is taller and the height can't go below a certain threshold.

About the key column CSS changes:
 - removed `height: 47px` from stylesheet
   - the height is "unset" each time we calculate the height of the header compared to the inputs. This allows the bounding rect height to be more precise
   - we don't want to rely on `header.style.height` since that's the property we are setting ourselves (or unsetting)
 -  relies on `min-height` and content of the header to change the height when the key column content is taller
 - if the form input content is taller, then the `height` is set to the same as the form content
 - NOTE: when the clone button is clicked, the "Set value for multiple records" control shows in all key column headers which squeezes the content
   - The change to the `useEffect` to trigger when `forms.length` changes handles the case when clone is used
   - this still runs on page load since forms is not defined yet and then "changes" when rendering the form rows
About the form row CSS changes:
 - NOTE: when the multi form row is opened, the column header might grow to the same height as the other content (or the form header remains taller)
   - the same logic from above is applied to determine which elements to set the "height" for
   
About the form row CSS changes:
 - when the page loads, the height is "unset" for all form rows
   - makes sure the calculations made are accurate using the bounding rect height
   - the `min-height` for `inputs-row` (the child of `form-inputs-row`) is set to "inherit" so it can use the same `min-height` that we set when calculating
     - if the header is taller than the form row, then the `min-height` of the form row is set to the height of the header
 - when there are multiple forms
   - the same calculation is done as above to see if the header has become taller than the inputs after the "Set value for multiple records" shows
 - when the multi form input row is open
   - change the `min-height` style to be "unset" in case the form row becomes taller than the head when it was smaller than before
   - the multi form input row has `flex-grow: 1` so the content will stretch to fill the area if the header is taller AFTER the multi form input row is opened