### PR TITLE
test(e2e): reduce CI flakiness with retries and timeout headroom

### DIFF
--- a/test/e2e/setup/playwright.configuration.ts
+++ b/test/e2e/setup/playwright.configuration.ts
@@ -47,7 +47,8 @@ const getConfig = (options: TestOptions) => {
     // Fail the build on CI if you accidentally left test.only in the source code.
     forbidOnly: !!process.env.CI,
 
-    retries: 0,
+    // CI flakes (timeouts/races) shouldn't fail the whole build; Playwright still reports retried tests as "flaky".
+    retries: process.env.CI ? 2 : 0,
 
     // Opt out of parallel tests on CI.
     workers: options.runSequentially ? 1 : 4,

--- a/test/e2e/specs/all-features/record/related-table.spec.ts
+++ b/test/e2e/specs/all-features/record/related-table.spec.ts
@@ -69,7 +69,7 @@ const testParams = {
 
 // TODO playwright: we should break this file into at least two files
 
-test.describe('Related tables', () => {
+test.describe.serial('Related tables', () => {
   test.beforeEach(async ({ page, baseURL }, testInfo) => {
     const keys = [];
     keys.push(testParams.key.name + testParams.key.operator + testParams.key.value);

--- a/test/e2e/specs/default-config/multi-form-input/multi-form-input-clone.spec.ts
+++ b/test/e2e/specs/default-config/multi-form-input/multi-form-input-clone.spec.ts
@@ -13,6 +13,9 @@ const testParams = {
 }
 
 test('clone button', async ({ page, baseURL }, testInfo) => {
+  // cloning to the 200-form max plus submitting 201 records is heavy; the 60s default times out under CI load.
+  test.slow();
+
   const cloneFormInput = RecordeditLocators.getCloneFormInput(page);
   const cloneFormSubmitButton = RecordeditLocators.getCloneFormInputSubmitButton(page);
 

--- a/test/e2e/utils/recordedit-utils.ts
+++ b/test/e2e/utils/recordedit-utils.ts
@@ -1127,6 +1127,9 @@ export const testCreateRecords = (usedParams: TestCreateRecordsParams) => {
     test(`${presentation.description}`, async ({ page, baseURL }, testInfo) => {
       const numForms = presentation.inputs.length;
 
+      // multi-form create clones, validates, and submits every form in one test; the 60s default times out under CI load.
+      if (numForms > 1) test.slow();
+
       await test.step('open recordedit page', async () => {
         await page.goto(generateChaiseURL(APP_NAMES.RECORDEDIT, presentation.schemaName, presentation.tableName, testInfo, baseURL));
         await RecordeditLocators.waitForRecordeditPageReady(page);


### PR DESCRIPTION
Summary of changes:
  - Enable `retries: 2` on CI so transient flakes (timeouts, backend 503s) retry and are reported as `flaky` instead of failing the build.
  - Mark the two heavy multi-form create tests `test.slow()` (clone button + the shared create helper) so they stop hitting the 60s default under load.
  - Run the order-dependent `related-table` group as `describe.serial`.