### PR TITLE
docs: fix anchor links on the docs website

### DIFF
--- a/docs/dev-docs/dev-guide.md
+++ b/docs/dev-docs/dev-guide.md
@@ -68,6 +68,7 @@ This is a guide for people who develop Chaise.
 - [Performance](#performance)
   - [Debugging](#debugging)
   - [Memoization](#memoization)
+- [Documentation](#documentation)
 
 ## Commit message conventions
 
@@ -1349,4 +1350,19 @@ That being said, performance-related changes applied incorrectly can even harm p
 Useful links:
 - https://react.dev/reference/react/memo
 - https://dmitripavlutin.com/use-react-memo-wisely/
+
+## Documentation
+
+The Markdown files under [`docs/user-docs`](../user-docs) that are listed in [`docs/index.rst`](../index.rst) are published on [docs.derivacloud.org](https://docs.derivacloud.org/chaise/index.html) by deriva-docs. If you add a new user-docs file, add it to `index.rst` as well.
+
+GitHub and the docs site (Sphinx) generate heading anchors differently. GitHub keeps `_` and a leading `1.` number and drops other punctuation without a separator, while Sphinx turns `_` and punctuation runs into `-` and strips leading digits. So a heading like `### 1. Install Chaise` is `#1-install-chaise` on GitHub but `#install-chaise` on the site, and an in-page link can only target one of them. To support both, an explicit `<a name="<github-slug>"></a>` anchor is added right before any heading whose two slugs differ: GitHub resolves the link through the heading's own id, and the explicit anchor gives Sphinx a matching `id`.
+
+[`scripts/docs-anchors.py`](../../scripts/docs-anchors.py) automates this. It follows the toctree in `index.rst` to find the published files, computes both slugs for every heading, and reports or inserts the needed anchors. Run it after adding or renaming headings:
+
+```sh
+python3 scripts/docs-anchors.py          # check only; exits non-zero if anchors are missing
+python3 scripts/docs-anchors.py --fix    # insert the missing anchors
+```
+
+It is idempotent, so re-running is safe. Links flagged with `!` point at no heading (a typo or a stale cross-reference) and must be fixed by hand.
 

--- a/docs/user-docs/logging-pre-feb-20.md
+++ b/docs/user-docs/logging-pre-feb-20.md
@@ -71,7 +71,7 @@ The table below summarizes all the requests that we currently are logging in cha
 
 | App                                                 | Description                                           | Action                                       | Extra                        | Notes                                                                                                                                                 | Change                        |
 |-----------------------------------------------------|-------------------------------------------------------|----------------------------------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| chaise-wide (record, recordset, recordedit, viewer) | get catalog snapshot  information                               | model/snaptime                                |                              |                                                                                                                                                       | [added (4/18/19)](#041819) [updated (10/??/19)](#10??19)    |
+| chaise-wide (record, recordset, recordedit, viewer) | get catalog snapshot  information                               | model/snaptime                                |                              |                                                                                                                                                       | [added (4/18/19)](#041819) [updated (10/??/19)](#1019)    |
 |                                                     | get catalog schemas information                       | model/schema                                 |                              |                                                                                                                                                       | [added (4/18/19)](#041819)    |
 |                                                     |                                                       |                                              |                              |                                                                                                                                                       |                               |
 | record                                              | load main entity                                      | record/main                                  | ppid, pcid                   |                                                                                                                                                       | [bug fix (4/18/19)](#041819)  |
@@ -325,6 +325,7 @@ If the user clicked on a link in the navbar, the `PCID` will properly denote wha
 
 ## Change Log
 
+<a name="1019"></a>
 ### 10/??/19
 
 #### Commit Links
@@ -334,7 +335,7 @@ If the user clicked on a link in the navbar, the `PCID` will properly denote wha
  - changed model/catalog -> model/snaptime
 
 ##### Added
- - [Button Action List](#button-action-list)
+ - [Button Action List](#client-button-action-list)
 
 ### 07/16/19
 
@@ -344,6 +345,7 @@ If the user clicked on a link in the navbar, the `PCID` will properly denote wha
 ###### Added
  - Added `pcid` and `ppid` to navbar links that are for the same origin/host.
 
+<a name="071219"></a>
 ### 07/12/19
 
 ##### Commit Links
@@ -369,6 +371,7 @@ If the user clicked on a link in the navbar, the `PCID` will properly denote wha
 ###### Added
   - We are going to send `cid`, `wid`, and `pid` headers with authen requests from now on.
 
+<a name="041819"></a>
 ### 04/18/19
 
 ###### Commit Links
@@ -406,6 +409,7 @@ If the user clicked on a link in the navbar, the `PCID` will properly denote wha
 - Added `cfacet`, `cfacet_str`, and `cfacet_path`.
 - Added `cqp` attribute to track urls that are using `?` (query parameter) instead of `#` (hash fragment).
 
+<a name="030819"></a>
 ### 03/08/19
 
 ###### Commit Links

--- a/docs/user-docs/logging.md
+++ b/docs/user-docs/logging.md
@@ -7,7 +7,7 @@ This document will describe how chaise is logging server requests as well as cli
 ## Table of Contents
 
 - [Logging](#logging)
-    - [Overview](#Overview)
+    - [Overview](#overview)
     - [Attributes](#attributes)
     - [Action definition](#action-definition)
     - [List of requests](#list-of-requests)
@@ -387,6 +387,7 @@ As you might have noticed, we are not adding any extra flag to signal truncation
 
 In this section we're going to mention some of the patterns that you can use to process the logs.
 
+<a name="asset-download--csv-default-export"></a>
 #### Asset Download & CSV Default Export
 
 Since the asset download and also the default CSV export requests are simple redirects to the location, we cannot pass `dcctx` to the header. Instead, we're sending these query parameters:

--- a/docs/user-docs/login-app.md
+++ b/docs/user-docs/login-app.md
@@ -21,16 +21,19 @@ This document will focus on the new implementation of the login app using React.
 
 You need to follow these steps to add the login app to any non-Chaise web page:
 
+<a name="1-install-chaise"></a>
 ### 1. Install Chaise
 
 Make sure Chaise is properly installed. The following steps (and the login app) assume that Chaise is installed and deployed on the server. For more information about how to install Chaise please refer to [installation document](installation.md).
 
+<a name="2-include-login-dependencies"></a>
 ### 2. Include login dependencies
 
 For the login to work, we need to include several JavaScript and CSS files on the page. To do so, you can either change your build process to prefetch them or include a JavaScript file that will dynamically fetch them. The first method MUST be done after Chaise installation; otherwise, it would break the app. That's why we suggest doing it as part of the automated process of building Chaise and other apps.
 
 While the second method seems more straightforward, it will drastically affect the UX by increasing the load time of the login. Therefore we recommend the first method.
 
+<a name="21-change-the-build-process-to-prefetch-dependencies-preferred-method"></a>
 #### 2.1. Change the build process to prefetch dependencies (Preferred method)
 
 To summarize, after Chaise installation in your build scripts, you need to copy the contents of `lib/login/login-dependencies.html` into the HTML page that displays the login. This file won't be present in the Chaise repository folder, and you can only find this folder where you've deployed chaise (By default it should be under `/var/www/chaise/`).
@@ -72,6 +75,7 @@ The following is an example of how this can be achieved using [Jekyll](https://j
 
 4. Build your Jekyll site as you normally would (using `jekyll build` or `jekyll serve` commands.)
 
+<a name="22-dynamically-fetch-the-dependencies"></a>
 #### 2.2. Dynamically fetch the dependencies
 
 To automatically fetch the dependencies, you must include the `/chaise/lib/login/login.dependencies.js` on your page.
@@ -84,6 +88,7 @@ To automatically fetch the dependencies, you must include the `/chaise/lib/login
 
 As we mentioned before, this can cause UX issues as it will increase the loading time of the login app.
 
+<a name="3-prefetch-custom-styles-optional"></a>
 ### 3. Prefetch custom styles (optional)
 
 If you define the `customCSS` property in your [chaise-config](chaise-config.md), Chaise will fetch it during the runtime. To increase the performance, you can prefetch this file by including it in your HTML file (this only needs to be done once and can be done manually). So
@@ -100,6 +105,7 @@ If you define the `customCSS` property in your [chaise-config](chaise-config.md)
 ```
 If you want to prefetch it, the include statement MUST be added before the content of `lib/login/login-dependencies.html` .
 
+<a name="4-use-login"></a>
 ### 4. Use login
 
 The login React app expects a `login` tag on the page and will populate the app inside it. So make sure you've included it on your page.

--- a/docs/user-docs/navbar-app.md
+++ b/docs/user-docs/navbar-app.md
@@ -24,16 +24,19 @@ This documentation focuses on the navbar and how it can be used in external HTML
 
 You need to follow these steps to add the navbar app to any non-Chaise web page:
 
+<a name="1-install-chaise"></a>
 ### 1. Install Chaise
 
 Make sure Chaise is properly installed. The following steps (and the navbar app) assume that Chaise is installed and deployed on the server. For more information about how to install Chaise please refer to [installation document](installation.md).
 
+<a name="2-include-navbar-dependencies"></a>
 ### 2. Include navbar dependencies
 
 For the navbar to work, we need to include several JavaScript and CSS files on the page. To do so, you can either change your build process to prefetch them or include a JavaScript file that will dynamically fetch them. The first method MUST be done after Chaise installation; otherwise, it would break the app. That's why we suggest doing it as part of the automated process of building Chaise and other apps.
 
 While the second method seems more straightforward, it will drastically affect the UX by increasing the load time of the navbar. Therefore we recommend the first method.
 
+<a name="21-change-the-build-process-to-prefetch-dependencies-preferred-method"></a>
 #### 2.1. Change the build process to prefetch dependencies (Preferred method)
 
 To summarize, after Chaise installation in your build scripts, you need to copy the contents of `lib/navbar/navbar-dependencies.html` into the HTML page that displays the navbar. This file won't be present in the Chaise repository folder, and you can only find this folder where you've deployed chaise (By default it should be under `/var/www/chaise/`).
@@ -75,6 +78,7 @@ The following is an example of how this can be achieved using [Jekyll](https://j
 
 4. Build your Jekyll site as you normally would (using `jekyll build` or `jekyll serve` commands.)
 
+<a name="22-dynamically-fetch-the-dependencies"></a>
 #### 2.2. Dynamically fetch the dependencies
 
 To automatically fetch the dependencies, you must include the `/chaise/lib/navbar/navbar.dependencies.js` on your page.
@@ -87,6 +91,7 @@ To automatically fetch the dependencies, you must include the `/chaise/lib/navba
 
 As we mentioned before, this can cause UX issues as it will increase the loading time of the navbar app.
 
+<a name="3-prefetch-custom-styles-optional"></a>
 ### 3. Prefetch custom styles (optional)
 
 If you define the `customCSS` property in your [chaise-config](chaise-config.md), Chaise will fetch it during the runtime. To increase the performance, you can prefetch this file by including it in your HTML file (this only needs to be done once and can be done manually). So
@@ -103,6 +108,7 @@ If you define the `customCSS` property in your [chaise-config](chaise-config.md)
 ```
 If you want to prefetch it, the include statement MUST be added before the content of `lib/navbar/navbar-dependencies.html` .
 
+<a name="4-use-navbar"></a>
 ### 4. Use navbar
 
 The navbar React app expects a `navbar` tag on the page and will populate the app inside it. So make sure you've included it as the first element on the body of your page.
@@ -124,6 +130,7 @@ The navbar React app expects a `navbar` tag on the page and will populate the ap
   ```
 
 
+<a name="5-avoid-manually-including-bootstrap"></a>
 ### 5. Avoid manually including bootstrap
 
 Chaise uses [Bootstrap version 5.1.9](https://getbootstrap.com/docs/5.1/getting-started/introduction/), so it will be included in pages using Navbar. Therefore there's no reason to include Bootstrap manually. Apart from an extra file that has to be fetched to render the page, the Bootstrap version you have included might be different from the one that Chaises uses, which might have some side effects.

--- a/scripts/docs-anchors.py
+++ b/scripts/docs-anchors.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Keep in-page doc links working on BOTH GitHub and the Sphinx docs site.
+
+The docs are read two ways:
+  - GitHub, which slugs heading ids with github-slugger (keeps `_`, keeps a
+    leading `1.` number, drops other punctuation without a separator).
+  - https://docs.derivacloud.org (Sphinx/docutils make_id, which turns `_` and
+    most punctuation into `-` and strips leading digits).
+
+So a heading like `#### markdown_name` becomes `#markdown_name` on GitHub but
+`#markdown-name` on the site, and an auto-generated table-of-contents link only
+resolves on one of them. To support both we add an explicit
+`<a name="<github-slug>"></a>` anchor right before any heading whose link target
+does not slug identically on both renderers. GitHub maps `#foo` to the explicit
+anchor (via its `user-content-` prefix) and Sphinx emits an `id="foo"`, so the
+link works everywhere.
+
+Usage:
+  python3 scripts/docs-anchors.py            # check (exit 1 if anchors missing)
+  python3 scripts/docs-anchors.py --fix      # insert the missing anchors
+  python3 scripts/docs-anchors.py --fix FILE...  # limit to specific files
+
+With no FILE args it scans the *.md files that docs/index.rst feeds to the docs
+site. Re-running is safe; existing anchors are left untouched.
+"""
+import glob
+import os
+import re
+import sys
+
+USAGE = """Usage:
+  python3 scripts/docs-anchors.py            # check (exit 1 if anchors missing)
+  python3 scripts/docs-anchors.py --fix      # insert the missing anchors
+  python3 scripts/docs-anchors.py --fix FILE...  # limit to specific files"""
+
+# github-slugger: lowercase, drop punctuation (keeps '_' and '-'), spaces -> '-'.
+# Only ASCII punctuation is handled; these docs contain no exotic unicode in headings.
+GH_REMOVE = re.compile(r"""[\\'!"#$%&()*+,./:;<=>?@\[\]^`{|}~]""")
+# docutils make_id: non-alphanumeric runs -> '-', strip leading digits/hyphens.
+NON_ID = re.compile(r"[^a-z0-9]+")
+NON_ID_ENDS = re.compile(r"^[-0-9]+|-+$")
+# CommonMark allows up to 3 leading spaces before an ATX heading.
+HEADING = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)\s*#*\s*$")
+FENCE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
+REF = re.compile(r"\]\(#([^)\s\"]+)")
+ANAME = re.compile(r'<a\s+name="([^"]+)"\s*>\s*</a>', re.I)
+
+
+def gh_slug(text, seen):
+    s = GH_REMOVE.sub("", text.strip().lower()).replace(" ", "-")
+    seen[s] = seen.get(s, -1) + 1
+    return s if seen[s] == 0 else f"{s}-{seen[s]}"
+
+
+def du_slug(text, seen):
+    s = NON_ID_ENDS.sub("", NON_ID.sub("-", " ".join(text.lower().split())))
+    seen[s] = seen.get(s, -1) + 1
+    return s if seen[s] == 0 else f"{s}-{seen[s]}"
+
+
+def _heading_text(raw):
+    """Approximate the rendered text: drop inline code backticks and link syntax."""
+    raw = re.sub(r"`([^`]*)`", r"\1", raw)
+    return re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", raw)
+
+
+def _content_lines(lines):
+    """Yield (index, line) for lines outside fenced code blocks. A fence opens on
+    ``` / ~~~ (3+) and closes only on a bare matching marker of >= length, so an
+    info-string line like ```js never closes a block (CommonMark behaviour)."""
+    fence = None  # (char, length) of the open fence, or None
+    for i, ln in enumerate(lines):
+        m = FENCE.match(ln)
+        if m:
+            marker, info = m.group(1), m.group(2)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1] and not info.strip():
+                fence = None
+            continue
+        if fence is None:
+            yield i, ln
+
+
+def analyze(lines):
+    """Return (inserts, unresolved). inserts maps line-index -> [slugs to add]."""
+    headings, refs, existing = [], set(), set()
+    gh_seen, du_seen = {}, {}
+    for i, ln in _content_lines(lines):
+        m = HEADING.match(ln)
+        if m:
+            txt = _heading_text(m.group(2))
+            headings.append((i, gh_slug(txt, gh_seen), du_slug(txt, du_seen)))
+        refs.update(REF.findall(ln))
+        existing.update(ANAME.findall(ln))
+
+    slug2head = {}
+    for h in headings:
+        slug2head.setdefault(h[1], h)
+        slug2head.setdefault(h[2], h)
+
+    inserts, unresolved = {}, []
+    for slug in sorted(refs):
+        h = slug2head.get(slug)
+        if not h:
+            if slug not in existing:
+                unresolved.append(slug)
+            continue
+        if slug == h[1] == h[2] or slug in existing:
+            continue  # resolves natively on both, or already anchored
+        inserts.setdefault(h[0], []).append(slug)
+    return inserts, unresolved
+
+
+def process(path, fix):
+    with open(path, encoding="utf-8") as f:
+        lines = f.readlines()
+    inserts, unresolved = analyze(lines)
+    added = sum(len(v) for v in inserts.values())
+    if added or unresolved:
+        print(f"\n{path}")
+        for idx in sorted(inserts):
+            for slug in inserts[idx]:
+                print(f'  {"+" if fix else "missing anchor:"} <a name="{slug}"></a> before line {idx + 1}')
+        for slug in unresolved:
+            print(f"  ! #{slug} matches no heading (broken or cross-file link) — review manually")
+    if fix and added:
+        for idx in sorted(inserts, reverse=True):
+            for slug in reversed(inserts[idx]):
+                lines.insert(idx, f'<a name="{slug}"></a>\n')
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+    return added
+
+
+def _index_rst_md_files():
+    """The *.md files the published docs site renders, gathered by following the
+    toctrees in docs/index.rst and any .rst files it (transitively) includes."""
+    docs = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs")
+    if not os.path.isfile(os.path.join(docs, "index.rst")):
+        return sorted(glob.glob(os.path.join(docs, "user-docs", "*.md")))
+    md, seen_rst, queue = [], set(), ["index.rst"]
+    while queue:
+        rst = queue.pop()
+        if rst in seen_rst or not os.path.isfile(os.path.join(docs, rst)):
+            continue
+        seen_rst.add(rst)
+        base = os.path.dirname(rst)
+        with open(os.path.join(docs, rst), encoding="utf-8") as f:
+            for entry in re.findall(r"^\s+(\S+\.(?:md|rst))\s*$", f.read(), re.M):
+                path = os.path.normpath(os.path.join(base, entry))
+                if path.endswith(".rst"):
+                    queue.append(path)
+                elif os.path.isfile(os.path.join(docs, path)) and path not in md:
+                    md.append(path)
+    return [os.path.join(docs, p) for p in md]
+
+
+def main(argv):
+    flags = [a for a in argv if a.startswith("--")]
+    unknown = [a for a in flags if a != "--fix"]
+    if unknown:
+        print(f"Unknown option(s): {', '.join(unknown)}\n\n{USAGE}", file=sys.stderr)
+        return 2
+    fix = "--fix" in flags
+    files = [a for a in argv if not a.startswith("--")]
+    if not files:
+        files = _index_rst_md_files()
+    missing = sum(process(p, fix) for p in files if os.path.isfile(p))
+    print(f'\n{"Added" if fix else "Missing"} {missing} anchor(s).')
+    if missing and not fix:
+        print("Run with --fix to insert them.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Same treatment as informatics-isi-edu/ermrestjs#1130: in-page links used GitHub-style anchors that don't resolve on the Sphinx-built docs.derivacloud.org site.

- Added explicit anchors where the two slug styles diverge and fixed a few links pointing at renamed headings.
- Added `scripts/docs-anchors.py` (copy of the ermrestjs script) and documented it in the dev guide.