### PR TITLE
Bulk edit changes

### DIFF
--- a/src/components/faceting/facet-choice-picker.tsx
+++ b/src/components/faceting/facet-choice-picker.tsx
@@ -669,7 +669,7 @@ const FacetChoicePicker = ({
               onClick={() => openRecordsetModal()}
             >
               <span className='chaise-btn-icon far fa-window-restore'></span>
-              <span>{useShowMore ? 'Show More' : 'Show Details'}</span>
+              <span>{useShowMore ? 'Show more' : 'Show details'}</span>
             </button>
           </ChaiseTooltip>
           {facetModel.noConstraints &&

--- a/src/components/recordset/table-header.tsx
+++ b/src/components/recordset/table-header.tsx
@@ -17,10 +17,11 @@ import useRecordset from '@isrd-isi-edu/chaise/src/hooks/recordset';
 import { LogActions, LogReloadCauses } from '@isrd-isi-edu/chaise/src/models/log';
 import { fixedEncodeURIComponent } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
-import { CUSTOM_EVENTS, RECORDEDIT_MAX_ROWS } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { CUSTOM_EVENTS } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { generateRandomInteger } from '@isrd-isi-edu/chaise/src/utils/math-utils';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
 import { fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
+import { isBulkEditEnabled } from '@isrd-isi-edu/chaise/src/utils/record-utils';
 
 
 type TableHeaderProps = {
@@ -35,6 +36,22 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
   } = useRecordset();
 
   const container = useRef<HTMLDivElement>(null);
+
+  /**
+ * as long as the table doesn't have any static update:false ACL, we should show the button.
+   * if user cannot edit any of the displayed rows, we should disable the button.
+   */
+  const canShowEditButton = config.displayMode === RecordsetDisplayMode.FULLSCREEN && config.editable && reference && reference.canUpdate;
+  const disableEditButton = canShowEditButton && !isBulkEditEnabled(page);
+  let editButtonTooltip: string | JSX.Element = 'Edit this page of records.';
+  if (disableEditButton) {
+    editButtonTooltip = (
+      <>
+        There are no records that you can edit in this result page.<br />
+        There may be editable records in other pages or with different search criteria
+      </>
+    );
+  }
 
   const pageLimits = [10, 25, 50, 75, 100, 200];
   if (pageLimits.indexOf(pageLimit) === -1) {
@@ -180,34 +197,6 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
     return isAddableDisplayMode && reference && reference.canCreate;
   }
 
-  /**
-   * whether to display edit button
-   */
-  const shouldShowEditButton = () => {
-    return config.displayMode === RecordsetDisplayMode.FULLSCREEN && canUpdate();
-  }
-
-  /**
-   * whether to disable edit button (check if pagelimit is more than maximum allowed)
-   */
-  const shouldEditButtonDisabled = () => {
-    return pageLimit > RECORDEDIT_MAX_ROWS;
-  }
-
-  /**
-   * Condition to make sure at least one row can be updated
-   */
-  const canUpdate = () => {
-    const res = config.editable && page && reference && reference.canUpdate;
-
-    if (res) {
-      return page.tuples.some(function (row: any) {
-        return row.canUpdate;
-      });
-    }
-    return false;
-  };
-
   return (
     <div className='chaise-table-header row' ref={container}>
       <div
@@ -252,16 +241,13 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
           )}
 
           {/* Edit Button */}
-          {shouldShowEditButton() && (
-            <ChaiseTooltip
-              placement='bottom-end'
-              tooltip={shouldEditButtonDisabled() ? `Editing disabled when items per page > ${RECORDEDIT_MAX_ROWS}` : 'Edit this page of records.'}
-            >
+          {canShowEditButton && (
+            <ChaiseTooltip placement='bottom-end' tooltip={editButtonTooltip} >
               <span>
                 <button
                   className='chaise-btn chaise-btn-primary chaise-table-header-edit-link'
                   onClick={editRecord}
-                  disabled={shouldEditButtonDisabled()}
+                  disabled={disableEditButton}
                 >
                   <span className='chaise-btn-icon fa-solid fa-pen' />
                   <span>Bulk edit</span>

--- a/src/utils/record-utils.ts
+++ b/src/utils/record-utils.ts
@@ -7,7 +7,6 @@ import { RecordsetDisplayMode, RecordsetSelectMode } from '@isrd-isi-edu/chaise/
 // services
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
-import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 // utils
 import { CLASS_NAMES, RELATED_TABLE_DEFAULT_PAGE_SIZE } from '@isrd-isi-edu/chaise/src/utils/constants';
@@ -152,6 +151,7 @@ export function generateRelatedRecordModel(ref: any, index: number, isInline: bo
       isLoading: false,
       isInitialized: false,
       hasTimeoutError: false,
+      pageLimit: getRelatedPageLimit(ref),
     },
     recordsetProps: {
       initialPageLimit: getRelatedPageLimit(ref),
@@ -380,4 +380,13 @@ export function referenceHasRelatedEntities(reference: any): boolean {
   return reference && !(reference.related.length > 0 || reference.columns.some((col: any) => {
     return col.isInboundForeignKey || (col.isPathColumn && col.hasPath && !col.isUnique && !col.hasAggregate)
   }));
+}
+
+/**
+ * whether we can enable the bulk edit button.
+ * used in both the recordset and related tables
+ * @param page the displayed page of results
+ */
+export function isBulkEditEnabled(page: any): boolean {
+  return page && page.length > 0 && page.tuples.some((tuple: any) => tuple.canUpdate);
 }

--- a/test/e2e/data_setup/data/multi-permissions/dynamic_acl_related_table.json
+++ b/test/e2e/data_setup/data/multi-permissions/dynamic_acl_related_table.json
@@ -18,5 +18,15 @@
         "id": 4,
         "fk_col": 1,
         "name": "related four"
+    },
+    {
+        "id": 5,
+        "fk_col": 1,
+        "name": "related five"
+    },
+    {
+        "id": 6,
+        "fk_col": 1,
+        "name": "related six"
     }
 ]

--- a/test/e2e/data_setup/data/multi-permissions/dynamic_acl_related_table_2.json
+++ b/test/e2e/data_setup/data/multi-permissions/dynamic_acl_related_table_2.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": 1,
+        "fk_col": 1,
+        "name": "related 2 one"
+    },
+    {
+        "id": 2,
+        "fk_col": 1,
+        "name": "related 2 two"
+    }
+]

--- a/test/e2e/data_setup/schema/multi-permissions.json
+++ b/test/e2e/data_setup/schema/multi-permissions.json
@@ -901,11 +901,18 @@
                         },
                         {
                             "source": [
+                                {"inbound": ["multi-permissions", "dynamic_acl_related_table_2_fk1"]},
+                                "RID"
+                            ],
+                            "markdown_name": "related_2"
+                        },
+                        {
+                            "source": [
                                 {"inbound": ["multi-permissions", "dynamic_acl_assoc_table_fk1"]},
                                 {"outbound": ["multi-permissions", "dynamic_acl_assoc_table_fk2"]},
                                 "RID"
                             ],
-                            "markdown_name": "related_2"
+                            "markdown_name": "related_3"
                         }
                     ]
                 }
@@ -1026,6 +1033,61 @@
                         {
                             "column_name": "fk_col",
                             "table_name": "dynamic_acl_related_table",
+                            "schema_name": "multi-permissions"
+                        }
+                    ],
+                    "referenced_columns": [
+                        {
+                            "column_name": "id",
+                            "table_name": "dynamic_acl_main_table",
+                            "schema_name": "multi-permissions"
+                        }
+                    ]
+                }
+            ],
+            "column_definitions": [
+                {
+                    "name": "id",
+                    "nullok": false,
+                    "type": {
+                        "typename": "int2"
+                    }
+                },
+                {
+                    "name": "name",
+                    "type": {
+                        "typename": "text"
+                    }
+                },
+                {
+                    "name": "fk_col",
+                    "type": {
+                        "typename": "int2"
+                    }
+                }
+            ],
+            "annotations": {
+              "tag:isrd.isi.edu,2016:table-display": {
+                "*": {
+                  "page_size": 4
+                }
+              }
+            }
+        },
+        "dynamic_acl_related_table_2": {
+            "table_name": "dynamic_acl_related_table_2",
+            "schema_name": "multi-permissions",
+            "kind": "table",
+            "keys": [
+                {"unique_columns": ["id"]}
+            ],
+            "foreign_keys": [
+                {
+                    "names": [["multi-permissions", "dynamic_acl_related_table_2_fk1"]],
+                    "foreign_key_columns": [
+                        {
+                            "column_name": "fk_col",
+                            "table_name": "dynamic_acl_related_table_2",
                             "schema_name": "multi-permissions"
                         }
                     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",               /* Specify module resolution strategy: 'node' (Node.js), 'classic' (TypeScript pre-1.6), or 'bundler'. */
     "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     "paths": {                                      /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
       "@isrd-isi-edu/chaise/*": ["*"],


### PR DESCRIPTION
As described in #2663, the bulk edit button in record and recordset is inconsistent. This PR will change that.

The new logic for both cases is as follows:

- Hide the button if `update` right on the table is false  (or the edit is disabled by chaise-config)
- Disable the button if there aren’t any rows that the user can edit. This could be because there aren’t any rows, or the table has dynamic ACL and none of the displayed rows are editable.


Other changes in this PR:

- Updated the `moduleResolution` in `tsconfig.json` (`node` value is going to be deprecated). 
- Fixed the letter casing for the "Show more"/"Show details" buttons of facets.