### PR TITLE
Support wait_for in asset annotation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout asset-wait-for
           sudo make root-install
       - name: Install chaise
         run: |

--- a/src/components/modals/upload-progress-modal.tsx
+++ b/src/components/modals/upload-progress-modal.tsx
@@ -29,6 +29,10 @@ export interface UploadProgressModalProps {
    */
   linkedData: any[];
   /**
+   * the result of secondary requests (waitfors)
+   */
+  templateVariables: any;
+  /**
    * prop to show modal
    */
   show: boolean;
@@ -42,7 +46,7 @@ export interface UploadProgressModalProps {
   onCancel: (exception?: any) => void;
 }
 
-const UploadProgressModal = ({ rows, linkedData, show, onSuccess, onCancel }: UploadProgressModalProps) => {
+const UploadProgressModal = ({ rows, linkedData, templateVariables, show, onSuccess, onCancel }: UploadProgressModalProps) => {
 
   const { reference, setLastContiguousChunk, lastContiguousChunkRef } = useRecordedit();
 
@@ -153,7 +157,7 @@ const UploadProgressModal = ({ rows, linkedData, show, onSuccess, onCancel }: Up
             tempFilesCt++;
             tempTotalSize += row[k].file.size;
 
-            tuple.push(createUploadFileObject(row[k], column, row, linkedData[rowIdx], rowIdx));
+            tuple.push(createUploadFileObject(row[k], column, row, linkedData[rowIdx], templateVariables[rowIdx], rowIdx));
           } else {
             row[k] = (row[k] && row[k].url && row[k].url.length) ? row[k].url : null;
           }
@@ -202,6 +206,7 @@ const UploadProgressModal = ({ rows, linkedData, show, onSuccess, onCancel }: Up
         item.hatracObj.calculateChecksum(
           item.row,
           item.linkedData,
+          item.templateVariables,
           (uploaded: number) => onChecksumProgressChanged(item, uploaded)
         ).then((url: string) => onChecksumCompleted(item, url)).catch(onError);
       });
@@ -349,7 +354,9 @@ const UploadProgressModal = ({ rows, linkedData, show, onSuccess, onCancel }: Up
    * @desc
    * Creates an uploadFile obj to keep track of file and its upload.
    */
-  const createUploadFileObject = (data: FileObject, column: any, row: any, linkedData: any, rowIdx: number): UploadFileObject => {
+  const createUploadFileObject = (
+    data: FileObject, column: any, row: any, linkedData: any, templateVariables: any, rowIdx: number
+  ): UploadFileObject => {
     const file = data.file;
 
     const uploadFileObject: UploadFileObject = {
@@ -376,8 +383,9 @@ const UploadProgressModal = ({ rows, linkedData, show, onSuccess, onCancel }: Up
       reference: reference,
       row: row,
       rowIdx: rowIdx,
-      linkedData: linkedData
-    }
+      linkedData: linkedData,
+      templateVariables,
+    };
 
     return uploadFileObject;
   };

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -869,6 +869,7 @@ const RecordeditInner = ({
           show={!!uploadProgressModalProps}
           rows={uploadProgressModalProps.rows}
           linkedData={uploadProgressModalProps.linkedData}
+          templateVariables={uploadProgressModalProps.templateVariables}
           onSuccess={uploadProgressModalProps.onSuccess}
           onCancel={uploadProgressModalProps.onCancel}
         />

--- a/src/models/recordedit.ts
+++ b/src/models/recordedit.ts
@@ -200,6 +200,10 @@ export interface UploadFileObject {
    */
   linkedData: any,
   /**
+   * the waitfor data
+   */
+  templateVariables: any,
+  /**
    * which row this is
    */
   rowIdx: number
@@ -253,6 +257,10 @@ export interface UploadProgressProps {
    * the outbound fk values (linke data) for all the forms
    */
   linkedData: any[];
+  /**
+   * the template variables (wait for data) for all the forms
+   */
+  templateVariables: any[];
   /**
    * prop to trigger on delete confirmation
    */

--- a/src/services/recordedit-initial-load-flow-control.ts
+++ b/src/services/recordedit-initial-load-flow-control.ts
@@ -9,7 +9,10 @@ import $log from '@isrd-isi-edu/chaise/src/services/logger';
 // utils
 import { getPrefillObject } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
 
-export default class RecordeditFlowControl {
+/**
+ * The flow control for loading the default and preffiled fk values
+ */
+export default class RecordeditInitialLoadFlowControl {
   queue: FlowControlQueueInfo;
 
   /**
@@ -40,11 +43,16 @@ export default class RecordeditFlowControl {
    * @param queryParams the query parameters on the page (used for finding the prefill object)
    * @param queue should be passed if we want a existing queue
    */
-  constructor(queryParams: any, queue?: FlowControlQueueInfo) {
+  constructor(queryParams?: any, queue?: FlowControlQueueInfo) {
     this.queue = queue ? queue : new FlowControlQueueInfo();
 
-    this.prefillObj = getPrefillObject(queryParams);
-    this.prefillProcessed = !this.prefillObj;
+    if (queryParams) {
+      this.prefillObj = getPrefillObject(queryParams);
+      this.prefillProcessed = !this.prefillObj;
+    } else {
+      this.prefillObj = null;
+      this.prefillProcessed = true;
+    }
 
     this.foreignKeyRequests = [];
   }

--- a/src/services/recordedit-wait-for-flow-control.ts
+++ b/src/services/recordedit-wait-for-flow-control.ts
@@ -1,0 +1,115 @@
+// models
+import { LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
+import { FlowControlQueueInfo } from '@isrd-isi-edu/chaise/src/models/flow-control';
+
+// services
+import $log from '@isrd-isi-edu/chaise/src/services/logger';
+import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
+
+/**
+ * The flow control for loading the wait-for columns required for the asset columns
+ */
+export default class RecordeditWaitForFlowControl {
+  queue: FlowControlQueueInfo;
+
+  /**
+   * the requests that should be sent
+   */
+  waitForRequests: {
+    /**
+     * whether the request is processed (either finished or waiting)
+     */
+    processed: boolean,
+    /**
+     * whether we're waiting for the request to finish
+     */
+    isLoading: boolean,
+    /**
+     * the wait-for column object
+     * (used for fetching the data)
+     */
+    waitForColumn: any,
+    /**
+     * the index of the column in the list of columnModels
+     * (used for setting the value))
+     */
+    colIndex: number,
+    /**
+     * the log stack node for the request
+     */
+    logStackNode: any
+  }[] = [];
+
+  /**
+   * the computed template variables
+   */
+  templateVariables: any[] = [];
+
+  /**
+   * create and initialize the flowcontrol object
+   * @param queryParams the query parameters on the page (used for finding the prefill object)
+   * @param queue should be passed if we want a existing queue
+   */
+  constructor(reference: any, queue?: FlowControlQueueInfo) {
+    this.queue = queue ? queue : new FlowControlQueueInfo();
+
+    if (reference.activeList) {
+      reference.activeList.requests.forEach((activeListModel: any) => {
+        // TODO this feels hacky
+        if (!activeListModel.firstOutbound) return;
+
+        const logStackNode = LogService.getStackNode(
+          LogStackTypes.PSEUDO_COLUMN,
+          activeListModel.column.table,
+          {
+            source: activeListModel.column.compressedDataSource,
+            entity: activeListModel.column.isEntityMode,
+            ...(activeListModel.column.aggregateFn && { agg: activeListModel.column.aggregateFn }),
+          },
+        );
+        this.waitForRequests.push({
+          processed: false,
+          isLoading: true,
+          waitForColumn: activeListModel.column,
+          colIndex: activeListModel.index,
+          logStackNode
+        });
+      });
+    }
+  }
+
+  /**
+   * returns true if we have free slots for requests.
+   * @param printMessage whether we should print the message about full queue or not
+   * @returns
+   */
+  haveFreeSlot(printMessage = true) {
+    const res = this.queue.occupiedSlots < this.queue.maxRequests;
+    if (!res && printMessage) {
+      $log.debug('No free slot available.');
+    }
+    return res;
+  }
+
+  /**
+   * restart the flow-contorl
+   */
+  reset() {
+    this.queue.occupiedSlots = 0;
+    this.templateVariables = [];
+    this.waitForRequests.forEach((req) => {
+      req.processed = false;
+      req.isLoading = true;
+    });
+  }
+
+  /**
+   * whether all the requests are finished.
+   * can be used to change the state of spinner
+   * @returns boolean
+   */
+  allRequestsFinished(): boolean {
+    return this.waitForRequests.every((req) => req.processed && !req.isLoading);
+  }
+
+}

--- a/src/services/recordedit-wait-for-flow-control.ts
+++ b/src/services/recordedit-wait-for-flow-control.ts
@@ -55,7 +55,6 @@ export default class RecordeditWaitForFlowControl {
 
     if (reference.activeList) {
       reference.activeList.requests.forEach((activeListModel: any) => {
-        // TODO this feels hacky
         if (!activeListModel.firstOutbound) return;
 
         const logStackNode = LogService.getStackNode(

--- a/src/services/recordset-flow-control.ts
+++ b/src/services/recordset-flow-control.ts
@@ -1,6 +1,5 @@
 // models
-import { LogActions, LogObjectType, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
-import { FlowControlQueueInfo } from '@isrd-isi-edu/chaise/src/models/flow-control';
+import { LogObjectType, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
 
 // servies
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';

--- a/test/e2e/data_setup/data/product/file_w_wait_for_in_url_pattern_1_o1.json
+++ b/test/e2e/data_setup/data/product/file_w_wait_for_in_url_pattern_1_o1.json
@@ -1,0 +1,7 @@
+[
+  {"id": 1, "file_w_wait_for_in_url_pattern_1_o1_fk_col": 11, "name": "one"},
+  {"id": 2, "file_w_wait_for_in_url_pattern_1_o1_fk_col": 22, "name": "two"},
+  {"id": 3, "file_w_wait_for_in_url_pattern_1_o1_fk_col": 33, "name": "three"},
+  {"id": 4, "file_w_wait_for_in_url_pattern_1_o1_fk_col": 44, "name": "four"},
+  {"id": 5, "file_w_wait_for_in_url_pattern_1_o1_fk_col": 55, "name": "five"}
+]

--- a/test/e2e/data_setup/data/product/file_w_wait_for_in_url_pattern_1_o1_o1.json
+++ b/test/e2e/data_setup/data/product/file_w_wait_for_in_url_pattern_1_o1_o1.json
@@ -1,0 +1,7 @@
+[
+  {"id": 11, "name": "eleven"},
+  {"id": 22, "name": "twenty-two"},
+  {"id": 33, "name": "thirty-three"},
+  {"id": 44, "name": "forty-four"},
+  {"id": 55, "name": "fifty-five"}
+]

--- a/test/e2e/data_setup/schema/recordedit/product-add.json
+++ b/test/e2e/data_setup/schema/recordedit/product-add.json
@@ -908,7 +908,7 @@
           },
           "annotations": {
             "tag:isrd.isi.edu,2017:asset": {
-              "url_pattern":"/hatrac/js/chaise/{{{_timestamp_txt}}}/{{{path_to_o1_o1.values.name}}}/{{{_id}}}/{{{_asset_col.md5_hex}}}",
+              "url_pattern":"/hatrac/js/chaise/{{{_timestamp_txt}}}/asset-1-{{{path_to_o1_o1.values.name}}}/{{{_id}}}/{{{_asset_col.md5_hex}}}",
               "filename_column" : "asset_filename_col",
               "wait_for": ["path_to_o1_o1"]
             }
@@ -916,6 +916,28 @@
         },
         {
           "name": "asset_filename_col",
+          "nullok": true,
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "asset_col_2",
+          "nullok": true,
+          "type": {
+
+            "typename": "text"
+          },
+          "annotations": {
+            "tag:isrd.isi.edu,2017:asset": {
+              "url_pattern":"/hatrac/js/chaise/{{{_timestamp_txt}}}/asset-2-{{{path_to_o1_o1.rowName}}}/{{{_id}}}/{{{_asset_col_2.md5_hex}}}",
+              "filename_column" : "asset_filename_col_2",
+              "wait_for": ["path_to_o1_o1"]
+            }
+          }
+        },
+        {
+          "name": "asset_filename_col_2",
           "nullok": true,
           "type": {
             "typename": "text"
@@ -931,12 +953,13 @@
       "annotations": {
         "tag:isrd.isi.edu,2016:visible-columns": {
           "*": [
-            "id", ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"], "asset_col"
+            "id", ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"], "asset_col", "asset_col_2"
           ],
           "entry": [
             "id",
             ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"],
             "asset_col",
+            "asset_col_2",
             "timestamp_txt"
           ]
         },

--- a/test/e2e/data_setup/schema/recordedit/product-add.json
+++ b/test/e2e/data_setup/schema/recordedit/product-add.json
@@ -860,6 +860,177 @@
           }
         }
       }
+    },
+    "file_w_wait_for_in_url_pattern_1": {
+      "kind": "table",
+      "keys": [
+        {
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "foreign_keys": [{
+        "names": [["product-add", "file_w_wait_for_in_url_pattern_1_fk1"]],
+        "foreign_key_columns": [{
+          "table_name": "file_w_wait_for_in_url_pattern_1",
+          "schema_name": "product-add",
+          "column_name": "fk_col"
+        }],
+        "referenced_columns": [{
+          "table_name": "file_w_wait_for_in_url_pattern_1_o1",
+          "schema_name": "product-add",
+          "column_name": "id"
+        }]
+      }],
+      "table_name": "file_w_wait_for_in_url_pattern_1",
+      "schema_name": "product-add",
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type": {
+            "typename": "int4"
+          }
+        },
+        {
+          "name": "fk_col",
+          "nullok": true,
+          "type": {
+            "typename": "int4"
+          }
+        },
+        {
+          "name": "asset_col",
+          "nullok": true,
+          "type": {
+            "typename": "text"
+          },
+          "annotations": {
+            "tag:isrd.isi.edu,2017:asset": {
+              "url_pattern":"/hatrac/js/chaise/{{{_timestamp_txt}}}/{{{path_to_o1_o1.values.name}}}/{{{_id}}}/{{{_asset_col.md5_hex}}}",
+              "filename_column" : "asset_filename_col",
+              "wait_for": ["path_to_o1_o1"]
+            }
+          }
+        },
+        {
+          "name": "asset_filename_col",
+          "nullok": true,
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "timestamp_txt",
+          "type": {
+            "typename": "text"
+          }
+        }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns": {
+          "*": [
+            "id", ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"], "asset_col"
+          ],
+          "entry": [
+            "id",
+            ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"],
+            "asset_col",
+            "timestamp_txt"
+          ]
+        },
+        "tag:isrd.isi.edu,2019:source-definitions": {
+          "columns": true,
+          "fkeys": false,
+          "sources": {
+            "path_to_o1_o1": {
+              "source": [
+                {"outbound": ["product-add", "file_w_wait_for_in_url_pattern_1_fk1"]},
+                {"outbound": ["product-add", "file_w_wait_for_in_url_pattern_1_o1_fk1"]},
+                "RID"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "file_w_wait_for_in_url_pattern_1_o1": {
+      "kind": "table",
+      "keys": [
+        {
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "foreign_keys": [{
+        "names": [["product-add", "file_w_wait_for_in_url_pattern_1_o1_fk1"]],
+        "foreign_key_columns": [{
+          "table_name": "file_w_wait_for_in_url_pattern_1_o1",
+          "schema_name": "product-add",
+          "column_name": "file_w_wait_for_in_url_pattern_1_o1_fk_col"
+        }],
+        "referenced_columns": [{
+          "table_name": "file_w_wait_for_in_url_pattern_1_o1_o1",
+          "schema_name": "product-add",
+          "column_name": "id"
+        }]
+      }],
+      "table_name": "file_w_wait_for_in_url_pattern_1_o1",
+      "schema_name": "product-add",
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type": {
+            "typename": "int4"
+          }
+        },
+        {
+          "name": "name",
+          "nullok": false,
+          "type": {
+            "typename": "text"
+          }
+        },
+        {
+          "name": "file_w_wait_for_in_url_pattern_1_o1_fk_col",
+          "nullok": true,
+          "type": {
+            "typename": "int4"
+          }
+        }
+      ]
+    },
+    "file_w_wait_for_in_url_pattern_1_o1_o1": {
+      "kind": "table",
+      "keys": [
+        {
+          "unique_columns": [
+            "id"
+          ]
+        }
+      ],
+      "foreign_keys": [],
+      "table_name": "file_w_wait_for_in_url_pattern_1_o1_o1",
+      "schema_name": "product-add",
+      "column_definitions": [
+        {
+          "name": "id",
+          "nullok": false,
+          "type": {
+            "typename": "int4"
+          }
+        },
+        {
+          "name": "name",
+          "nullok": false,
+          "type": {
+            "typename": "text"
+          }
+        }
+      ]
     }
   },
   "comment": null,

--- a/test/e2e/specs/all-features-confirmation/recordedit/add-new.spec.ts
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add-new.spec.ts
@@ -1,7 +1,32 @@
 import { test } from '@playwright/test';
+import moment from 'moment';
 
 import { RecordeditInputType } from '@isrd-isi-edu/chaise/test/e2e/locators/recordedit';
 import { testCreateRecords, TestCreateRecordsParams } from '@isrd-isi-edu/chaise/test/e2e/utils/recordedit-utils';
+
+const currentTimestampTimeStr = moment().format('x');
+
+const testFiles = [
+  {
+    name: 'testfile1MB_add.txt',
+    size: '1024000',
+    path: 'testfile1MB_add.txt',
+    tooltip: '- testfile1MB_add.txt\n- 1000 kB'
+  },
+  {
+    name: 'testfile500kb_add.png',
+    size: '512000',
+    path: 'testfile500kb_add.png',
+    tooltip: '- testfile500kb_add.png\n- 500 kB'
+  },
+  {
+    name: 'testfile10MB_add.txt',
+    size: '10240000',
+    path: 'testfile10MB_add.txt',
+    tooltip: '- testfile10MB_add.txt\n- 9.77 MB'
+  },
+];
+
 
 const parallelTestParams: TestCreateRecordsParams = {
   tables: [
@@ -102,12 +127,112 @@ const parallelTestParams: TestCreateRecordsParams = {
           ]
         ]
       }
+    },
+    {
+      num_files: 2,
+      presentation: {
+        description: 'file upload with outbound fkey usage in url_pattern',
+        schemaName: 'product-add',
+        tableName: 'file_w_fk_in_url_pattern',
+        tableDisplayname: 'file_w_fk_in_url_pattern',
+        columns: [
+          { name: 'id', displayname: 'id', type: RecordeditInputType.TEXT, isRequired: true, skipValidation: true },
+          { name: 'category', displayname: 'Category', type: RecordeditInputType.FK_POPUP, isRequired: false, skipValidation: true },
+          { name: 'asset_col', displayname: 'asset_col', type: RecordeditInputType.FILE, skipValidation: true },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true }
+        ],
+        inputs: [
+          {
+            'id': '3',
+            'asset_col': testFiles[0],
+            'category': { modal_num_rows: 5, modal_option_index: 1, rowName: 'Ranch' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '4',
+            'asset_col': testFiles[1],
+            'category': { modal_num_rows: 5, modal_option_index: 3, rowName: 'Resort' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          // the form will be removed:
+          {
+            'id': '5',
+            'asset_col': testFiles[1],
+            'category': { modal_num_rows: 5, modal_option_index: 0, rowName: 'Hotel' },
+            'timestamp_txt': currentTimestampTimeStr
+          }
+        ]
+      },
+      submission: {
+        tableDisplayname: 'file_w_fk_in_url_pattern',
+        resultColumnNames: ['id', 'Category', 'asset_col'],
+        resultRowValues: [
+          ['3', '10004', { caption: 'testfile1MB_add.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/Ranch/3/` }],
+          ['4', '10006', { caption: 'testfile500kb_add.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/Resort/4/` }]
+        ]
+      }
+    },
+    {
+      num_files: 3,
+      presentation: {
+        description: 'file upload with wait_for usage in url_pattern',
+        schemaName: 'product-add',
+        tableName: 'file_w_wait_for_in_url_pattern_1',
+        tableDisplayname: 'file_w_wait_for_in_url_pattern_1',
+        columns: [
+          { name: 'id', displayname: 'id', type: RecordeditInputType.INT_4, isRequired: true, skipValidation: true },
+          {
+            name: 'file_w_wait_for_in_url_pattern_1_o1',
+            displayname: 'file_w_wait_for_in_url_pattern_1_o1',
+            type: RecordeditInputType.FK_POPUP,
+            isRequired: false, skipValidation: true
+          },
+          { name: 'asset_col', displayname: 'asset_col', type: RecordeditInputType.FILE, skipValidation: true },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true },
+        ],
+        inputs: [
+          {
+            'id': '1',
+            'asset_col': testFiles[0],
+            'file_w_wait_for_in_url_pattern_1_o1': { modal_num_rows: 5, modal_option_index: 1, rowName: 'two' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '2',
+            'asset_col': testFiles[1],
+            'file_w_wait_for_in_url_pattern_1_o1': { modal_num_rows: 5, modal_option_index: 2, rowName: 'three' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '3',
+            'asset_col': testFiles[2],
+            'file_w_wait_for_in_url_pattern_1_o1': { modal_num_rows: 5, modal_option_index: 3, rowName: 'four' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          // the form will be removed:
+          {
+            'id': '4',
+            'asset_col': testFiles[2],
+            'file_w_wait_for_in_url_pattern_1_o1': { modal_num_rows: 5, modal_option_index: 3, rowName: 'four' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+        ],
+      },
+      submission: {
+        tableDisplayname: 'file_w_wait_for_in_url_pattern_1',
+        resultColumnNames: ['id', 'file_w_wait_for_in_url_pattern_1_o1', 'asset_col'],
+        resultRowValues: [
+          ['1', '2', { caption: 'testfile1MB_add.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/twenty-two/1/` }],
+          ['2', '3', { caption: 'testfile500kb_add.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/thirty-three/2/` }],
+          ['3', '4', { caption: 'testfile1MB_add.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/fourty-four/3/` }]
+        ]
+      }
     }
   ]
 }
 
 test.describe('Recordedit create (parallel)', () => {
   test.describe.configure({ mode: 'parallel' });
-  testCreateRecords(parallelTestParams);
+  testCreateRecords(parallelTestParams, testFiles, currentTimestampTimeStr);
 });
 

--- a/test/e2e/specs/all-features-confirmation/recordedit/add-sequential.spec.ts
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add-sequential.spec.ts
@@ -1,0 +1,291 @@
+import { test } from '@playwright/test';
+import moment from 'moment';
+
+import { RecordeditInputType } from '@isrd-isi-edu/chaise/test/e2e/locators/recordedit';
+import { createFiles, deleteFiles, testCreateRecords, TestCreateRecordsParams } from '@isrd-isi-edu/chaise/test/e2e/utils/recordedit-utils';
+import { deleteHatracNamespaces } from '@isrd-isi-edu/chaise/test/e2e/utils/catalog-utils';
+
+const currentTimestampTimeStr = moment().format('x');
+
+const testFiles = [
+  {
+    name: 'testfile1MB_add_seq.txt',
+    size: '1024000',
+    path: 'testfile1MB_add_seq.txt',
+    tooltip: '- testfile1MB_add_seq.txt\n- 1000 kB'
+  },
+  {
+    name: 'testfile500kb_add_seq.png',
+    size: '512000',
+    path: 'testfile500kb_add_seq.png',
+    tooltip: '- testfile500kb_add_seq.png\n- 500 kB'
+  },
+  {
+    name: 'testfile10MB_add_seq.txt',
+    size: '10240000',
+    path: 'testfile10MB_add_seq.txt',
+    tooltip: '- testfile10MB_add_seq.txt\n- 9.77 MB'
+  },
+  {
+    name: 'testfile128kb_add_seq_4.txt',
+    size: '12800',
+    path: 'testfile128kb_add_seq_4.txt',
+  },
+  {
+    name: 'testfile500kb_add_seq_5.png',
+    size: '512000',
+    path: 'testfile500kb_add_seq_5.png',
+    tooltip: '- testfile500kb_add_seq_5.png\n- 500 kB',
+  },
+  {
+    name: 'testfile128kb_add_seq_6.txt',
+    size: '12800',
+    path: 'testfile128kb_add_seq_6.txt',
+  },
+];
+
+// we're testing this table multiple times
+const fileTableDefaultPresentationProps = {
+  schemaName: 'product-add',
+  tableName: 'file',
+  tableDisplayname: 'file',
+  tableComment: 'asset/object',
+  columns: [
+    { name: 'fileid', displayname: 'fileid', type: RecordeditInputType.INT_4, skipValidation: true },
+    { name: 'uri', displayname: 'uri', type: RecordeditInputType.FILE, comment: 'asset/reference' },
+    { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true }
+  ]
+}
+
+const testParams: TestCreateRecordsParams = {
+  tables: [
+    {
+      num_files: 2, // only two forms will be submitted
+      presentation: {
+        ...fileTableDefaultPresentationProps,
+        description: 'multi create with new files',
+        inputs: [
+          { 'fileid': '1', 'uri': testFiles[0], 'timestamp_txt': currentTimestampTimeStr },
+          { 'fileid': '2', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr },
+          { 'fileid': '3', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr } // the form will be removed
+        ]
+      },
+      submission: {
+        tableDisplayname: 'file',
+        resultColumnNames: ['fileid', 'uri', 'filename', 'bytes'],
+        resultRowValues: [
+          [
+            '1',
+            { caption: 'testfile1MB_add_seq.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/1/.txt/3a8c740953a168d9761d0ba2c9800475:` },
+            'testfile1MB_add_seq.txt',
+            '1.02 MB'
+          ],
+          [
+            '2',
+            { caption: 'testfile500kb_add_seq.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:` },
+            'testfile500kb_add_seq.png',
+            '512 kB'
+          ]
+        ]
+      }
+    },
+    {
+      num_files: 2, // only two forms will be submitted
+      presentation: {
+        description: 'multi create when one file previously uploaded to hatrac',
+        schemaName: 'product-add',
+        tableName: 'file',
+        tableDisplayname: 'file',
+        tableComment: 'asset/object',
+        columns: [
+          { name: 'fileid', displayname: 'fileid', type: RecordeditInputType.INT_4, skipValidation: true },
+          { name: 'uri', displayname: 'uri', type: RecordeditInputType.FILE, comment: 'asset/reference' },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true }
+        ],
+        inputs: [
+          { 'fileid': '1', 'uri': testFiles[2], 'timestamp_txt': currentTimestampTimeStr }, // this is new
+          { 'fileid': '2', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr }, // this is uploaded in the previous test
+          { 'fileid': '3', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr } // the form will be removed
+        ]
+      },
+      submission: {
+        tableDisplayname: 'file',
+        resultColumnNames: ['fileid', 'uri', 'filename', 'bytes'],
+        resultRowValues: [
+          [
+            '1',
+            { caption: 'testfile10MB_add_seq.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/1/.txt/b5dad28809685d9764dbd08fa23600bc:` },
+            'testfile10MB_add_seq.txt',
+            '10.2 MB'
+          ],
+          [
+            '2',
+            { caption: 'testfile500kb_add_seq.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:` },
+            'testfile500kb_add_seq.png',
+            '512 kB'
+          ]
+        ]
+      }
+    },
+    {
+      num_files: 2, // only two forms will be submitted
+      presentation: {
+        description: 'multi create when both files previously uploaded to hatrac',
+        schemaName: 'product-add',
+        tableName: 'file',
+        tableDisplayname: 'file',
+        tableComment: 'asset/object',
+        columns: [
+          { name: 'fileid', displayname: 'fileid', type: RecordeditInputType.INT_4, skipValidation: true },
+          { name: 'uri', displayname: 'uri', type: RecordeditInputType.FILE, comment: 'asset/reference' },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true }
+        ],
+        inputs: [
+          { 'fileid': '1', 'uri': testFiles[0], 'timestamp_txt': currentTimestampTimeStr }, // this is uploaded in the previous test
+          { 'fileid': '2', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr }, // this is uploaded in the previous test
+          { 'fileid': '3', 'uri': testFiles[1], 'timestamp_txt': currentTimestampTimeStr } // the form will be removed
+        ]
+      },
+      submission: {
+        tableDisplayname: 'file',
+        resultColumnNames: ['fileid', 'uri', 'filename', 'bytes'],
+        resultRowValues: [
+          [
+            '1',
+            { caption: 'testfile1MB_add_seq.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/1/.txt/3a8c740953a168d9761d0ba2c9800475:` },
+            'testfile1MB_add_seq.txt',
+            '1.02 MB'
+          ],
+          [
+            '2',
+            { caption: 'testfile500kb_add_seq.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/2/.png/2ada69fe3cdadcefddc5a83144bddbb4:` },
+            'testfile500kb_add_seq.png',
+            '512 kB'
+          ]
+        ]
+      }
+    },
+    {
+      num_files: 2,
+      presentation: {
+        description: 'upload with $fkey in url_pattern',
+        schemaName: 'product-add',
+        tableName: 'file_w_fk_in_url_pattern',
+        tableDisplayname: 'file_w_fk_in_url_pattern',
+        columns: [
+          { name: 'id', displayname: 'id', type: RecordeditInputType.TEXT, isRequired: true, skipValidation: true },
+          { name: 'category', displayname: 'Category', type: RecordeditInputType.FK_POPUP, isRequired: false, skipValidation: true },
+          { name: 'asset_col', displayname: 'asset_col', type: RecordeditInputType.FILE, skipValidation: true },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true }
+        ],
+        inputs: [
+          {
+            'id': '3',
+            'asset_col': testFiles[3],
+            'category': { modal_num_rows: 5, modal_option_index: 1, rowName: 'Ranch' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '4',
+            'asset_col': testFiles[4],
+            'category': { modal_num_rows: 5, modal_option_index: 3, rowName: 'Resort' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          // the form will be removed:
+          {
+            'id': '5',
+            'asset_col': testFiles[4],
+            'category': { modal_num_rows: 5, modal_option_index: 0, rowName: 'Hotel' },
+            'timestamp_txt': currentTimestampTimeStr
+          }
+        ]
+      },
+      submission: {
+        tableDisplayname: 'file_w_fk_in_url_pattern',
+        resultColumnNames: ['id', 'Category', 'asset_col'],
+        resultRowValues: [
+          ['3', '10004', { caption: 'testfile128kb_add_seq_4.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/Ranch/3/` }],
+          ['4', '10006', { caption: 'testfile500kb_add_seq_5.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/Resort/4/` }]
+        ]
+      }
+    },
+    {
+      num_files: 3,
+      presentation: {
+        description: 'upload with wait_for in url_pattern',
+        schemaName: 'product-add',
+        tableName: 'file_w_wait_for_in_url_pattern_1',
+        tableDisplayname: 'file_w_wait_for_in_url_pattern_1',
+        columns: [
+          { name: 'id', displayname: 'id', type: RecordeditInputType.INT_4, isRequired: true, skipValidation: true },
+          {
+            name: 'fk_col',
+            displayname: 'fk_col',
+            type: RecordeditInputType.FK_POPUP,
+            isRequired: false, skipValidation: true
+          },
+          { name: 'asset_col', displayname: 'asset_col', type: RecordeditInputType.FILE, skipValidation: true },
+          { name: 'timestamp_txt', displayname: 'timestamp_txt', type: RecordeditInputType.TEXT, skipValidation: true },
+        ],
+        inputs: [
+          {
+            'id': '1',
+            'asset_col': testFiles[3],
+            'fk_col': { modal_num_rows: 5, modal_option_index: 1, rowName: 'two' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '2',
+            'asset_col': testFiles[4],
+            'fk_col': { modal_num_rows: 5, modal_option_index: 2, rowName: 'three' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          {
+            'id': '3',
+            'asset_col': testFiles[5],
+            'fk_col': { modal_num_rows: 5, modal_option_index: 3, rowName: 'four' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+          // the form will be removed:
+          {
+            'id': '4',
+            'asset_col': testFiles[5],
+            'file_w_wait_for_in_url_pattern_1_o1': { modal_num_rows: 5, modal_option_index: 3, rowName: 'four' },
+            'timestamp_txt': currentTimestampTimeStr
+          },
+        ],
+      },
+      submission: {
+        tableDisplayname: 'file_w_wait_for_in_url_pattern_1',
+        resultColumnNames: ['id', 'file_w_wait_for_in_url_pattern_1_o1', 'asset_col'],
+        resultRowValues: [
+          ['1', '2', { caption: 'testfile128kb_add_seq_4.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/twenty-two/1/` }],
+          ['2', '3', { caption: 'testfile500kb_add_seq_5.png', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/thirty-three/2/` }],
+          ['3', '4', { caption: 'testfile128kb_add_seq_6.txt', url: `/hatrac/js/chaise/${currentTimestampTimeStr}/forty-four/3/` }]
+        ]
+      }
+    }
+  ]
+}
+
+
+test.describe('Recordedit create', () => {
+  /**
+   * we have to make sure we're running test cases sequentially since upload test cases are testing that users
+   * can upload the same file to the same location. That's why we're not running tests here in parallel.
+   *
+   * also having all the asset uploads done sequentially makes the test cases more stable and faster.
+   */
+  test.describe.configure({ mode: 'default' });
+
+  test.beforeAll(async () => {
+    await createFiles(testFiles);
+  });
+
+  testCreateRecords(testParams);
+
+  test.afterAll(async () => {
+    await deleteFiles(testFiles);
+    await deleteHatracNamespaces([`/hatrac/js/chaise/${currentTimestampTimeStr}`]);
+  });
+});

--- a/test/e2e/specs/all-features-confirmation/recordedit/add.config.ts
+++ b/test/e2e/specs/all-features-confirmation/recordedit/add.config.ts
@@ -5,6 +5,7 @@ export default getConfig({
   configFileName: 'recordedit/add.dev.json',
   mainSpecName: 'all-features-confirmation',
   testMatch: [
-    'add.spec.ts'
+    'add.spec.ts',
+    'add-sequential.spec.ts'
   ]
 });

--- a/test/e2e/utils/recordedit-utils.ts
+++ b/test/e2e/utils/recordedit-utils.ts
@@ -441,6 +441,7 @@ export const testSubmission = async (page: Page, params: TestSubmissionParams, i
     // provide more information about what went wrong
     const alertContent = await AlertLocators.getErrorAlert(page).textContent();
     expect(alertContent).toEqual('');
+    return;
   }
 
   await expect.soft(RecordeditLocators.getSubmitSpinner(page)).not.toBeAttached({ timeout: timeout });
@@ -1104,7 +1105,12 @@ export type TestCreateRecordsParams = {
   }[]
 };
 
-
+/**
+ * can be used for testing create scenario. works for single or multi create.
+ * This function will also make sure that we can remove forms.
+ *  - if num_files > 0, it will remove the last form.
+ *  - otherwise will add an extra form and remove it.
+ */
 export const testCreateRecords = (usedParams: TestCreateRecordsParams) => {
   for (const params of usedParams.tables) {
     const presentation = params.presentation;


### PR DESCRIPTION
This PR is the chaise side of changes for https://github.com/informatics-isi-edu/ermrestjs/pull/1028. This includes,

- Adding a secondary flow-control to recordedit for fetching the wait-for data.
- Using the new function signature of the hatrac-related APIs to pass the template variables.
- Improving the alert that we display when the `url_pattern` didn't produce a proper URL.
- Extracted the asset related tests from the `recordedit/add.spec.ts` into a `recordedit/add-sequential.spec.ts` to reduce the test time. Also added new tests for the new feature.


