### PR TITLE
Fix the login issue regarding globus organization login flow

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -16,6 +16,7 @@ import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
 
 // services
 import { ConfigService, ConfigServiceSettings } from '@isrd-isi-edu/chaise/src/services/config';
+import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utilities
 import { validateTermsAndConditionsConfig } from '@isrd-isi-edu/chaise/src/utils/config-utils';
@@ -70,9 +71,14 @@ const LoginPopupApp = (): JSX.Element => {
     // if the config is invalid, don't require group membership to continue automatically
     if (!validConfig || hasGroup) {
       const qString = queryStringToJSON(windowRef.location.search);
-      if (qString.referrerid && (typeof qString.action === 'undefined') && windowRef.opener) {
-        //For child window
-        windowRef.opener.postMessage(windowRef.location.search, windowRef.opener.location.href);
+
+      if (qString.referrerid && (typeof qString.action === 'undefined')) {
+
+        // tell the parent window that the login was successful
+        const channelName = `chaise-successful_login-${qString.referrerid}`;
+        $log.debug(`Broadcasting login message to channel: ${channelName}`);
+        const channel = new BroadcastChannel(channelName);
+        channel.postMessage({});
 
         // Create the user in 'user_profile" table with `onconflict=skip` if user exists already
         // POST /ermrest/catalog/registry/entity/CFDE:user_profile?onconflict=skip

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -1013,7 +1013,7 @@ export default function RecordeditProvider({
     const logObject = logInfo.logObject;
     const channelName = `chaise-${logObject.pcid}-${logObject.ppid}`;
     const channel = new BroadcastChannel(channelName);
-    console.log(`sending a message to ${channelName}`);
+    $log.debug(`sending a message to ${channelName}`);
     channel.postMessage(message);
   }
 


### PR DESCRIPTION
If you use the organization login feature of globus, the login popup gets stuck and never closes. So, users had to manually close the popup and refresh the main page.

After investigating this, I realized that the `window.opener` API becomes `null` in this scenario. So, in this PR, I completely rewrote this logic to use the `BroadcastChannel` API instead.

With `BroadcastChannel`, we can broadcast this event to all chaise pages. But since the goal of this PR is fixing the bug (and not changing the expected behavior), I'm only broadcasting to the page that calls the login flow. We should have a discussion if we want to change this behavior.

