### PR TITLE
feat (viewer): allow users to rotate the image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ npm link @isrd-isi-edu/ermrestjs
 - Avoid `any` types
 - Single quotes, semicolons, 2-space indent
 - All functions must have proper JSDoc comments (you can skip the return type if it's self-explanatory)
+- **SCSS colors**: never use a hex/literal color directly in SCSS. Either reuse an existing general-purpose entry from `src/assets/scss/maps/_color-map.scss`, or add a new entry there and reference it via `map.get(variables.$color-map, '<key>')`.
 
 ## Commit Messages
 

--- a/config/viewer-config-sample.js
+++ b/config/viewer-config-sample.js
@@ -34,6 +34,11 @@ var viewerConfigs = {
             // what should be displayed in the page title in full screen mode (non-iframe)
             "page_title_markdown_pattern": "",
 
+            // (optional) a jsonb column that holds the settings for the image (e.g., rotate)
+            // "image_config_column_name": "Config",
+            // (optional) the format version that should be used (default is "1.0")
+            // "image_config_format_version": "1.0",
+
             /**
              * @DEPRECATED This is here for just backward compatibilty and should not be used.
              * if defined and value is none-empty, we will not send any extra request for image channel info

--- a/docs/viewer/viewer-config.md
+++ b/docs/viewer/viewer-config.md
@@ -187,3 +187,14 @@ So an example of a stored channel config looks like the following:
   }
 }
 ```
+
+
+```json
+{
+  "name": "image-parameters",
+  "version": "1.0",
+  "config": {
+      "rotate": 180
+  }
+}
+```

--- a/docs/viewer/viewer-config.md
+++ b/docs/viewer/viewer-config.md
@@ -13,7 +13,8 @@ The following is the assumed model of a fully-configured viewer app:
 
 (All the table and column names are configurable)
 
-- `Image` table is the entry point of the viewer app.
+- `Image` table is the entry point of the viewer app. It can also store image-level
+  settings such as the default rotation (see [image configuration](#image-configuration)).
 - `Processed_Image` table is the actual table that stores the data for each image channel
   in each z-plane. For example, if an image has two stored z-indices and each one has
   two channels, there will be 4 records of `Processed_Image` table.
@@ -84,6 +85,11 @@ will manipulate the displayed colors for each channel. This column is defined as
 
 ```
 > If the Config column is not defined, or the value is not in the expected format, the OSD viewer will use the default values.
+
+The column value may be a single object as shown above, or an **array of such objects**.
+When it's an array, the viewer picks the first entry whose `name` and `version` match the
+expected format (`"channel-parameters"` / `"1.0"`); the rest are ignored. This lets you keep
+multiple parameter sets (e.g. for different format versions) in the same column.
 
 Currently, in the viewer app, we're using `"channel-parameters"` as the format name and `"1.0"`
 as the version number. And the config attributes are as follows:
@@ -188,6 +194,53 @@ So an example of a stored channel config looks like the following:
 }
 ```
 
+## Image Configuration
+
+The `Image` table can have a config column (`image_config_column_name`) that stores
+image-level settings. Currently this is used to persist the default rotation. Like the
+channel config, this is a `jsonb` column with the following expected structure:
+
+```json
+{
+  "name": "<format-name>",
+  "version": "<format-version>",
+  "config": {
+
+  }
+}
+```
+> If the column is not defined, or the value is not in the expected format, the OSD viewer will use the default values.
+
+As with the channel config, the column value may be a single object or an **array of such
+objects**. When it's an array, the viewer uses the first entry whose `name` and `version`
+match the expected format; the rest are ignored.
+
+Currently the viewer app uses `"image-parameters"` as the format name and `"1.0"` as the
+version number (the version can be overridden via `image_config_format_version`). The config
+attributes are as follows:
+
+<table>
+    <tbody>
+        <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Acceptable values</th>
+            <th>Default value</th>
+        </tr>
+        <tr>
+            <td><strong>rotate</strong></td>
+            <td>
+                The default rotation (in degrees, clockwise) applied to the image when
+                the viewer loads. Users with update permission on the config column can
+                change and save this from the toolbar.
+            </td>
+            <td>Integers in [0, 360) range (typically 0, 90, 180, 270)</td>
+            <td>0</td>
+        </tr>
+    </tbody>
+</table>
+
+So an example of a stored image config looks like the following:
 
 ```json
 {

--- a/src/assets/scss/_button-group.scss
+++ b/src/assets/scss/_button-group.scss
@@ -50,7 +50,7 @@
 .chaise-btn-group-text {
   display: flex;
   align-items: center;
-  padding: variables.$btn-padding-y variables.$btn-padding-x;
+  padding: variables.$btn-padding-y variables.$group-btn-text-padding-x;
   margin-bottom: 0;
   font-size: 1rem;
   color: map.get(variables.$color-map, 'black');

--- a/src/assets/scss/_button-group.scss
+++ b/src/assets/scss/_button-group.scss
@@ -57,7 +57,7 @@
   text-align: center;
   white-space: nowrap;
   background-color: map.get(variables.$color-map, 'chaise-btn-group-text');
-  border: variables.$btn-border-width solid map.get(variables.$color-map, 'border');
+  border: variables.$btn-border-width solid map.get(variables.$color-map, 'black');
   @include helpers.border-radius(variables.$btn-border-radius);
 }
 

--- a/src/assets/scss/_button-group.scss
+++ b/src/assets/scss/_button-group.scss
@@ -43,20 +43,41 @@
   }
 }
 
+// Textual addon inside a chaise-btn-group. Same role as
+// .chaise-input-group-text for input groups: a non-clickable label cell that
+// sits flush with the adjacent buttons and shares their border-radius and
+// negative-margin overlap behavior.
+.chaise-btn-group-text {
+  display: flex;
+  align-items: center;
+  padding: variables.$btn-padding-y variables.$btn-padding-x;
+  margin-bottom: 0;
+  font-size: 1rem;
+  color: map.get(variables.$color-map, 'black');
+  text-align: center;
+  white-space: nowrap;
+  background-color: map.get(variables.$color-map, 'chaise-btn-group-text');
+  border: variables.$btn-border-width solid map.get(variables.$color-map, 'border');
+  @include helpers.border-radius(variables.$btn-border-radius);
+}
+
 .chaise-btn-group {
-  // Prevent double borders when buttons are next to each other
+  // Prevent double borders when adjacent children touch.
   > .chaise-btn-group:not(:first-child):not([disabled]),
-  > .chaise-btn:not(:first-child):not([disabled]) {
+  > .chaise-btn:not(:first-child):not([disabled]),
+  > .chaise-btn-group-text:not(:first-child) {
     margin-left: variables.$btn-border-width * -1;
   }
-  // Reset rounded corners
+  // Reset rounded corners on the side that touches a sibling.
   > .chaise-btn-group:not(:last-child) > .chaise-btn,
-  > .chaise-btn:not(:last-child):not(.dropdown-toggle) {
+  > .chaise-btn:not(:last-child):not(.dropdown-toggle),
+  > .chaise-btn-group-text:not(:last-child) {
     @include helpers.border-right-radius(0);
   }
 
   > .chaise-btn-group:not(:first-child) > .chaise-btn,
-  > .chaise-btn:not(:first-child) {
+  > .chaise-btn:not(:first-child),
+  > .chaise-btn-group-text:not(:first-child) {
     @include helpers.border-left-radius(0);
   }
 }

--- a/src/assets/scss/_buttons.scss
+++ b/src/assets/scss/_buttons.scss
@@ -52,8 +52,12 @@
 
   &.chaise-btn.chaise-btn-primary[disabled],
   &.chaise-btn.chaise-btn-secondary[disabled],
+  &.chaise-btn.chaise-btn-danger[disabled],
+  &.chaise-btn.chaise-btn-success[disabled],
   &.chaise-btn.chaise-btn-primary.disabled,
-  &.chaise-btn.chaise-btn-secondary.disabled {
+  &.chaise-btn.chaise-btn-secondary.disabled,
+  &.chaise-btn.chaise-btn-danger.disabled,
+  &.chaise-btn.chaise-btn-success.disabled {
     color: map.get(variables.$color-map, 'disabled');
     background-color: map.get(variables.$color-map, 'disabled-background');
     border-color: map.get(variables.$color-map, 'disabled-background');
@@ -85,6 +89,12 @@
     color: map.get(variables.$color-map, 'white');
     background-color: map.get(variables.$color-map, 'danger');
     border-color: color.adjust(map.get(variables.$color-map, 'danger'), $lightness: -10%);
+  }
+
+  &.chaise-btn-success {
+    color: map.get(variables.$color-map, 'white');
+    background-color: map.get(variables.$color-map, 'success');
+    border-color: color.adjust(map.get(variables.$color-map, 'success'), $lightness: -10%);
   }
 
   &.chaise-download-btn {

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -16,6 +16,7 @@ $btn-padding-y: 4px;
 $btn-padding-x: 10px;
 $btn-padding-sm-y: 2px;
 $btn-padding-sm-x: 5px;
+$group-btn-text-padding-x: 5px;
 
 // input
 $input-remove-width: 18px;

--- a/src/assets/scss/_viewer.scss
+++ b/src/assets/scss/_viewer.scss
@@ -47,6 +47,36 @@
       margin-right: 5px;
       margin-bottom: 5px;
     }
+
+    // When buttons are wrapped in a chaise-btn-group, they should be visually
+    // attached (no inter-button gap). The group itself keeps the standard
+    // right/bottom spacing so it doesn't crowd neighboring toolbar buttons.
+    .chaise-btn-group {
+      margin-right: 5px;
+      margin-bottom: 5px;
+      > .chaise-btn {
+        margin-right: 0;
+        margin-bottom: 0;
+
+        // Match the default chaise-btn-primary border (black) for every button
+        // and every interaction state. Without this, the success/danger
+        // variants use a darker-green/darker-red border, and hover/focus can
+        // shift the border color further. We want the same visible black
+        // border at all times so the grouped buttons match the rest of the
+        // toolbar.
+        //
+        // The :not([disabled]):not(.disabled) guard lets the global disabled
+        // rule (which sets a grey border) win when the button is disabled.
+        &:not([disabled]):not(.disabled) {
+          &,
+          &:hover,
+          &:focus,
+          &:active {
+            border-color: map.get(variables.$color-map, 'black');
+          }
+        }
+      }
+    }
   }
 
   // viewer error overlay

--- a/src/assets/scss/_viewer.scss
+++ b/src/assets/scss/_viewer.scss
@@ -41,61 +41,6 @@
     padding-top: 10px;
   }
 
-  // Hamburger-style rotation menu (experimental variant). Hide the default
-  // dropdown caret so the toggle reads as a clean hamburger icon.
-  .viewer-rotate-menu .dropdown-toggle::after {
-    display: none;
-  }
-
-  // Banner that appears at the top of the image area while the viewport is
-  // rotated but the rotation hasn't been saved/discarded yet. Portal-ed into
-  // .main-body by ViewerMenuButtons.
-  .viewer-rotation-banner {
-    position: absolute;
-    top: 10px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 10;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
-    background: rgba(255, 255, 255, 0.95);
-    border: 1px solid map.get(variables.$color-map, 'border');
-    border-radius: 4px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-    white-space: nowrap;
-
-    .viewer-rotation-banner-text {
-      font-size: 0.9rem;
-      color: map.get(variables.$color-map, 'black');
-    }
-  }
-
-  // Collapsed banner — small tab poking down from the top center, clickable to
-  // re-expand the banner. Hugs the very top edge so the rest of the image area
-  // is free; bottom corners rounded so it reads as a tab pulled down.
-  .viewer-rotation-banner-tab {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 10;
-    padding: 2px 14px;
-    border-top: none !important;
-    border-top-left-radius: 0;
-    border-top-right-radius: 0;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
-  }
-
-  // Slightly soften the dismiss button so it doesn't compete with Save/Discard.
-  .viewer-rotation-banner-dismiss {
-    opacity: 0.7;
-    &:hover { opacity: 1; }
-  }
-
   .menu-btn-container {
     padding-top: 5px;
     .chaise-btn {

--- a/src/assets/scss/_viewer.scss
+++ b/src/assets/scss/_viewer.scss
@@ -41,6 +41,61 @@
     padding-top: 10px;
   }
 
+  // Hamburger-style rotation menu (experimental variant). Hide the default
+  // dropdown caret so the toggle reads as a clean hamburger icon.
+  .viewer-rotate-menu .dropdown-toggle::after {
+    display: none;
+  }
+
+  // Banner that appears at the top of the image area while the viewport is
+  // rotated but the rotation hasn't been saved/discarded yet. Portal-ed into
+  // .main-body by ViewerMenuButtons.
+  .viewer-rotation-banner {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid map.get(variables.$color-map, 'border');
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    white-space: nowrap;
+
+    .viewer-rotation-banner-text {
+      font-size: 0.9rem;
+      color: map.get(variables.$color-map, 'black');
+    }
+  }
+
+  // Collapsed banner — small tab poking down from the top center, clickable to
+  // re-expand the banner. Hugs the very top edge so the rest of the image area
+  // is free; bottom corners rounded so it reads as a tab pulled down.
+  .viewer-rotation-banner-tab {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    padding: 2px 14px;
+    border-top: none !important;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+  }
+
+  // Slightly soften the dismiss button so it doesn't compete with Save/Discard.
+  .viewer-rotation-banner-dismiss {
+    opacity: 0.7;
+    &:hover { opacity: 1; }
+  }
+
   .menu-btn-container {
     padding-top: 5px;
     .chaise-btn {
@@ -51,10 +106,21 @@
     // When buttons are wrapped in a chaise-btn-group, they should be visually
     // attached (no inter-button gap). The group itself keeps the standard
     // right/bottom spacing so it doesn't crowd neighboring toolbar buttons.
-    .chaise-btn-group {
+    //
+    // The outer 5px margin is applied only to direct chaise-btn-group children
+    // of .menu-btn-container — otherwise nested groups (e.g. the react-bootstrap
+    // Dropdown wrapper that we also tag with chaise-btn-group for its visual
+    // attachment rules) would double the margin.
+    //
+    // The .chaise-btn override below uses a descendant (not direct-child)
+    // selector so it also reaches toggles wrapped by react-bootstrap Dropdown
+    // (which inserts a wrapper between the group and the button).
+    > .chaise-btn-group {
       margin-right: 5px;
       margin-bottom: 5px;
-      > .chaise-btn {
+    }
+    .chaise-btn-group {
+      .chaise-btn {
         margin-right: 0;
         margin-bottom: 0;
 

--- a/src/assets/scss/maps/_color-map.scss
+++ b/src/assets/scss/maps/_color-map.scss
@@ -3,6 +3,7 @@ $map: (
   'accordion-inner-header-background': #f1f1f1,
   'black': #333,
   'border': #ccc,
+  'chaise-btn-group-text': #d6d6d6,
   'code-block': #c7254e,
   'code-block-background': #f9f2f4,
   'code-block-background-alt': #f5f5f5,

--- a/src/assets/scss/maps/_color-map.scss
+++ b/src/assets/scss/maps/_color-map.scss
@@ -49,6 +49,7 @@ $map: (
   'record-status-link-color': darkblue,
   'record-status-success': rgba(113, 195, 129, 0.68),
   'record-status-warning': rgba(232, 170, 82, 0.38),
+  'success': #5cb85c,
   'spinner': #6e6e6e,
   'spinner-alt': #828282,
   'spinner-background': #d9edf7,

--- a/src/assets/scss/maps/_color-map.scss
+++ b/src/assets/scss/maps/_color-map.scss
@@ -3,7 +3,7 @@ $map: (
   'accordion-inner-header-background': #f1f1f1,
   'black': #333,
   'border': #ccc,
-  'chaise-btn-group-text': #d6d6d6,
+  'chaise-btn-group-text': #f1f1f1,
   'code-block': #c7254e,
   'code-block-background': #f9f2f4,
   'code-block-background-alt': #f5f5f5,

--- a/src/components/icons/rotate-left.tsx
+++ b/src/components/icons/rotate-left.tsx
@@ -1,0 +1,65 @@
+type Props = { className?: string; width?: number };
+
+const RotateLeftIcon = ({ className, width = 14 }: Props) => (
+  // <svg
+  //   style={{ width: '23px', paddingBottom: '2px' }}
+  //   className={className}
+  //   viewBox='0 0 24 24'
+  //   fill='none'
+  //   stroke='currentColor'
+  //   strokeWidth='2'
+  //   strokeLinecap='round'
+  //   strokeLinejoin='round'
+  //   aria-hidden='true'
+  // >
+  //   {/* version 01 */}
+  //   {/* Object being rotated */}
+  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
+  //   {/* Arc: cubic Bezier — longer vertical run on the right, larger radius at the top transition */}
+  //   {/* <path d='M 17 16 C 17 8 18 6 8 6' /> */}
+  //   {/* Stretched chevron unchanged */}
+  //   {/* <polyline points='13 4 8 6 13 8' /> */}
+
+  //   {/* version 02 */}
+  //   {/* Object being rotated */}
+  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
+  //   {/* Arc: tail further right (19), head further up (y=4), larger gap to the square in both directions */}
+  //   {/* <path d='M 19 16 C 19 7 18 4 8 4' /> */}
+  //   {/* Chevron raised to (8, 4), arms shifted up */}
+  //   {/* <polyline points='13 2 8 4 13 6' /> */}
+
+  //   {/* version 03 */}
+  //   {/* Object being rotated */}
+  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
+  //   {/* Arc shaft */}
+  //   {/* <path d='M 19 16 C 19 7 18 4 8 4' /> */}
+  //   {/* Chevron with 90° spread (±45°) — wider so three lines stay distinct at small sizes */}
+  //   {/* <polyline points='11 1 8 4 11 7' /> */}
+
+  //   {/* version 04 */}
+  //   {/* Object being rotated */}
+  //   <rect x='2' y='10' width='12' height='12' rx='1.5' />
+  //   {/* Arc shaft: terminates at the back of the triangle (x=12) */}
+  //   <path d='M 19 16 C 19 8 17 4 12 4' />
+  //   {/* Filled triangle arrowhead: tip at (8, 4), base from (12, 1) to (12, 7) */}
+  //   <polygon points='8 4 12 1 12 7' fill='currentColor' stroke='none' />
+  // </svg>
+
+  <svg
+    style={{ width: `${width}px`, paddingBottom: '2px' }}
+    className={className}
+    viewBox='0 0 14 14'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.25'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+  >
+    <rect x='1.17' y='5.83' width='7' height='7' rx='0.88' />
+    <path d='M 11.08 9.33 C 11.08 4.08 10.5 2.33 4.67 2.33' />
+    <polyline points='6.42 0.58 4.67 2.33 6.42 4.08' />
+  </svg>
+);
+
+export default RotateLeftIcon;

--- a/src/components/icons/rotate-left.tsx
+++ b/src/components/icons/rotate-left.tsx
@@ -1,50 +1,6 @@
 type Props = { className?: string; width?: number };
 
 const RotateLeftIcon = ({ className, width = 14 }: Props) => (
-  // <svg
-  //   style={{ width: '23px', paddingBottom: '2px' }}
-  //   className={className}
-  //   viewBox='0 0 24 24'
-  //   fill='none'
-  //   stroke='currentColor'
-  //   strokeWidth='2'
-  //   strokeLinecap='round'
-  //   strokeLinejoin='round'
-  //   aria-hidden='true'
-  // >
-  //   {/* version 01 */}
-  //   {/* Object being rotated */}
-  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
-  //   {/* Arc: cubic Bezier — longer vertical run on the right, larger radius at the top transition */}
-  //   {/* <path d='M 17 16 C 17 8 18 6 8 6' /> */}
-  //   {/* Stretched chevron unchanged */}
-  //   {/* <polyline points='13 4 8 6 13 8' /> */}
-
-  //   {/* version 02 */}
-  //   {/* Object being rotated */}
-  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
-  //   {/* Arc: tail further right (19), head further up (y=4), larger gap to the square in both directions */}
-  //   {/* <path d='M 19 16 C 19 7 18 4 8 4' /> */}
-  //   {/* Chevron raised to (8, 4), arms shifted up */}
-  //   {/* <polyline points='13 2 8 4 13 6' /> */}
-
-  //   {/* version 03 */}
-  //   {/* Object being rotated */}
-  //   {/* <rect x='2' y='10' width='12' height='12' rx='1.5' /> */}
-  //   {/* Arc shaft */}
-  //   {/* <path d='M 19 16 C 19 7 18 4 8 4' /> */}
-  //   {/* Chevron with 90° spread (±45°) — wider so three lines stay distinct at small sizes */}
-  //   {/* <polyline points='11 1 8 4 11 7' /> */}
-
-  //   {/* version 04 */}
-  //   {/* Object being rotated */}
-  //   <rect x='2' y='10' width='12' height='12' rx='1.5' />
-  //   {/* Arc shaft: terminates at the back of the triangle (x=12) */}
-  //   <path d='M 19 16 C 19 8 17 4 12 4' />
-  //   {/* Filled triangle arrowhead: tip at (8, 4), base from (12, 1) to (12, 7) */}
-  //   <polygon points='8 4 12 1 12 7' fill='currentColor' stroke='none' />
-  // </svg>
-
   <svg
     style={{ width: `${width}px`, paddingBottom: '2px' }}
     className={className}

--- a/src/components/icons/rotate-right.tsx
+++ b/src/components/icons/rotate-right.tsx
@@ -1,0 +1,24 @@
+type Props = { className?: string; width?: number };
+
+const RotateRightIcon = ({ className, width = 14 }: Props) => (
+  <svg
+    style={{ width: `${width}px`, paddingBottom: '2px' }}
+    className={className}
+    viewBox='0 0 14 14'
+    fill='none'
+    stroke='currentColor'
+    strokeWidth='1.25'
+    strokeLinecap='round'
+    strokeLinejoin='round'
+    aria-hidden='true'
+  >
+    {/* Square: 7x7 in lower-right (mirror of rotate-left v6) */}
+    <rect x='5.83' y='5.83' width='7' height='7' rx='0.88' />
+    {/* Arc shaft: tail at left, curves up and over to apex on the right */}
+    <path d='M 2.92 9.33 C 2.92 4.08 3.5 2.33 9.33 2.33' />
+    {/* Chevron arrowhead: apex (9.33, 2.33) points right, arms to (7.58, 0.58) and (7.58, 4.08) */}
+    <polyline points='7.58 0.58 9.33 2.33 7.58 4.08' />
+  </svg>
+);
+
+export default RotateRightIcon;

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -35,6 +35,11 @@ const ViewerMenuButtons = (): JSX.Element => {
 
   const [showChannelList, setShowChannelList] = useState(false);
   const [waitingForScreenshot, setWaitingForScreenshot] = useState(false);
+  /**
+   * Current display rotation in degrees, normalized to [0, 360).
+   * Mirrors what OSD is showing so we can decide when to surface the Save/Reset controls.
+   */
+  const [currentRotation, setCurrentRotation] = useState(0);
 
   useEffect(() => {
     const recieveIframeMessage = (event: any) => {
@@ -99,6 +104,29 @@ const ViewerMenuButtons = (): JSX.Element => {
     }
 
     logViewerClientAction(action, false);
+  }
+
+  const rotateImage = () => {
+    const degrees = -90;
+    getOSDViewerIframe().contentWindow!.postMessage(
+      { messageType: 'rotate', content: { degrees } },
+      origin,
+    );
+    setCurrentRotation((prev) => (((prev + degrees) % 360) + 360) % 360);
+    logViewerClientAction(LogActions.VIEWER_ROTATE, false);
+  }
+
+  const resetRotation = () => {
+    getOSDViewerIframe().contentWindow!.postMessage({ messageType: 'resetRotation' }, origin);
+    setCurrentRotation(0);
+    logViewerClientAction(LogActions.VIEWER_ROTATE_RESET, false);
+  }
+
+  const saveRotation = () => {
+    // TODO(rotation): persist current rotation to the Image table once the
+    // schema/ACL (canUpdateImageConfig) is wired up. For now this is a no-op
+    // so the UI flow is testable without DB writes.
+    logViewerClientAction(LogActions.VIEWER_ROTATE_SAVE, false);
   }
 
   const takeScreenshot = () => {
@@ -185,6 +213,45 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>Reset Zoom</span>
         </button>
       </ChaiseTooltip>
+      <div className='chaise-btn-group'>
+        <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
+          <button
+            className='chaise-btn chaise-btn-primary'
+            type='button'
+            onClick={rotateImage}
+            disabled={disableFeatures}
+          >
+            <span className='chaise-btn-icon fa-solid fa-arrows-rotate'></span>
+            <span>Rotate Left</span>
+          </button>
+        </ChaiseTooltip>
+        {currentRotation !== 0 && (
+          <>
+            <ChaiseTooltip placement='top' tooltip='Save rotation'>
+              <button
+                className='chaise-btn chaise-btn-success icon-btn'
+                type='button'
+                onClick={saveRotation}
+                disabled={disableFeatures}
+                aria-label='Save rotation'
+              >
+                <span className='chaise-btn-icon fa-solid fa-check'></span>
+              </button>
+            </ChaiseTooltip>
+            <ChaiseTooltip placement='top' tooltip='Discard rotation and return to original orientation'>
+              <button
+                className='chaise-btn chaise-btn-danger icon-btn'
+                type='button'
+                onClick={resetRotation}
+                disabled={disableFeatures}
+                aria-label='Discard rotation'
+              >
+                <span className='chaise-btn-icon fa-solid fa-xmark'></span>
+              </button>
+            </ChaiseTooltip>
+          </>
+        )}
+      </div>
       <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
         <button
           className='chaise-btn chaise-btn-primary'

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useRef, useState, type JSX } from 'react';
-import { createPortal } from 'react-dom';
+import { useEffect, useState, type JSX } from 'react';
 
 // components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
-import Dropdown from 'react-bootstrap/Dropdown';
 import Spinner from 'react-bootstrap/Spinner';
 
 // hooks
@@ -39,17 +37,6 @@ const ViewerMenuButtons = (): JSX.Element => {
 
   const [showChannelList, setShowChannelList] = useState(false);
   const [waitingForScreenshot, setWaitingForScreenshot] = useState(false);
-  /**
-   * Current display rotation in degrees, normalized to [0, 360).
-   * Mirrors what OSD is showing so we can decide when to surface the Save/Reset controls.
-   */
-  const [currentRotation, setCurrentRotation] = useState(0);
-  /**
-   * Whether the rotation overlay banner has been tucked away. Resets on every
-   * new rotation / discard so transitions always start with the banner visible
-   * again. Set to true on Save so the user can tuck it after committing.
-   */
-  const [bannerCollapsed, setBannerCollapsed] = useState(false);
 
   useEffect(() => {
     const recieveIframeMessage = (event: any) => {
@@ -79,9 +66,8 @@ const ViewerMenuButtons = (): JSX.Element => {
 
     return () => {
       windowRef.removeEventListener('message', recieveIframeMessage);
-    }
+    };
   }, []);
-
 
   //------------------- UI related callbacks: --------------------//
 
@@ -114,94 +100,40 @@ const ViewerMenuButtons = (): JSX.Element => {
     }
 
     logViewerClientAction(action, false);
-  }
+  };
 
   const rotateImage = (degrees: number) => {
     getOSDViewerIframe().contentWindow!.postMessage(
       { messageType: 'rotate', content: { degrees } },
-      origin,
+      origin
     );
-    setCurrentRotation((prev) => (((prev + degrees) % 360) + 360) % 360);
-    // Every new rotation re-surfaces the banner; previous "tucked" state is
-    // about old information.
-    setBannerCollapsed(false);
-    logViewerClientAction(LogActions.VIEWER_ROTATE, false);
-  }
+    logViewerClientAction(LogActions.VIEWER_ROTATE, false, undefined, { degrees });
+  };
 
   const resetRotation = () => {
     getOSDViewerIframe().contentWindow!.postMessage({ messageType: 'resetRotation' }, origin);
-    setCurrentRotation(0);
-    setBannerCollapsed(false);
     logViewerClientAction(LogActions.VIEWER_ROTATE_RESET, false);
-  }
-
-  const saveRotation = () => {
-    // TODO(rotation): persist current rotation to the Image table once the
-    // schema/ACL (canUpdateImageConfig) is wired up. For now this is a no-op
-    // so the UI flow is testable without DB writes.
-    // Tuck the banner — user just acted on it, it should get out of the way.
-    setBannerCollapsed(true);
-    logViewerClientAction(LogActions.VIEWER_ROTATE_SAVE, false);
-  }
+  };
 
   const takeScreenshot = () => {
     setWaitingForScreenshot(true);
 
     const filename = imageID || 'image';
-    getOSDViewerIframe().contentWindow!.postMessage({ messageType: 'downloadView', content: filename }, origin);
+    getOSDViewerIframe().contentWindow!.postMessage(
+      { messageType: 'downloadView', content: filename },
+      origin
+    );
 
     logViewerClientAction(LogActions.VIEWER_SCREENSHOT, false);
-  }
-
-  //-------------------  render helpers:   --------------------//
-
-  /**
-   * The three icon buttons inside the Rotate trio. Returned as a fragment so
-   * it can be dropped into each label-style variant below.
-   */
-  const renderRotateTrioButtons = () => (
-    <>
-      <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
-        <button
-          className='chaise-btn chaise-btn-primary icon-btn'
-          type='button'
-          onClick={() => rotateImage(-90)}
-          disabled={disableFeatures}
-          aria-label='Rotate left'
-        >
-          <RotateLeftIcon className='chaise-btn-icon' width={17} />
-        </button>
-      </ChaiseTooltip>
-      <ChaiseTooltip placement='top' tooltip='Rotate image 90° clockwise'>
-        <button
-          className='chaise-btn chaise-btn-primary icon-btn'
-          type='button'
-          onClick={() => rotateImage(90)}
-          disabled={disableFeatures}
-          aria-label='Rotate right'
-        >
-          <RotateRightIcon className='chaise-btn-icon' width={17} />
-        </button>
-      </ChaiseTooltip>
-      <ChaiseTooltip placement='top' tooltip='Discard rotation and return to original orientation'>
-        <button
-          className='chaise-btn chaise-btn-primary icon-btn'
-          type='button'
-          onClick={resetRotation}
-          disabled={disableFeatures}
-          aria-label='Discard rotation'
-        >
-          <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
-        </button>
-      </ChaiseTooltip>
-    </>
-  );
+  };
 
   //-------------------  render logics:   --------------------//
   const disableFeatures = !mainImageLoaded;
 
   let toggleAnnotationSidebarTooltip = hideAnnotationSidebar ? 'Show ' : 'Hide ';
-  toggleAnnotationSidebarTooltip += annotationFormProps ? 'the annotation entry form' : 'the list of annotations';
+  toggleAnnotationSidebarTooltip += annotationFormProps
+    ? 'the annotation entry form'
+    : 'the list of annotations';
 
   let toggleAnnotationSidebarLabel = hideAnnotationSidebar ? 'Show ' : 'Hide ';
   toggleAnnotationSidebarLabel += annotationFormProps ? 'Annotation form' : 'Annotations';
@@ -211,72 +143,7 @@ const ViewerMenuButtons = (): JSX.Element => {
     screenshotTooltip = 'Processing the screenshot...';
   }
 
-  // Find the iframe's containing element so the rotation banner can be
-  // portal-ed in as an overlay at the top of the image area. Re-evaluated on
-  // every render so it picks up the element once it mounts.
-  const mainBodyEl = typeof document !== 'undefined' ? document.querySelector('.main-body') : null;
-
-  const rotationBanner = currentRotation !== 0 && mainBodyEl ? createPortal(
-    bannerCollapsed ? (
-      // Collapsed: a small tab poking down from the top of the image area.
-      // Clicking it expands the banner again.
-      <ChaiseTooltip placement='bottom' tooltip='Show rotation controls'>
-        <button
-          type='button'
-          className='viewer-rotation-banner-tab chaise-btn chaise-btn-primary'
-          onClick={() => setBannerCollapsed(false)}
-          aria-label='Show rotation controls'
-        >
-          <span className='chaise-btn-icon fa-solid fa-chevron-down'></span>
-        </button>
-      </ChaiseTooltip>
-    ) : (
-      <div className='viewer-rotation-banner'>
-        <span className='viewer-rotation-banner-text'>
-          Image is rotated {currentRotation}°. Save to keep this orientation, or discard to revert.
-        </span>
-        <ChaiseTooltip placement='bottom' tooltip='Save rotation'>
-          <button
-            className='chaise-btn chaise-btn-primary'
-            type='button'
-            onClick={saveRotation}
-            disabled={disableFeatures}
-          >
-            <span className='chaise-btn-icon fa-solid fa-check'></span>
-            <span>Save</span>
-          </button>
-        </ChaiseTooltip>
-        <ChaiseTooltip placement='bottom' tooltip='Discard rotation and return to original orientation'>
-          <button
-            className='chaise-btn chaise-btn-secondary'
-            type='button'
-            onClick={resetRotation}
-            disabled={disableFeatures}
-          >
-            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
-            <span>Discard</span>
-          </button>
-        </ChaiseTooltip>
-        <ChaiseTooltip placement='bottom' tooltip='Hide this banner'>
-          <button
-            className='chaise-btn chaise-btn-secondary icon-btn viewer-rotation-banner-dismiss'
-            type='button'
-            onClick={() => setBannerCollapsed(true)}
-            aria-label='Hide rotation banner'
-          >
-            <span className='chaise-btn-icon fa-solid fa-chevron-up'></span>
-          </button>
-        </ChaiseTooltip>
-      </div>
-    ),
-    mainBodyEl,
-  ) : null;
-
   return (
-    <>
-    {/* Banner overlay variant — commented out; the hamburger-menu variant is
-        the chosen UI. Kept here so it's easy to revive later. */}
-    {/* {rotationBanner} */}
     <div className='menu-btn-container'>
       <ChaiseTooltip placement='top' tooltip={toggleAnnotationSidebarTooltip}>
         <button
@@ -304,44 +171,6 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>{(showChannelList ? 'Hide' : 'Show') + ' Channel List'}</span>
         </button>
       </ChaiseTooltip>
-      {/* Original three labeled Zoom buttons — commented out in favor of the
-          trio variant below. Kept around so we can revive it for comparison. */}
-      {/*
-      <ChaiseTooltip placement='top' tooltip='Zoom in'>
-        <button
-          className='chaise-btn chaise-btn-primary'
-          type='button'
-          onClick={() => changeZoom(ViewerZoomFunction.ZOOM_IN)}
-          disabled={disableFeatures}
-        >
-          <span className='chaise-btn-icon fa-solid fa-magnifying-glass-plus'></span>
-          <span>Zoom In</span>
-        </button>
-      </ChaiseTooltip>
-      <ChaiseTooltip placement='top' tooltip='Zoom out'>
-        <button
-          className='chaise-btn chaise-btn-primary'
-          type='button'
-          onClick={() => changeZoom(ViewerZoomFunction.ZOOM_OUT)}
-          disabled={disableFeatures}
-        >
-          <span className='chaise-btn-icon fa-solid fa-magnifying-glass-minus'></span>
-          <span>Zoom Out</span>
-        </button>
-      </ChaiseTooltip>
-      <ChaiseTooltip placement='top' tooltip='Reset Zoom'>
-        <button
-          className='chaise-btn chaise-btn-primary'
-          type='button'
-          onClick={() => changeZoom(ViewerZoomFunction.RESET_ZOOM)}
-          disabled={disableFeatures}
-        >
-          <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
-          <span>Reset Zoom</span>
-        </button>
-      </ChaiseTooltip>
-      */}
-      {/* Trio variant: "Zoom" label + three icon-only buttons (in, out, reset). */}
       <div className='viewer-zoom-trio chaise-btn-group'>
         <span className='chaise-btn-group-text'>Zoom</span>
         <ChaiseTooltip placement='top' tooltip='Zoom in'>
@@ -378,67 +207,44 @@ const ViewerMenuButtons = (): JSX.Element => {
           </button>
         </ChaiseTooltip>
       </div>
-      {/* "Rotate" label + three icon-only buttons (left, right, discard). */}
       <div className='viewer-rotate-trio chaise-btn-group'>
         <span className='chaise-btn-group-text'>Rotate</span>
-        {renderRotateTrioButtons()}
-      </div>
-      {/* Split-button: "Rotate Right" + a hamburger that opens a menu with the
-          Save/Discard actions. Styled to mirror the faceting panel's dropdown
-          (renderFacetDropdownMenu in faceting.tsx) so the menu look/positioning
-          matches the rest of the app. */}
-      <div className='viewer-rotate-menu chaise-btn-group'>
-        <ChaiseTooltip placement='top' tooltip='Rotate image 90° clockwise'>
+        <ChaiseTooltip placement='top' tooltip='Rotate 90° counterclockwise'>
           <button
-            className='chaise-btn chaise-btn-primary'
+            className='chaise-btn chaise-btn-primary icon-btn'
+            type='button'
+            onClick={() => rotateImage(-90)}
+            disabled={disableFeatures}
+            aria-label='Rotate left'
+          >
+            <RotateLeftIcon className='chaise-btn-icon' width={17} />
+          </button>
+        </ChaiseTooltip>
+        <ChaiseTooltip placement='top' tooltip='Rotate 90° clockwise'>
+          <button
+            className='chaise-btn chaise-btn-primary icon-btn'
             type='button'
             onClick={() => rotateImage(90)}
             disabled={disableFeatures}
+            aria-label='Rotate right'
           >
             <RotateRightIcon className='chaise-btn-icon' width={17} />
-            <span>Rotate Right</span>
           </button>
         </ChaiseTooltip>
-        {/* Render as a nested chaise-btn-group so the outer group's CSS
-            (border-radius/-margin reset) reaches the toggle button. Always
-            shown so the toggle's geometry doesn't appear/disappear as the
-            user rotates; individual items are disabled when not applicable. */}
-        <Dropdown className='chaise-dropdown chaise-dropdown-no-icon chaise-btn-group'>
-          <ChaiseTooltip placement='top' tooltip='Rotation actions'>
-            <Dropdown.Toggle
-              className='chaise-btn chaise-btn-primary'
-              disabled={disableFeatures}
-              aria-label='Rotation actions'
-            >
-              <span className='chaise-btn-icon fa-solid fa-bars'></span>
-            </Dropdown.Toggle>
-          </ChaiseTooltip>
-          {/* `align='end'` anchors the menu's right edge to the toggle's right
-              edge, so the menu opens leftward — landing under the Rotate Left
-              button instead of hanging off to the right of the toggle. */}
-          <Dropdown.Menu align='end'>
-            <Dropdown.Item
-              className='dropdown-item-w-icon save-rotation-btn'
-              onClick={saveRotation}
-              disabled={disableFeatures}
-            >
-              <span>
-                <span className='dropdown-item-icon fa-solid fa-check-to-slot'></span>
-                <span>Save rotation</span>
-              </span>
-            </Dropdown.Item>
-            <Dropdown.Item
-              className='dropdown-item-w-icon discard-rotation-btn'
-              onClick={resetRotation}
-              disabled={disableFeatures || currentRotation === 0}
-            >
-              <span>
-                <span className='dropdown-item-icon fa-solid fa-undo'></span>
-                <span>Discard rotation</span>
-              </span>
-            </Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
+        <ChaiseTooltip
+          placement='top'
+          tooltip='Discard rotation and return to original orientation'
+        >
+          <button
+            className='chaise-btn chaise-btn-primary icon-btn'
+            type='button'
+            onClick={resetRotation}
+            disabled={disableFeatures}
+            aria-label='Discard rotation'
+          >
+            <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
+          </button>
+        </ChaiseTooltip>
       </div>
       <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
         <button
@@ -453,30 +259,11 @@ const ViewerMenuButtons = (): JSX.Element => {
               <Spinner animation='border' size='sm' />
             </span>
           )}
-          <span>Take a Screenshot</span>
-        </button>
-      </ChaiseTooltip>
-      {/* Icon-only variant of the screenshot button. Same handler + state, so
-          it swaps in the spinner alongside the labeled button. */}
-      <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
-        <button
-          className='chaise-btn chaise-btn-primary icon-btn'
-          type='button'
-          onClick={takeScreenshot}
-          disabled={waitingForScreenshot || disableFeatures}
-          aria-label='Take a screenshot'
-        >
-          {!waitingForScreenshot && <span className='chaise-btn-icon fa-solid fa-camera'></span>}
-          {waitingForScreenshot && (
-            <span className='chaise-btn-icon'>
-              <Spinner animation='border' size='sm' />
-            </span>
-          )}
+          <span>Screenshot</span>
         </button>
       </ChaiseTooltip>
     </div>
-    </>
   );
-}
+};
 
 export default ViewerMenuButtons;

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -203,7 +203,7 @@ const ViewerMenuButtons = (): JSX.Element => {
             disabled={disableFeatures}
             aria-label='Reset zoom'
           >
-            <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
+            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
           </button>
         </ChaiseTooltip>
       </div>
@@ -242,7 +242,7 @@ const ViewerMenuButtons = (): JSX.Element => {
             disabled={disableFeatures}
             aria-label='Discard rotation'
           >
-            <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
+            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
           </button>
         </ChaiseTooltip>
       </div>

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -20,6 +20,7 @@ import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 import { errorMessages } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { getOSDViewerIframe } from '@isrd-isi-edu/chaise/src/utils/viewer-utils';
 import RotateLeftIcon from '@isrd-isi-edu/chaise/src/components/icons/rotate-left';
+import RotateRightIcon from '@isrd-isi-edu/chaise/src/components/icons/rotate-right';
 
 /**
  * created a separate comp for this to avoid rerendering the parent when internal state changes.
@@ -115,8 +116,7 @@ const ViewerMenuButtons = (): JSX.Element => {
     logViewerClientAction(action, false);
   }
 
-  const rotateImage = () => {
-    const degrees = -90;
+  const rotateImage = (degrees: number) => {
     getOSDViewerIframe().contentWindow!.postMessage(
       { messageType: 'rotate', content: { degrees } },
       origin,
@@ -152,6 +152,50 @@ const ViewerMenuButtons = (): JSX.Element => {
 
     logViewerClientAction(LogActions.VIEWER_SCREENSHOT, false);
   }
+
+  //-------------------  render helpers:   --------------------//
+
+  /**
+   * The three icon buttons inside the Rotate trio. Returned as a fragment so
+   * it can be dropped into each label-style variant below.
+   */
+  const renderRotateTrioButtons = () => (
+    <>
+      <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
+        <button
+          className='chaise-btn chaise-btn-primary icon-btn'
+          type='button'
+          onClick={() => rotateImage(-90)}
+          disabled={disableFeatures}
+          aria-label='Rotate left'
+        >
+          <RotateLeftIcon className='chaise-btn-icon' width={17} />
+        </button>
+      </ChaiseTooltip>
+      <ChaiseTooltip placement='top' tooltip='Rotate image 90° clockwise'>
+        <button
+          className='chaise-btn chaise-btn-primary icon-btn'
+          type='button'
+          onClick={() => rotateImage(90)}
+          disabled={disableFeatures}
+          aria-label='Rotate right'
+        >
+          <RotateRightIcon className='chaise-btn-icon' width={17} />
+        </button>
+      </ChaiseTooltip>
+      <ChaiseTooltip placement='top' tooltip='Discard rotation and return to original orientation'>
+        <button
+          className='chaise-btn chaise-btn-primary icon-btn'
+          type='button'
+          onClick={resetRotation}
+          disabled={disableFeatures}
+          aria-label='Discard rotation'
+        >
+          <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
+        </button>
+      </ChaiseTooltip>
+    </>
+  );
 
   //-------------------  render logics:   --------------------//
   const disableFeatures = !mainImageLoaded;
@@ -260,6 +304,9 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>{(showChannelList ? 'Hide' : 'Show') + ' Channel List'}</span>
         </button>
       </ChaiseTooltip>
+      {/* Original three labeled Zoom buttons — commented out in favor of the
+          trio variant below. Kept around so we can revive it for comparison. */}
+      {/*
       <ChaiseTooltip placement='top' tooltip='Zoom in'>
         <button
           className='chaise-btn chaise-btn-primary'
@@ -293,64 +340,63 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>Reset Zoom</span>
         </button>
       </ChaiseTooltip>
-      {/* Inline button-group variant (Rotate Left + Save + Discard as separate
-          attached buttons) — commented out; superseded by the hamburger-menu
-          variant below. Kept around so we can revive it for comparison later. */}
-      {/*
-      <div className='chaise-btn-group'>
-        <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
+      */}
+      {/* Trio variant: "Zoom" label + three icon-only buttons (in, out, reset). */}
+      <div className='viewer-zoom-trio chaise-btn-group'>
+        <span className='chaise-btn-group-text'>Zoom</span>
+        <ChaiseTooltip placement='top' tooltip='Zoom in'>
           <button
-            className='chaise-btn chaise-btn-primary'
+            className='chaise-btn chaise-btn-primary icon-btn'
             type='button'
-            onClick={rotateImage}
+            onClick={() => changeZoom(ViewerZoomFunction.ZOOM_IN)}
             disabled={disableFeatures}
+            aria-label='Zoom in'
           >
-            <RotateLeftIcon className='chaise-btn-icon' />
-            <span>Rotate Left</span>
+            <span className='chaise-btn-icon fa-solid fa-magnifying-glass-plus'></span>
           </button>
         </ChaiseTooltip>
-        {currentRotation !== 0 && (
-          <>
-            <ChaiseTooltip placement='top' tooltip='Save rotation'>
-              <button
-                className='chaise-btn chaise-btn-primary icon-btn'
-                type='button'
-                onClick={saveRotation}
-                disabled={disableFeatures}
-                aria-label='Save rotation'
-              >
-                <span className='chaise-btn-icon fa-solid fa-check'></span>
-              </button>
-            </ChaiseTooltip>
-            <ChaiseTooltip placement='top' tooltip='Discard rotation and return to original orientation'>
-              <button
-                className='chaise-btn chaise-btn-secondary icon-btn'
-                type='button'
-                onClick={resetRotation}
-                disabled={disableFeatures}
-                aria-label='Discard rotation'
-              >
-                <span className='chaise-btn-icon fa-solid fa-xmark'></span>
-              </button>
-            </ChaiseTooltip>
-          </>
-        )}
+        <ChaiseTooltip placement='top' tooltip='Zoom out'>
+          <button
+            className='chaise-btn chaise-btn-primary icon-btn'
+            type='button'
+            onClick={() => changeZoom(ViewerZoomFunction.ZOOM_OUT)}
+            disabled={disableFeatures}
+            aria-label='Zoom out'
+          >
+            <span className='chaise-btn-icon fa-solid fa-magnifying-glass-minus'></span>
+          </button>
+        </ChaiseTooltip>
+        <ChaiseTooltip placement='top' tooltip='Reset Zoom'>
+          <button
+            className='chaise-btn chaise-btn-primary icon-btn'
+            type='button'
+            onClick={() => changeZoom(ViewerZoomFunction.RESET_ZOOM)}
+            disabled={disableFeatures}
+            aria-label='Reset zoom'
+          >
+            <span className='chaise-btn-icon fa-solid fa-rotate-left'></span>
+          </button>
+        </ChaiseTooltip>
       </div>
-      */}
-      {/* Split-button: "Rotate Left" + a hamburger that opens a menu with the
+      {/* "Rotate" label + three icon-only buttons (left, right, discard). */}
+      <div className='viewer-rotate-trio chaise-btn-group'>
+        <span className='chaise-btn-group-text'>Rotate</span>
+        {renderRotateTrioButtons()}
+      </div>
+      {/* Split-button: "Rotate Right" + a hamburger that opens a menu with the
           Save/Discard actions. Styled to mirror the faceting panel's dropdown
           (renderFacetDropdownMenu in faceting.tsx) so the menu look/positioning
           matches the rest of the app. */}
       <div className='viewer-rotate-menu chaise-btn-group'>
-        <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
+        <ChaiseTooltip placement='top' tooltip='Rotate image 90° clockwise'>
           <button
             className='chaise-btn chaise-btn-primary'
             type='button'
-            onClick={rotateImage}
+            onClick={() => rotateImage(90)}
             disabled={disableFeatures}
           >
-            <RotateLeftIcon className='chaise-btn-icon' width={17} />
-            <span>Rotate Left</span>
+            <RotateRightIcon className='chaise-btn-icon' width={17} />
+            <span>Rotate Right</span>
           </button>
         </ChaiseTooltip>
         {/* Render as a nested chaise-btn-group so the outer group's CSS
@@ -408,6 +454,24 @@ const ViewerMenuButtons = (): JSX.Element => {
             </span>
           )}
           <span>Take a Screenshot</span>
+        </button>
+      </ChaiseTooltip>
+      {/* Icon-only variant of the screenshot button. Same handler + state, so
+          it swaps in the spinner alongside the labeled button. */}
+      <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
+        <button
+          className='chaise-btn chaise-btn-primary icon-btn'
+          type='button'
+          onClick={takeScreenshot}
+          disabled={waitingForScreenshot || disableFeatures}
+          aria-label='Take a screenshot'
+        >
+          {!waitingForScreenshot && <span className='chaise-btn-icon fa-solid fa-camera'></span>}
+          {waitingForScreenshot && (
+            <span className='chaise-btn-icon'>
+              <Spinner animation='border' size='sm' />
+            </span>
+          )}
         </button>
       </ChaiseTooltip>
     </div>

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type JSX } from 'react';
+import { useEffect, useRef, useState, type JSX } from 'react';
 
 // components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
@@ -33,10 +33,26 @@ const ViewerMenuButtons = (): JSX.Element => {
     annotationFormProps,
     imageID,
     mainImageLoaded,
+    canUpdateImageConfig,
+    mainImageRotation,
+    savingImageConfig,
+    saveImageConfig,
   } = useViewer();
 
   const [showChannelList, setShowChannelList] = useState(false);
   const [waitingForScreenshot, setWaitingForScreenshot] = useState(false);
+
+  /**
+   * the live viewport rotation in degrees. chaise issues every rotate command,
+   * so it can track this without round-tripping to osd-viewer. initialized from
+   * (and kept in sync with) the saved default; the save button persists it.
+   */
+  const currentRotationRef = useRef(mainImageRotation);
+  useEffect(() => {
+    // runs on initial load and after each successful save; in both cases the
+    // live rotation already matches the saved default, so this stays consistent.
+    currentRotationRef.current = mainImageRotation;
+  }, [mainImageRotation]);
 
   useEffect(() => {
     const recieveIframeMessage = (event: any) => {
@@ -103,6 +119,7 @@ const ViewerMenuButtons = (): JSX.Element => {
   };
 
   const rotateImage = (degrees: number) => {
+    currentRotationRef.current = ((currentRotationRef.current + degrees) % 360 + 360) % 360;
     getOSDViewerIframe().contentWindow!.postMessage(
       { messageType: 'rotate', content: { degrees } },
       origin
@@ -111,8 +128,17 @@ const ViewerMenuButtons = (): JSX.Element => {
   };
 
   const resetRotation = () => {
-    getOSDViewerIframe().contentWindow!.postMessage({ messageType: 'resetRotation' }, origin);
+    // discard unsaved rotation: return to the saved default (not necessarily 0)
+    currentRotationRef.current = mainImageRotation;
+    getOSDViewerIframe().contentWindow!.postMessage(
+      { messageType: 'resetRotation', content: { degrees: mainImageRotation } },
+      origin
+    );
     logViewerClientAction(LogActions.VIEWER_ROTATE_RESET, false);
+  };
+
+  const saveRotation = () => {
+    saveImageConfig(currentRotationRef.current);
   };
 
   const takeScreenshot = () => {
@@ -171,7 +197,7 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>{(showChannelList ? 'Hide' : 'Show') + ' Channel List'}</span>
         </button>
       </ChaiseTooltip>
-      <div className='viewer-zoom-trio chaise-btn-group'>
+      <div className='viewer-zoom-btn-group chaise-btn-group'>
         <span className='chaise-btn-group-text'>Zoom</span>
         <ChaiseTooltip placement='top' tooltip='Zoom in'>
           <button
@@ -203,11 +229,11 @@ const ViewerMenuButtons = (): JSX.Element => {
             disabled={disableFeatures}
             aria-label='Reset zoom'
           >
-            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
+            <span className='chaise-btn-icon fa-solid fa-undo'></span>
           </button>
         </ChaiseTooltip>
       </div>
-      <div className='viewer-rotate-trio chaise-btn-group'>
+      <div className='viewer-rotate-btn-group chaise-btn-group'>
         <span className='chaise-btn-group-text'>Rotate</span>
         <ChaiseTooltip placement='top' tooltip='Rotate 90° counterclockwise'>
           <button
@@ -233,7 +259,7 @@ const ViewerMenuButtons = (): JSX.Element => {
         </ChaiseTooltip>
         <ChaiseTooltip
           placement='top'
-          tooltip='Discard rotation and return to original orientation'
+          tooltip='Discard unsaved rotation and return to the saved orientation'
         >
           <button
             className='chaise-btn chaise-btn-primary icon-btn'
@@ -242,9 +268,28 @@ const ViewerMenuButtons = (): JSX.Element => {
             disabled={disableFeatures}
             aria-label='Discard rotation'
           >
-            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
+            <span className='chaise-btn-icon fa-solid fa-undo'></span>
           </button>
         </ChaiseTooltip>
+        {canUpdateImageConfig &&
+          <ChaiseTooltip placement='top' tooltip='Save the current rotation'>
+            <button
+              className='chaise-btn chaise-btn-primary icon-btn'
+              type='button'
+              onClick={saveRotation}
+              disabled={savingImageConfig || disableFeatures}
+              aria-label='Save rotation'
+            >
+              {savingImageConfig ? (
+                <span className='chaise-btn-icon'>
+                  <Spinner animation='border' size='sm' />
+                </span>
+              ) : (
+                <span className='chaise-btn-icon fa-solid fa-check-to-slot'></span>
+              )}
+            </button>
+          </ChaiseTooltip>
+        }
       </div>
       <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
         <button

--- a/src/components/viewer/viewer-menu-buttons.tsx
+++ b/src/components/viewer/viewer-menu-buttons.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState, type JSX } from 'react';
+import { createPortal } from 'react-dom';
 
 // components
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
+import Dropdown from 'react-bootstrap/Dropdown';
 import Spinner from 'react-bootstrap/Spinner';
 
 // hooks
@@ -17,6 +19,7 @@ import { ChaiseAlertType } from '@isrd-isi-edu/chaise/src/providers/alerts';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 import { errorMessages } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { getOSDViewerIframe } from '@isrd-isi-edu/chaise/src/utils/viewer-utils';
+import RotateLeftIcon from '@isrd-isi-edu/chaise/src/components/icons/rotate-left';
 
 /**
  * created a separate comp for this to avoid rerendering the parent when internal state changes.
@@ -40,6 +43,12 @@ const ViewerMenuButtons = (): JSX.Element => {
    * Mirrors what OSD is showing so we can decide when to surface the Save/Reset controls.
    */
   const [currentRotation, setCurrentRotation] = useState(0);
+  /**
+   * Whether the rotation overlay banner has been tucked away. Resets on every
+   * new rotation / discard so transitions always start with the banner visible
+   * again. Set to true on Save so the user can tuck it after committing.
+   */
+  const [bannerCollapsed, setBannerCollapsed] = useState(false);
 
   useEffect(() => {
     const recieveIframeMessage = (event: any) => {
@@ -113,12 +122,16 @@ const ViewerMenuButtons = (): JSX.Element => {
       origin,
     );
     setCurrentRotation((prev) => (((prev + degrees) % 360) + 360) % 360);
+    // Every new rotation re-surfaces the banner; previous "tucked" state is
+    // about old information.
+    setBannerCollapsed(false);
     logViewerClientAction(LogActions.VIEWER_ROTATE, false);
   }
 
   const resetRotation = () => {
     getOSDViewerIframe().contentWindow!.postMessage({ messageType: 'resetRotation' }, origin);
     setCurrentRotation(0);
+    setBannerCollapsed(false);
     logViewerClientAction(LogActions.VIEWER_ROTATE_RESET, false);
   }
 
@@ -126,6 +139,8 @@ const ViewerMenuButtons = (): JSX.Element => {
     // TODO(rotation): persist current rotation to the Image table once the
     // schema/ACL (canUpdateImageConfig) is wired up. For now this is a no-op
     // so the UI flow is testable without DB writes.
+    // Tuck the banner — user just acted on it, it should get out of the way.
+    setBannerCollapsed(true);
     logViewerClientAction(LogActions.VIEWER_ROTATE_SAVE, false);
   }
 
@@ -152,7 +167,72 @@ const ViewerMenuButtons = (): JSX.Element => {
     screenshotTooltip = 'Processing the screenshot...';
   }
 
+  // Find the iframe's containing element so the rotation banner can be
+  // portal-ed in as an overlay at the top of the image area. Re-evaluated on
+  // every render so it picks up the element once it mounts.
+  const mainBodyEl = typeof document !== 'undefined' ? document.querySelector('.main-body') : null;
+
+  const rotationBanner = currentRotation !== 0 && mainBodyEl ? createPortal(
+    bannerCollapsed ? (
+      // Collapsed: a small tab poking down from the top of the image area.
+      // Clicking it expands the banner again.
+      <ChaiseTooltip placement='bottom' tooltip='Show rotation controls'>
+        <button
+          type='button'
+          className='viewer-rotation-banner-tab chaise-btn chaise-btn-primary'
+          onClick={() => setBannerCollapsed(false)}
+          aria-label='Show rotation controls'
+        >
+          <span className='chaise-btn-icon fa-solid fa-chevron-down'></span>
+        </button>
+      </ChaiseTooltip>
+    ) : (
+      <div className='viewer-rotation-banner'>
+        <span className='viewer-rotation-banner-text'>
+          Image is rotated {currentRotation}°. Save to keep this orientation, or discard to revert.
+        </span>
+        <ChaiseTooltip placement='bottom' tooltip='Save rotation'>
+          <button
+            className='chaise-btn chaise-btn-primary'
+            type='button'
+            onClick={saveRotation}
+            disabled={disableFeatures}
+          >
+            <span className='chaise-btn-icon fa-solid fa-check'></span>
+            <span>Save</span>
+          </button>
+        </ChaiseTooltip>
+        <ChaiseTooltip placement='bottom' tooltip='Discard rotation and return to original orientation'>
+          <button
+            className='chaise-btn chaise-btn-secondary'
+            type='button'
+            onClick={resetRotation}
+            disabled={disableFeatures}
+          >
+            <span className='chaise-btn-icon fa-solid fa-xmark'></span>
+            <span>Discard</span>
+          </button>
+        </ChaiseTooltip>
+        <ChaiseTooltip placement='bottom' tooltip='Hide this banner'>
+          <button
+            className='chaise-btn chaise-btn-secondary icon-btn viewer-rotation-banner-dismiss'
+            type='button'
+            onClick={() => setBannerCollapsed(true)}
+            aria-label='Hide rotation banner'
+          >
+            <span className='chaise-btn-icon fa-solid fa-chevron-up'></span>
+          </button>
+        </ChaiseTooltip>
+      </div>
+    ),
+    mainBodyEl,
+  ) : null;
+
   return (
+    <>
+    {/* Banner overlay variant — commented out; the hamburger-menu variant is
+        the chosen UI. Kept here so it's easy to revive later. */}
+    {/* {rotationBanner} */}
     <div className='menu-btn-container'>
       <ChaiseTooltip placement='top' tooltip={toggleAnnotationSidebarTooltip}>
         <button
@@ -213,6 +293,10 @@ const ViewerMenuButtons = (): JSX.Element => {
           <span>Reset Zoom</span>
         </button>
       </ChaiseTooltip>
+      {/* Inline button-group variant (Rotate Left + Save + Discard as separate
+          attached buttons) — commented out; superseded by the hamburger-menu
+          variant below. Kept around so we can revive it for comparison later. */}
+      {/*
       <div className='chaise-btn-group'>
         <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
           <button
@@ -221,7 +305,7 @@ const ViewerMenuButtons = (): JSX.Element => {
             onClick={rotateImage}
             disabled={disableFeatures}
           >
-            <span className='chaise-btn-icon fa-solid fa-arrows-rotate'></span>
+            <RotateLeftIcon className='chaise-btn-icon' />
             <span>Rotate Left</span>
           </button>
         </ChaiseTooltip>
@@ -229,7 +313,7 @@ const ViewerMenuButtons = (): JSX.Element => {
           <>
             <ChaiseTooltip placement='top' tooltip='Save rotation'>
               <button
-                className='chaise-btn chaise-btn-success icon-btn'
+                className='chaise-btn chaise-btn-primary icon-btn'
                 type='button'
                 onClick={saveRotation}
                 disabled={disableFeatures}
@@ -240,7 +324,7 @@ const ViewerMenuButtons = (): JSX.Element => {
             </ChaiseTooltip>
             <ChaiseTooltip placement='top' tooltip='Discard rotation and return to original orientation'>
               <button
-                className='chaise-btn chaise-btn-danger icon-btn'
+                className='chaise-btn chaise-btn-secondary icon-btn'
                 type='button'
                 onClick={resetRotation}
                 disabled={disableFeatures}
@@ -251,6 +335,64 @@ const ViewerMenuButtons = (): JSX.Element => {
             </ChaiseTooltip>
           </>
         )}
+      </div>
+      */}
+      {/* Split-button: "Rotate Left" + a hamburger that opens a menu with the
+          Save/Discard actions. Styled to mirror the faceting panel's dropdown
+          (renderFacetDropdownMenu in faceting.tsx) so the menu look/positioning
+          matches the rest of the app. */}
+      <div className='viewer-rotate-menu chaise-btn-group'>
+        <ChaiseTooltip placement='top' tooltip='Rotate image 90° counterclockwise'>
+          <button
+            className='chaise-btn chaise-btn-primary'
+            type='button'
+            onClick={rotateImage}
+            disabled={disableFeatures}
+          >
+            <RotateLeftIcon className='chaise-btn-icon' width={17} />
+            <span>Rotate Left</span>
+          </button>
+        </ChaiseTooltip>
+        {/* Render as a nested chaise-btn-group so the outer group's CSS
+            (border-radius/-margin reset) reaches the toggle button. Always
+            shown so the toggle's geometry doesn't appear/disappear as the
+            user rotates; individual items are disabled when not applicable. */}
+        <Dropdown className='chaise-dropdown chaise-dropdown-no-icon chaise-btn-group'>
+          <ChaiseTooltip placement='top' tooltip='Rotation actions'>
+            <Dropdown.Toggle
+              className='chaise-btn chaise-btn-primary'
+              disabled={disableFeatures}
+              aria-label='Rotation actions'
+            >
+              <span className='chaise-btn-icon fa-solid fa-bars'></span>
+            </Dropdown.Toggle>
+          </ChaiseTooltip>
+          {/* `align='end'` anchors the menu's right edge to the toggle's right
+              edge, so the menu opens leftward — landing under the Rotate Left
+              button instead of hanging off to the right of the toggle. */}
+          <Dropdown.Menu align='end'>
+            <Dropdown.Item
+              className='dropdown-item-w-icon save-rotation-btn'
+              onClick={saveRotation}
+              disabled={disableFeatures}
+            >
+              <span>
+                <span className='dropdown-item-icon fa-solid fa-check-to-slot'></span>
+                <span>Save rotation</span>
+              </span>
+            </Dropdown.Item>
+            <Dropdown.Item
+              className='dropdown-item-w-icon discard-rotation-btn'
+              onClick={resetRotation}
+              disabled={disableFeatures || currentRotation === 0}
+            >
+              <span>
+                <span className='dropdown-item-icon fa-solid fa-undo'></span>
+                <span>Discard rotation</span>
+              </span>
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
       <ChaiseTooltip placement='top' tooltip={screenshotTooltip}>
         <button
@@ -269,6 +411,7 @@ const ViewerMenuButtons = (): JSX.Element => {
         </button>
       </ChaiseTooltip>
     </div>
+    </>
   );
 }
 

--- a/src/models/log.ts
+++ b/src/models/log.ts
@@ -123,6 +123,7 @@ export enum LogActions {
   VIEWER_ZOOM_OUT= 'toolbar' + ';zoom-out',
   VIEWER_ROTATE= 'toolbar' + ';rotate',
   VIEWER_ROTATE_RESET= 'toolbar' + ';rotate-reset',
+  VIEWER_ROTATE_SAVE= 'toolbar' + ';rotate-save',
   // VIEWER_ZOOM_IN_MOUSE= 'mouse' + ';zoom-in',
   // VIEWER_ZOOM_OUT_MOUSE= 'mouse' + ';zoom-out',
 

--- a/src/models/log.ts
+++ b/src/models/log.ts
@@ -121,6 +121,9 @@ export enum LogActions {
   VIEWER_ZOOM_RESET= 'toolbar' + ';zoom-reset',
   VIEWER_ZOOM_IN= 'toolbar' + ';zoom-in',
   VIEWER_ZOOM_OUT= 'toolbar' + ';zoom-out',
+  VIEWER_ROTATE= 'toolbar' + ';rotate',
+  VIEWER_ROTATE_RESET= 'toolbar' + ';rotate-reset',
+  VIEWER_ROTATE_SAVE= 'toolbar' + ';rotate-save',
   // VIEWER_ZOOM_IN_MOUSE= 'mouse' + ';zoom-in',
   // VIEWER_ZOOM_OUT_MOUSE= 'mouse' + ';zoom-out',
 

--- a/src/models/log.ts
+++ b/src/models/log.ts
@@ -123,7 +123,6 @@ export enum LogActions {
   VIEWER_ZOOM_OUT= 'toolbar' + ';zoom-out',
   VIEWER_ROTATE= 'toolbar' + ';rotate',
   VIEWER_ROTATE_RESET= 'toolbar' + ';rotate-reset',
-  VIEWER_ROTATE_SAVE= 'toolbar' + ';rotate-save',
   // VIEWER_ZOOM_IN_MOUSE= 'mouse' + ';zoom-in',
   // VIEWER_ZOOM_OUT_MOUSE= 'mouse' + ';zoom-out',
 

--- a/src/models/viewer.ts
+++ b/src/models/viewer.ts
@@ -63,7 +63,7 @@ export type ViewerConfigProps = {
     /**
      * a jsonb column that holds the settings (rotation, etc.) for the image
      */
-    image_config_column_name: string;
+    image_config_column_name?: string;
     /**
      * the format version that should be used (default is 1.0)
      */

--- a/src/models/viewer.ts
+++ b/src/models/viewer.ts
@@ -23,13 +23,13 @@ export type ViewerConfigProps = {
      * the z-index of displayed main image. if the z-plane image doesnt change,
      * this value will be used for fetching and storing the annotations.
      */
-    default_z_index_column_name?: string,
+    default_z_index_column_name?: string;
 
     /**
      * the column that has the pixel per meter value. If value is defined,
      * it will be passed without any modifications to openseadragon-viewer
      */
-    pixel_per_meter_column_name?: string,
+    pixel_per_meter_column_name?: string;
 
     /**
      * The following watermark attributes are used for the watermark
@@ -40,25 +40,34 @@ export type ViewerConfigProps = {
      * if the watermark is defined in the same table, use this attribute
      * if empty, we will not use it
      */
-    watermark_column_name?: string,
+    watermark_column_name?: string;
 
     /**
      * if the watermakr is defined in another table that has fk to image,
      * use the following attribute
      * TODO: need a better way to specify better foreignkey path
      */
-    watermark_foreign_key_visible_column_name?: string,
-    watermark_foreign_key_data_column_name?: string,
+    watermark_foreign_key_visible_column_name?: string;
+    watermark_foreign_key_data_column_name?: string;
 
     /**
      * what should be displayed in the head title (the browser tab)
      */
-    head_title_markdown_pattern?: string,
+    head_title_markdown_pattern?: string;
 
     /**
      * what should be displayed in the page title in full screen mode (non-iframe)
      */
-    page_title_markdown_pattern?: string,
+    page_title_markdown_pattern?: string;
+
+    /**
+     * a jsonb column that holds the settings (rotation, etc.) for the image
+     */
+    image_config_column_name: string;
+    /**
+     * the format version that should be used (default is 1.0)
+     */
+    image_config_format_version?: string;
 
     /**
      * @DEPRECATED This is here for just backward compatibilty and should not be used.
@@ -68,8 +77,8 @@ export type ViewerConfigProps = {
      * As a hack, if the stored value has query parameters, we will only
      * use the query parameters. Otherwise it will use the stored value as is.
      */
-    legacy_osd_url_column_name?: string,
-  },
+    legacy_osd_url_column_name?: string;
+  };
   /**
    * the table that stores each individual image for each channel in each z
    */
@@ -77,34 +86,34 @@ export type ViewerConfigProps = {
     /**
      * schema of procesed image table
      */
-    schema_name: string,
+    schema_name: string;
     /**
      * procesed image table
      */
-    table_name: string,
+    table_name: string;
 
     /**
      * the channel number column
      */
-    channel_number_column_name: string,
+    channel_number_column_name: string;
 
     /**
      * how to sort the processed_image records
      */
     column_order?: {
-      column: string,
-      descending?: boolean
-    }[],
+      column: string;
+      descending?: boolean;
+    }[];
 
     /**
      * where to filter based on z_index
      */
-    z_index_column_name?: string,
+    z_index_column_name?: string;
 
     /**
      * where to filter based on the image
      */
-    reference_image_column_name: string,
+    reference_image_column_name: string;
 
     /**
      * The following attributes will help chaise to generate a url
@@ -131,72 +140,72 @@ export type ViewerConfigProps = {
      *   - other types (jpeg): The location of image is stored in
      *    `image_url_column_name` column and transformation is not needed.
      */
-    image_url_column_name: string,
-    display_method_column_name?: string,
-    iiif_version?: string | number,
-    image_url_pattern?: { [display_method: string]: string }
-  },
+    image_url_column_name: string;
+    display_method_column_name?: string;
+    iiif_version?: string | number;
+    image_url_pattern?: { [display_method: string]: string };
+  };
   /**
    * the table that stores the channel data
    */
   image_channel: {
     // channel table
-    schema_name: string,
-    table_name: string,
+    schema_name: string;
+    table_name: string;
 
     // the sort criteria
     column_order?: {
-      column: string,
-      descending?: boolean
-    }[],
+      column: string;
+      descending?: boolean;
+    }[];
 
     /**
      * the fk column to image
      */
-    reference_image_column_name: string,
+    reference_image_column_name: string;
 
     /**
      * the channelName column
      */
-    channel_name_column_name: string,
+    channel_name_column_name: string;
 
     /**
      * the channelNumber column
      */
-    channel_number_column_name: string,
+    channel_number_column_name: string;
 
     /**
      * the pseudoColor column (the value must be in color hex format)
      */
-    pseudo_color_column_name: string,
+    pseudo_color_column_name: string;
 
     /**
      * a boolean column that signals whether the image is greyscale or rgb
      */
-    is_rgb_column_name: string,
+    is_rgb_column_name: string;
 
     /**
      * a jsonb column that holds the settings for the channel
      */
-    channel_config_column_name: string,
+    channel_config_column_name: string;
     /**
      * the format version that should be used (default is 1.0)
      */
-    channel_config_format_version?: string,
+    channel_config_format_version?: string;
 
     /**
      * @DEPRECATED This is here for just backward compatibilty and should not be used.
      * the actual location of image file (info.json, ImageProperties.xml, etc)
      */
-    image_url_column_name?: string
-  },
+    image_url_column_name?: string;
+  };
   /**
    * the table that stores the annotation data
    */
   image_annotation: {
     // annotation table
-    schema_name: string,
-    table_name: string,
+    schema_name: string;
+    table_name: string;
 
     // fk to image table in annotation table
     /**
@@ -207,34 +216,34 @@ export type ViewerConfigProps = {
      * the visible column name is used in id attribute with the following format:
      * id=row-<visible-column-name>
      */
-    reference_image_visible_column_name: string,
-    reference_image_column_name: string,
+    reference_image_visible_column_name: string;
+    reference_image_column_name: string;
 
     /**
      * the asset column that has the annotation
      */
-    overlay_column_name: string,
+    overlay_column_name: string;
     /**
      * This attribute is only needed if youre planning on passing
      * annotation urls as query parameters. In this case, this path
      * is used to distinguish between annotation and image urls in the
      * `url` query parameter.
      */
-    overlay_hatrac_path: string,
+    overlay_hatrac_path: string;
 
     /**
      * the columns that are used internally and should be removed from the entry form
      * TODO should be improved
      */
-    z_index_column_name: string,
-    channels_column_name: string,
+    z_index_column_name: string;
+    channels_column_name: string;
 
     /**
      * annoated term fk in annotation table
      * This information is used to ensure the combination of image, annotated_term, z_index are unique
      */
-    annotated_term_displayname: string,
-    annotated_term_column_name: string,
+    annotated_term_displayname: string;
+    annotated_term_column_name: string;
     /**
      * TODO: need a better way to specify better foreignkey path
      * to find the visible column name, navigate to record page and find the
@@ -245,19 +254,19 @@ export type ViewerConfigProps = {
      *
      * the fk must be based on either be to annotated_term_id_column_name or annotated_term_name_column_name
      */
-    annotated_term_visible_column_name: string,
-    annotated_term_foreign_key_constraint: [string | null, string],
+    annotated_term_visible_column_name: string;
+    annotated_term_foreign_key_constraint: [string | null, string];
 
     /**
      * annoated term table
      * This information is used to display proper value (id vs name)
      */
-    annotated_term_table_name: string,
-    annotated_term_table_schema_name: string,
-    annotated_term_id_column_name: string,
-    annotated_term_name_column_name: string
-  }
-}
+    annotated_term_table_name: string;
+    annotated_term_table_schema_name: string;
+    annotated_term_id_column_name: string;
+    annotated_term_name_column_name: string;
+  };
+};
 
 export type ViewerAnnotationModal = {
   /**
@@ -329,3 +338,119 @@ export enum ViewerZoomFunction {
   ZOOM_OUT = 'zoomOutView',
   RESET_ZOOM = 'homeView'
 }
+
+/**
+ * The inner channel config (the CONFIG_ATTR contents of the channel_config
+ * column) that manipulates the displayed colors. See the "Channel Configuration"
+ * section of docs/viewer/viewer-config.md.
+ */
+export type OSDChannelConfig = {
+  black_level_uint8?: number;
+  white_level_uint8?: number;
+  gamma?: number;
+  saturation_percent?: number;
+  hue_degree?: number;
+  display_greyscale?: boolean;
+};
+
+/**
+ * A single channel entry in OSDViewerParameters.channels.
+ * Built by viewer-utils (_buildChannelEntry / initializeOSDParams) and consumed
+ * by osd-viewer. The keys match VIEWER_CONSTANT.OSD_VIEWER.*_QPARAM.
+ *
+ * The fields below mirror the per-channel query parameters osd-viewer accepts
+ * (see the "Channel parameters" section of openseadragon-viewer's usage.md):
+ * `channelName`, `aliasName`, `pseudoColor`, `isRGB`. (`channelNumber` is the
+ * channel index; the `url` query param is split out into
+ * OSDViewerParameters.mainImage.info rather than living here.) Unlike those,
+ * `channelConfig` is an object passed only through the postMessage, not as a
+ * URL query param.
+ */
+export type OSDViewerChannel = {
+  channelNumber?: number;
+  channelName?: string | null;
+  aliasName?: string | null;
+  pseudoColor?: string | null;
+  isRGB?: boolean | null;
+  /**
+   * the inner channel config (the CONFIG_ATTR contents), when present
+   */
+  channelConfig?: OSDChannelConfig;
+  acls?: {
+    canUpdateConfig: boolean;
+  };
+  /**
+   * channel query-param style keys are set dynamically (channelName, aliasName,
+   * pseudoColor, isRGB), hence the index signature
+   */
+  [key: string]: unknown;
+};
+
+/**
+ * The image-level config passed to osd-viewer (the inner CONFIG_ATTR contents
+ * of the image_config column). Currently only the default rotation.
+ */
+export type OSDImageConfig = {
+  /**
+   * default rotation in degrees, clockwise
+   */
+  rotate?: number;
+  [key: string]: unknown;
+};
+
+/**
+ * The parameter object that chaise builds and sends to osd-viewer via the
+ * `initializeViewer` postMessage. It's assembled across viewer-utils
+ * (initializeOSDParams + loadImageMetadata) and the viewer provider.
+ *
+ * NOTE: it also carries query-param style scalar keys (waterMark,
+ * meterScaleInPixels, scale, x, y, z, ignoreReferencePoint, ignoreDimension,
+ * enableSVGStrokeWidth, zoomLineThickness, showHistogram) that are set
+ * dynamically, hence the index signature. Unlike those, `channelConfig` and
+ * `imageConfig` are objects passed only through this message (not as URL query
+ * params: osd-viewer's processParams would drop them).
+ */
+export type OSDViewerParameters = {
+  /**
+   * the main image: the displayed z-index and its per-channel tile sources
+   */
+  mainImage: {
+    zIndex?: number;
+    info: { url: string; channelNumber: number }[];
+  };
+  channels: OSDViewerChannel[];
+  /**
+   * annotation SVG file urls to load
+   */
+  annotationSetURLs: string[];
+  zPlane: {
+    count: number;
+    minZIndex: number | null;
+    maxZIndex: number | null;
+  };
+  acls: {
+    mainImage: {
+      canUpdateDefaultZIndex: boolean;
+    };
+  };
+  /**
+   * whether more channels exist in the backend than were loaded
+   */
+  hasMore?: boolean;
+  /**
+   * total channel count in the backend
+   */
+  totalChannelCount?: number;
+  /**
+   * tells osd-viewer to use this object as-is instead of running it through processParams
+   */
+  isProcessed: boolean;
+  /**
+   * image-level config (e.g. default rotation), when configured
+   */
+  imageConfig?: OSDImageConfig;
+  /**
+   * dynamically set query-param style scalars (waterMark, scale, x, y, z, etc.)
+   */
+  [key: string]: unknown;
+};

--- a/src/providers/viewer.tsx
+++ b/src/providers/viewer.tsx
@@ -19,7 +19,7 @@ import {
   ViewerError,
 } from '@isrd-isi-edu/chaise/src/models/errors';
 import { LogActions, LogAppModes, LogObjectType, LogStackPaths, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
-import { ViewerAnnotationModal } from '@isrd-isi-edu/chaise/src/models/viewer';
+import { ViewerAnnotationModal, OSDViewerParameters, OSDImageConfig } from '@isrd-isi-edu/chaise/src/models/viewer';
 import { RecordeditDisplayMode, RecordeditProps, appModes } from '@isrd-isi-edu/chaise/src/models/recordedit';
 import {
   DisabledRow,
@@ -45,7 +45,8 @@ import { isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/chaise/sr
 import {
   ReadAllAnnotationResultType, fetchZPlaneList, fetchZPlaneListByZIndex, getOSDViewerIframe,
   buildChannelListFromRows, fetchProcessedImageForChannels,
-  hasURLQueryParam, initializeOSDParams, loadImageMetadata, readAllAnnotations, updateChannelConfig, updateDefaultZIndex
+  hasURLQueryParam, initializeOSDParams, loadImageMetadata, readAllAnnotations, updateChannelConfig, updateDefaultZIndex,
+  buildImageConfig, updateImageConfig
 } from '@isrd-isi-edu/chaise/src/utils/viewer-utils';
 import { HELP_PAGES, ID_NAMES, RECORDSET_DEFAULT_PAGE_SIZE, VIEWER_CONSTANT, errorMessages } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { updateHeadTitle } from '@isrd-isi-edu/chaise/src/utils/head-injector';
@@ -182,6 +183,23 @@ export const ViewerContext = createContext<{
   channelSelectorSubmitting: boolean;
   hideChannelSelectorModal: () => void;
   onChannelSelectorSubmit: (rows: SelectedRow[]) => void;
+  /**
+   * whether the user can update the image config column (gates the rotation save button)
+   */
+  canUpdateImageConfig: boolean;
+  /**
+   * the saved/default rotation in degrees. used to initialize the live rotation
+   * and as the target the discard button returns to.
+   */
+  mainImageRotation: number;
+  /**
+   * whether the image config save request is in flight (drives the save button spinner)
+   */
+  savingImageConfig: boolean;
+  /**
+   * persist the given rotation (in degrees) to the image config column
+   */
+  saveImageConfig: (rotation: number) => void;
 } | null>(null);
 
 type ViewerProviderProps = {
@@ -292,7 +310,7 @@ export default function ViewerProvider({
   } | null>(null)
 
   // passed to osd-viewer
-  const osdViewerParameters = useRef<any>({});
+  const osdViewerParameters = useRef<OSDViewerParameters>({} as OSDViewerParameters);
 
   // ERMrest Tuple objects for all currently-active channels; used to build disabled rows in the Add Channels modal.
   // Indexed by osdItemId; entries are nulled out when a channel is removed via the toolbar.
@@ -316,6 +334,19 @@ export default function ViewerProvider({
    * - When this is false, we should disable any button/feature that requires the main image to be loaded.
    */
   const [mainImageLoaded, setMainImageLoaded, mainImageLoadedRef] = useStateRef(false);
+
+  /**
+   * whether the user can update the image config column (gates the rotation save button)
+   */
+  const [canUpdateImageConfig, setCanUpdateImageConfig] = useState(false);
+  /**
+   * the saved/default rotation in degrees (from the image config column, updated after each save)
+   */
+  const [mainImageRotation, setMainImageRotation] = useState(0);
+  /**
+   * whether the image config save request is in flight
+   */
+  const [savingImageConfig, setSavingImageConfig] = useState(false);
 
   useEffect(() => {
     if (!initializationStartedRef.current) {
@@ -351,6 +382,10 @@ export default function ViewerProvider({
     let imageDataFromQueryParams = false;
     let hasProcessedImage = false;
     let hasChannelUrl = false;
+
+    // the inner image config (e.g. { rotate }) to pass to osd-viewer; set after
+    // reading the image tuple and applied to osdViewerParameters once it's built.
+    let imageConfigForOSD: OSDImageConfig | null = null;
 
     // if there are svgs in query param, we should just use it and shouldn't get it from db.
     let hasAnnotationQueryParam = false
@@ -395,6 +430,19 @@ export default function ViewerProvider({
         // get the default zindex value
         if (imageConfig.default_z_index_column_name && imageConfig.default_z_index_column_name in imageTuple.data) {
           defaultZIndex.current = imageTuple.data[imageConfig.default_z_index_column_name];
+        }
+
+        // read the image config (currently only rotation): the permission gates the
+        // save button, and the config itself is passed to osd-viewer as the default.
+        if (imageConfig.image_config_column_name) {
+          const imageConfigRes = buildImageConfig(imageTuple);
+          setCanUpdateImageConfig(imageConfigRes.canUpdateImageConfig);
+          if (imageConfigRes.config) {
+            imageConfigForOSD = imageConfigRes.config;
+            if (typeof imageConfigRes.config.rotate === 'number') {
+              setMainImageRotation(imageConfigRes.config.rotate);
+            }
+          }
         }
 
         /**
@@ -493,6 +541,12 @@ export default function ViewerProvider({
         osdViewerParameters.current.acls.mainImage = {
           canUpdateDefaultZIndex: imageTuple.canUpdate && imageTuple.checkPermissions('column_update', imageConfig.default_z_index_column_name)
         };
+
+        // pass the image config (e.g. default rotation) to osd-viewer.
+        // set here (not at :401) because osdViewerParameters.current was just reassigned above.
+        if (imageConfigForOSD) {
+          osdViewerParameters.current.imageConfig = imageConfigForOSD;
+        }
       }
 
       const qParamName = osdConstant.WATERMARK_QPARAM;
@@ -1523,6 +1577,48 @@ export default function ViewerProvider({
   }
 
   /**
+   * persist the given rotation (in degrees) to the image config column.
+   * mirrors the updateChannelConfig / updateDefaultZIndex message handlers:
+   * validate session, PUT, then handle the success alert / auth repaint.
+   * @param rotation the rotation in degrees to save
+   */
+  const saveImageConfig = (rotation: number) => {
+    logViewerClientAction(LogActions.VIEWER_ROTATE_SAVE, false, undefined, { rotation });
+    validateSessionBeforeMutation(() => {
+      setSavingImageConfig(true);
+      updateImageConfig(reference, imageIDRef.current!, rotation)
+        .then(() => {
+          addAlert('Image settings have been updated.', ChaiseAlertType.SUCCESS);
+          // the saved value becomes the new default that the discard button returns to
+          setMainImageRotation(rotation);
+        })
+        .catch((error: any) => {
+          validateSession()
+            .then((session) => {
+              if (!session && error instanceof ConfigService.ERMrest.ConflictError) {
+                // login in a modal should show (Session timed out)
+                dispatchError({ error: new ConfigService.ERMrest.UnauthorizedError() });
+                return;
+              }
+
+              if (error instanceof ConfigService.ERMrest.NoDataChangedError) {
+                // do nothing
+              } else if (error instanceof DifferentUserConflictError) {
+                dispatchError({ error, isDismissible: true });
+              } else {
+                addAlert(error.message, ChaiseAlertType.ERROR);
+              }
+            })
+            .catch((err) => {
+              // validate session will not reject, added to silence ts warning
+              $log.error(err);
+            });
+        })
+        .finally(() => setSavingImageConfig(false));
+    });
+  };
+
+  /**
    * can be used for logging client actions
    */
   const logViewerClientAction = (action: LogActions, isAnnotation: boolean, item?: ViewerAnnotationModal, extraInfo?: any) => {
@@ -1861,6 +1957,10 @@ export default function ViewerProvider({
       channelSelectorSubmitting,
       hideChannelSelectorModal,
       onChannelSelectorSubmit,
+      canUpdateImageConfig,
+      mainImageRotation,
+      savingImageConfig,
+      saveImageConfig,
     };
   }, [
     imageID,
@@ -1880,6 +1980,9 @@ export default function ViewerProvider({
     mainImageLoaded,
     channelSelectorModalProps,
     channelSelectorSubmitting,
+    canUpdateImageConfig,
+    mainImageRotation,
+    savingImageConfig,
   ]);
 
   return (

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -302,6 +302,13 @@ export const VIEWER_CONSTANT = {
       VERSION_ATTR: 'version',
       CONFIG_ATTR: 'config'
     },
+    IMAGE_CONFIG: {
+      FORMAT_NAME: 'image-parameters',
+      FORMAT_VERSION: '1.0',
+      CONFIG_ATTR: 'config',
+      NAME_ATTR: 'name',
+      VERSION_ATTR: 'version',
+    },
     NEW_ANNOTATION: {
       SVG_ID: 'NEW_SVG',
       GROUP_ID: 'NEW_GROUP'

--- a/src/utils/viewer-utils.ts
+++ b/src/utils/viewer-utils.ts
@@ -3,6 +3,7 @@ import React from 'react';
 // models
 import { LogActions, LogStackPaths, LogStackTypes } from '@isrd-isi-edu/chaise/src/models/log';
 import { SelectedRow } from '@isrd-isi-edu/chaise/src/models/recordset';
+import { OSDViewerParameters, OSDImageConfig } from '@isrd-isi-edu/chaise/src/models/viewer';
 
 // services
 import ViewerConfigService from '@isrd-isi-edu/chaise/src/services/viewer-config';
@@ -105,7 +106,7 @@ export const initializeOSDParams = (pageQueryParams: any, imageURI: string, defa
   const osdConstant = VIEWER_CONSTANT.OSD_VIEWER;
 
   let imageURIQueryParams: any = {};
-  const osdViewerParams: any = {
+  const osdViewerParams: OSDViewerParameters = {
     mainImage: { zIndex: defaultZIndex, info: [] },
     channels: [],
     annotationSetURLs: [],
@@ -192,7 +193,7 @@ export const initializeOSDParams = (pageQueryParams: any, imageURI: string, defa
  * @returns
  */
 export const loadImageMetadata = (
-  osdViewerParameters: React.RefObject<any>,
+  osdViewerParameters: React.RefObject<OSDViewerParameters>,
   viewerLogStack: any,
   viewerLogStackPath: string,
   imageID: string,
@@ -609,6 +610,55 @@ export const updateChannelConfig = (data: any, imageID: string): Promise<void> =
   });
 }
 
+/**
+ * Persist the image-level config (currently just rotation) to the image_config column.
+ * Mirrors updateDefaultZIndex: a direct attributegroup PUT, since the config column
+ * may not be a visible column. The caller handles session validation, the success
+ * alert, and the unauthorized repaint.
+ */
+export const updateImageConfig = (mainImageReference: any, imageID: string, rotation: number): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const ic = VIEWER_CONSTANT.OSD_VIEWER.IMAGE_CONFIG;
+    const colName = ViewerConfigService.imageConfig.image_config_column_name;
+
+    const tableName = mainImageReference.table.name,
+      schemaName = mainImageReference.table.schema.name;
+
+    const url = [
+      `${ConfigService.chaiseConfig.ermrestLocation}/catalog/${ConfigService.catalogID}/attributegroup`,
+      `${fixedEncodeURIComponent(schemaName)}:${fixedEncodeURIComponent(tableName)}`,
+      `RID;${fixedEncodeURIComponent(colName)}`
+    ].join('/');
+
+    const config: any = {};
+    config[ic.NAME_ATTR] = ic.FORMAT_NAME;
+    config[ic.VERSION_ATTR] = _getImageConfigFormatVersion();
+    config[ic.CONFIG_ATTR] = { rotate: rotation };
+
+    const payload: any = { RID: imageID };
+    payload[colName] = config;
+
+    const headers: any = {};
+    const stack = LogService.addExtraInfoToStack(null, {
+      'num_updated': 1,
+      'updated_keys': {
+        'cols': ['RID'],
+        'vals': [[imageID]]
+      }
+    });
+    headers[ConfigService.ERMrest.contextHeaderName] = {
+      catalog: ConfigService.catalogID,
+      schema_table: schemaName + ':' + tableName,
+      action: LogService.getActionString(LogActions.UPDATE),
+      stack: stack
+    };
+
+    ConfigService.http.put(url, [payload], { headers: headers }).then(() => {
+      resolve();
+    }).catch((err: any) => reject(err));
+  });
+}
+
 // --------------- local helper functions -------------------- //
 
 /**
@@ -658,6 +708,14 @@ const _getChannelConfigFormatVersion = () => {
   return res;
 }
 
+const _getImageConfigFormatVersion = () => {
+  let res = ViewerConfigService.imageConfig.image_config_format_version;
+  if (!isStringAndNotEmpty(res)) {
+    res = VIEWER_CONSTANT.OSD_VIEWER.IMAGE_CONFIG.FORMAT_VERSION;
+  }
+  return res;
+}
+
 /**
  * Map a single row's data + tuple into the channel entry format used in osdViewerParameters.channels.
  * channelNameFallback is used when channel_name is absent (processPage passes the running index; buildChannelListFromRows passes channelNumber).
@@ -698,6 +756,54 @@ const _buildChannelEntry = (data: any, tuple: any, channelNameFallback: any): an
   res[osdConstant.IS_RGB_QPARAM] = typeof isRGB === 'boolean' ? isRGB : null;
   if (hasConfig) {
     res[osdConstant.CHANNEL_CONFIG_QPARAM] = channelConfigs[osdConstant.CHANNEL_CONFIG.CONFIG_ATTR];
+  }
+
+  return res;
+};
+
+/**
+ * Extract the image-level config (currently just rotation) from the image row.
+ * Mirrors _buildChannelEntry but for the single Image tuple.
+ * Returns whether the user can update the config column, and the inner config
+ * object (the CONFIG_ATTR contents) which is passed as-is to osd-viewer.
+ */
+export const buildImageConfig = (tuple: any): { canUpdateImageConfig: boolean, config: OSDImageConfig | null } => {
+  const colName = ViewerConfigService.imageConfig.image_config_column_name;
+  const configAttr = VIEWER_CONSTANT.OSD_VIEWER.IMAGE_CONFIG.CONFIG_ATTR;
+
+  const res: { canUpdateImageConfig: boolean, config: OSDImageConfig | null } = {
+    canUpdateImageConfig: false,
+    config: null
+  };
+
+  if (!colName) return res;
+
+  res.canUpdateImageConfig = tuple
+    ? tuple.canUpdate && tuple.checkPermissions('column_update', colName)
+    : false;
+
+  let stored = tuple && tuple.data ? tuple.data[colName] : null;
+  stored = isObjectAndNotNull(stored) ? stored : [];
+  let rawConfig = null;
+  if (Array.isArray(stored)) {
+    const match = stored.filter(_isAppropriateImageConfig);
+    if (match.length > 0) {
+      rawConfig = match[0][configAttr];
+    }
+  } else if (_isAppropriateImageConfig(stored)) {
+    rawConfig = stored[configAttr];
+  }
+
+  // validate + normalize here so everything downstream (chaise state and
+  // osd-viewer) consumes a clean config. an invalid rotate (e.g. "somevalue")
+  // is dropped so we behave as if no rotation was set; a valid one is
+  // normalized to the [0, 360) range.
+  if (isObjectAndNotNull(rawConfig)) {
+    res.config = {};
+    const rotate = parseFloat(rawConfig.rotate);
+    if (!isNaN(rotate)) {
+      res.config.rotate = ((rotate % 360) + 360) % 360;
+    }
   }
 
   return res;
@@ -1117,6 +1223,14 @@ const _isAppropriateChannelConfig = (obj: any) => {
     ch.CONFIG_ATTR in obj && // has config attr
     obj[ch.NAME_ATTR] === ch.FORMAT_NAME && // name attr is correct
     obj[ch.VERSION_ATTR] === ViewerConfigService.channelConfig.channel_config_format_version; // version attr is correct
+}
+
+const _isAppropriateImageConfig = (obj: any) => {
+  const ic = VIEWER_CONSTANT.OSD_VIEWER.IMAGE_CONFIG;
+  return isObjectAndNotNull(obj) && // is a not-null object
+    ic.CONFIG_ATTR in obj && // has config attr
+    obj[ic.NAME_ATTR] === ic.FORMAT_NAME && // name attr is correct
+    obj[ic.VERSION_ATTR] === _getImageConfigFormatVersion(); // version attr is correct
 }
 
 /**

--- a/src/utils/viewer-utils.ts
+++ b/src/utils/viewer-utils.ts
@@ -624,21 +624,26 @@ export const updateImageConfig = (mainImageReference: any, imageID: string, rota
     const tableName = mainImageReference.table.name,
       schemaName = mainImageReference.table.schema.name;
 
+    if (!isStringAndNotEmpty(colName) || !colName) {
+      reject(new Error('image_config_column_name is not configured.'));
+      return;
+    }
+
     const url = [
       `${ConfigService.chaiseConfig.ermrestLocation}/catalog/${ConfigService.catalogID}/attributegroup`,
       `${fixedEncodeURIComponent(schemaName)}:${fixedEncodeURIComponent(tableName)}`,
       `RID;${fixedEncodeURIComponent(colName)}`
     ].join('/');
 
-    const config: any = {};
+    const config: Record<string, unknown> = {};
     config[ic.NAME_ATTR] = ic.FORMAT_NAME;
     config[ic.VERSION_ATTR] = _getImageConfigFormatVersion();
     config[ic.CONFIG_ATTR] = { rotate: rotation };
 
-    const payload: any = { RID: imageID };
+    const payload: Record<string, unknown> = { RID: imageID };
     payload[colName] = config;
 
-    const headers: any = {};
+    const headers: Record<string, unknown> = {};
     const stack = LogService.addExtraInfoToStack(null, {
       'num_updated': 1,
       'updated_keys': {
@@ -655,7 +660,7 @@ export const updateImageConfig = (mainImageReference: any, imageID: string, rota
 
     ConfigService.http.put(url, [payload], { headers: headers }).then(() => {
       resolve();
-    }).catch((err: any) => reject(err));
+    }).catch((err: unknown) => reject(err));
   });
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,11 +48,10 @@
 
     /* Module Resolution Options */
     "moduleResolution": "bundler",               /* Specify module resolution strategy: 'node' (Node.js), 'classic' (TypeScript pre-1.6), or 'bundler'. */
-    "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    "paths": {                                      /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      "@isrd-isi-edu/chaise/*": ["*"],
+    "paths": {                                      /* A series of entries which re-map imports to lookup locations relative to the tsconfig.json directory. */
+      "@isrd-isi-edu/chaise/*": ["./*"],
       "@isrd-isi-edu/e2e-test/*": ["./test/playwright/*"],
-      "@isrd-isi-edu/ermrestjs/*": ["node_modules/@isrd-isi-edu/ermrestjs/*"] // so npm link can properly resolve ermrestjs alias imports
+      "@isrd-isi-edu/ermrestjs/*": ["./node_modules/@isrd-isi-edu/ermrestjs/*"] // so npm link can properly resolve ermrestjs alias imports
     },
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */


### PR DESCRIPTION
This PR closes #2764. The summary of changes are

- Add a button-group to rotate left, right and discard rotation.
- Add custom SVG rotate left and right icons.
- Change the style of zoom buttons to be the same as the new rotate buttons.
- Read the default rotation from the image config column and apply it on load.
- Add a Save button to the rotate group (only shown to users who can update the config column) that persists the current rotation. Discard returns to the saved rotation, or 0 if none is saved.
- Add the `image_config_column_name` and `image_config_format_version` settings, and type the `osdViewerParameters` object that is sent to openseadragon-viewer.

The openseadrgon-viewer side of changes: https://github.com/informatics-isi-edu/openseadragon-viewer/pull/118
