### PR TITLE
fix: use localStorage instead of cookie for passing prefilled data to recordedit

### DIFF
--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -28,6 +28,7 @@ import ErrorProvider from '@isrd-isi-edu/chaise/src/providers/error';
 
 // services
 import { ConfigService, ConfigServiceSettings } from '@isrd-isi-edu/chaise/src/services/config';
+import { sweepStalePrefillEntries } from '@isrd-isi-edu/chaise/src/services/prefill-storage';
 
 // utils
 import { addClickListener } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
@@ -188,6 +189,9 @@ const AppWrapperInner = ({
   };
 
   useEffect(() => {
+    // sweep stale prefill localStorage entries
+    sweepStalePrefillEntries();
+
     const onError = (event: any) => {
       dispatchError({ error: event.error });
     };

--- a/src/components/record/related-table-actions.tsx
+++ b/src/components/record/related-table-actions.tsx
@@ -23,8 +23,8 @@ import {
 
 // services
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
-import { CookieService } from '@isrd-isi-edu/chaise/src/services/cookie';
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
+import { setPrefillData } from '@isrd-isi-edu/chaise/src/services/prefill-storage';
 
 // utils
 import {
@@ -245,11 +245,10 @@ const RelatedTableActions = ({
       relatedModel.initialReference.defaultLogInfo
     );
 
-    // Generate a unique cookie name and set it to expire after 24hrs.
-    const cookieName = 'recordedit-' + getRandomInt(0, Number.MAX_SAFE_INTEGER);
-    const cookieValue = getPrefillCookieObject(relatedModel.initialReference, recordPage.tuples[0]);
+    // Generate a unique id used as the localStorage key for the prefill data.
+    const prefillId = 'recordedit-' + getRandomInt(0, Number.MAX_SAFE_INTEGER);
     // eslint-disable-next-line react-hooks/purity
-    CookieService.setCookie(cookieName, cookieValue, new Date(Date.now() + 60 * 60 * 24 * 1000));
+    setPrefillData(prefillId, getPrefillCookieObject(relatedModel.initialReference, recordPage.tuples[0]));
 
     // Generate a unique id for this request
     // append it to the URL
@@ -270,7 +269,7 @@ const RelatedTableActions = ({
       addQueryParamsToURL(
         relatedModel.initialReference.unfilteredReference.contextualize.entryCreate.appLink,
         {
-          prefill: cookieName,
+          prefill: prefillId,
           invalidate: referrer_id,
         }
       ),

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -25,8 +25,8 @@ import { ChaiseAlertType } from '@isrd-isi-edu/chaise/src/providers/alerts';
 // services
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
 import $log from '@isrd-isi-edu/chaise/src/services/logger';
-import { CookieService } from '@isrd-isi-edu/chaise/src/services/cookie';
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
+import { removePrefillData } from '@isrd-isi-edu/chaise/src/services/prefill-storage';
 import RecordeditInitialLoadFlowControl from '@isrd-isi-edu/chaise/src/services/recordedit-initial-load-flow-control';
 import RecordeditWaitForFlowControl from '@isrd-isi-edu/chaise/src/services/recordedit-wait-for-flow-control';
 
@@ -583,9 +583,9 @@ export default function RecordeditProvider({
           // make sure the leave alert is disabled
           canLeaveRecordedit.current = true;
 
-          // cleanup the prefill query parameter
+          // cleanup the prefill localStorage entry
           if (queryParams.prefill) {
-            CookieService.deleteCookie(queryParams.prefill);
+            removePrefillData(queryParams.prefill);
           }
 
           // if there is a parent page, send a message that the edit/create is finished

--- a/src/services/prefill-storage.ts
+++ b/src/services/prefill-storage.ts
@@ -1,0 +1,50 @@
+// models
+import { PrefillObject } from '@isrd-isi-edu/chaise/src/models/recordedit';
+
+// services
+import $log from '@isrd-isi-edu/chaise/src/services/logger';
+
+// utils
+import LocalStorage from '@isrd-isi-edu/chaise/src/utils/storage';
+
+const KEY_PREFIX = 'chaise-prefill-';
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Store a prefill entry. Called by the parent page before opening a new
+ * recordedit tab.
+ */
+export const setPrefillData = (id: string, data: PrefillObject): void => {
+  LocalStorage.setStorage(KEY_PREFIX + id, { data, ts: Date.now() });
+};
+
+/**
+ * Read a prefill entry. Returns null if missing or malformed.
+ */
+export const getPrefillData = (id: string): PrefillObject | null => {
+  const stored = LocalStorage.getStorage(KEY_PREFIX + id);
+  if (!stored || typeof stored !== 'object' || !stored.data) return null;
+  return stored.data as PrefillObject;
+};
+
+/**
+ * Remove a prefill entry. Called by the child after a successful submit.
+ */
+export const removePrefillData = (id: string): void => {
+  LocalStorage.deleteStorageNamespace(KEY_PREFIX + id);
+};
+
+/**
+ * Sweep prefill entries older than the TTL. Called once on app boot so
+ * abandoned entries (user never submitted) eventually get cleaned up.
+ */
+export const sweepStalePrefillEntries = (): void => {
+  const now = Date.now();
+  LocalStorage.getKeysWithPrefix(KEY_PREFIX).forEach((key) => {
+    const stored = LocalStorage.getStorage(key);
+    if (!stored || typeof stored.ts !== 'number' || now - stored.ts > TTL_MS) {
+      $log.debug(`Removing stale prefill entry with key "${key}"`);
+      LocalStorage.deleteStorageNamespace(key);
+    }
+  });
+};

--- a/src/utils/recordedit-utils.ts
+++ b/src/utils/recordedit-utils.ts
@@ -14,9 +14,9 @@ import {
 import { DisabledRow, DisabledRowType, SelectedRow } from '@isrd-isi-edu/chaise/src/models/recordset';
 
 // services
-import { CookieService } from '@isrd-isi-edu/chaise/src/services/cookie';
 import { LogService } from '@isrd-isi-edu/chaise/src/services/log';
 import $log from '@isrd-isi-edu/chaise/src/services/logger';
+import { getPrefillData } from '@isrd-isi-edu/chaise/src/services/prefill-storage';
 
 // utilities
 import { simpleDeepCopy } from '@isrd-isi-edu/chaise/src/utils/data-utils';
@@ -740,30 +740,30 @@ export function populateLinkedData(reference: any, formNumber: number, foreignKe
  */
 export function getPrefillObject(queryParams: any): null | PrefillObject {
   if (!queryParams.prefill) return null;
-  const cookie = CookieService.getCookie(queryParams.prefill, true) as PrefillObject;
-  if (cookie == null || typeof cookie !== 'object') {
+  const stored = getPrefillData(queryParams.prefill);
+  if (stored == null || typeof stored !== 'object') {
     return null;
   }
 
   // make sure all the keys are in the object
   if (!(
-    ('keys' in cookie) && ('columnNameToRID' in cookie) && ('fkColumnNames' in cookie) &&
-    ('origUrl' in cookie) && ('rowname' in cookie)
+    ('keys' in stored) && ('columnNameToRID' in stored) && ('fkColumnNames' in stored) &&
+    ('origUrl' in stored) && ('rowname' in stored)
   )) {
     return null;
   }
 
   // validate the values
-  if (!Array.isArray(cookie.fkColumnNames) || typeof cookie.origUrl !== 'string') {
+  if (!Array.isArray(stored.fkColumnNames) || typeof stored.origUrl !== 'string') {
     return null;
   }
 
   return {
-    keys: cookie.keys,
-    fkColumnNames: cookie.fkColumnNames,
-    columnNameToRID: cookie.columnNameToRID,
-    origUrl: cookie.origUrl,
-    rowname: cookie.rowname
+    keys: stored.keys,
+    fkColumnNames: stored.fkColumnNames,
+    columnNameToRID: stored.columnNameToRID,
+    origUrl: stored.origUrl,
+    rowname: stored.rowname
   }
 }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,67 +1,78 @@
 import $log from '@isrd-isi-edu/chaise/src/services/logger';
 
 export default class LocalStorage {
-  static localStorageNotAvailable = false;
-
-  static localStorage: any = null;
-
-  // TODO: figure out how to initialize this
-  constructor() {
-    // a simple test to ensure localStorage is available
-    // (in some cases localStorage might be null)
+  static localStorageNotAvailable = (() => {
     try {
-      const test = 'test';
+      const test = '__chaise_storage_probe__';
       localStorage.setItem(test, test);
       localStorage.removeItem(test);
-    } catch (e: unknown) {
-      // $log.warn(messageMap.localStorageDisabled);
-      console.log('local storage disabled');
-      LocalStorage.localStorageNotAvailable = true;
+      return false;
+    } catch {
+      $log.warn('localStorage is not available');
+      return true;
     }
-  }
+  })();
+
+  static localStorage: any = null;
 
   /**
    * Deletes all the data in local storage defined under `storageLocation`
    *
-   * @param {String} storageLocation - name of object data is stored under
+   * @param storageLocation - name of object data is stored under
+   * @returns true if the operation succeeded
    */
-  static deleteStorageNamespace = function (storageLocation: string) {
-    if (LocalStorage.localStorageNotAvailable) return;
+  static deleteStorageNamespace = function (storageLocation: string): boolean {
+    if (LocalStorage.localStorageNotAvailable) return false;
 
-    localStorage.removeItem(storageLocation);
+    try {
+      localStorage.removeItem(storageLocation);
+      return true;
+    } catch (e) {
+      $log.warn(`failed to remove localStorage key "${storageLocation}"`, e);
+      return false;
+    }
   };
 
   /**
    * Deletes the data in local storage defined under `storageLocation` with `keyName`
    *
-   * @param {String} storageLocation - name of object data is stored under
-   * @param {String} keyName - key name of the data to be deleted
+   * @param storageLocation - name of object data is stored under
+   * @param keyName - key name of the data to be deleted
+   * @returns true if the operation succeeded
    */
-  static deleteStorageValue = function (storageLocation: string, keyName: string) {
-    if (LocalStorage.localStorageNotAvailable) return;
+  static deleteStorageValue = function (storageLocation: string, keyName: string): boolean {
+    if (LocalStorage.localStorageNotAvailable) return false;
 
     const value = LocalStorage.getStorage(storageLocation);
+    if (!value) return false;
 
     delete value[keyName];
-    LocalStorage.setStorage(storageLocation, value);
+    return LocalStorage.setStorage(storageLocation, value);
   };
 
   /**
    * Stores data in local storage under `storageLocation`
    *
-   * @param {String} storageLocation - name of object data is stored under
-   * @param {Object} data - data to be stored
+   * @param storageLocation - name of object data is stored under
+   * @param data - data to be stored
+   * @returns true if the operation succeeded
    */
-  static setStorage = function (storageLocation: string, data: object) {
-    if (LocalStorage.localStorageNotAvailable) return;
+  static setStorage = function (storageLocation: string, data: object): boolean {
+    if (LocalStorage.localStorageNotAvailable) return false;
 
-    localStorage.setItem(storageLocation, JSON.stringify(data));
+    try {
+      localStorage.setItem(storageLocation, JSON.stringify(data));
+      return true;
+    } catch (e) {
+      $log.warn(`failed to write localStorage key "${storageLocation}"`, e);
+      return false;
+    }
   };
 
   /**
    * Gets the data in local storage defined under `storageLocation`
    *
-   * @param {String} storageLocation - name of object data is stored under
+   * @param storageLocation - name of object data is stored under
    */
   static getStorage = function (storageLocation: string) {
     if (LocalStorage.localStorageNotAvailable) return null;
@@ -78,11 +89,12 @@ export default class LocalStorage {
   /**
    * Updates the data in local storage under `storageLocation`
    *
-   * @param {Object} data - data to be updated
-   * @param {String} storageLocation - name of object data is stored under
+   * @param storageLocation - name of object data is stored under
+   * @param data - data to be merged into the existing entry
+   * @returns true if the operation succeeded
    */
-  static updateStorage = function (storageLocation: string, data: any) {
-    if (LocalStorage.localStorageNotAvailable) return;
+  static updateStorage = function (storageLocation: string, data: any): boolean {
+    if (LocalStorage.localStorageNotAvailable) return false;
 
     const storedData = LocalStorage.getStorage(storageLocation) || {} as any;
 
@@ -90,8 +102,28 @@ export default class LocalStorage {
       storedData[key] = data[key];
     });
 
-    LocalStorage.setStorage(storageLocation, storedData);
+    return LocalStorage.setStorage(storageLocation, storedData);
   };
 
-  static isAvailable = (LocalStorage.localStorageNotAvailable === false);
+  /**
+   * Returns all localStorage keys that start with the given prefix.
+   * Use this instead of touching `window.localStorage` directly so callers
+   * stay isolated from the storage availability check.
+   *
+   * @param prefix - the key prefix to match
+   */
+  static getKeysWithPrefix = function (prefix: string): string[] {
+    if (LocalStorage.localStorageNotAvailable) return [];
+
+    const keys: string[] = [];
+    try {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith(prefix)) keys.push(key);
+      }
+    } catch (e) {
+      $log.warn('failed to iterate localStorage keys', e);
+    }
+    return keys;
+  };
 }


### PR DESCRIPTION
Fixes https://github.com/informatics-isi-edu/chaise/issues/2759.

By using `localStorage`, we're ensuring that the stored value doesn't get sent along with unrelated chaise HTTP requests. Since `localStorage` doesn't have built-in expiry, I made sure to store a timestamp alongside the prefilled data. On each page load, we check the stored values and delete any that have expired.

Initially, I considered using the `BroadcastChannel` API to pass data to recordedit. But if the user refreshes the recordedit tab after the parent record page has been closed, the prefill data would be gone. So we decided against it.