### PR TITLE
feat(recordset): add bulk copy button to copy a page of records

### DIFF
--- a/.claude/rules/e2e-tests.md
+++ b/.claude/rules/e2e-tests.md
@@ -108,6 +108,17 @@ test.describe('My feature', () => {
 });
 ```
 
+### Test & step descriptions
+
+Keep `test()` and `test.step()` descriptions short so the run logs stay easy to scan. Describe the action or
+the expectation in a few words; don't restate the assertion or explain the "why" (put rationale in a code
+comment if needed).
+
+```typescript
+await test.step('bulk copy opens copy mode', async () => { ... });   // ✅ concise
+await test.step('clicking the bulk copy button should open recordedit in copy mode and show the same number of forms as rows', async () => { ... });  // ❌ too long
+```
+
 ### Parameterized Tests
 
 Use a `for...of` loop around `test()` to run the same test with different data:

--- a/src/assets/scss/_table-header.scss
+++ b/src/assets/scss/_table-header.scss
@@ -39,14 +39,7 @@
   .chaise-table-header-buttons {
     display: flex;
     justify-content: flex-end;
-  }
-
-  .chaise-table-header-buttons-span {
-    margin: 0px 5px;
-
-    &:last-child {
-      margin-right: 0;
-    }
+    gap: 5px;
   }
 
   .chaise-table-header-spinner {

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -6,7 +6,6 @@ import ChaiseSpinner from '@isrd-isi-edu/chaise/src/components/spinner';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import DisplayCommentValue from '@isrd-isi-edu/chaise/src/components/display-comment-value';
 import DisplayValue from '@isrd-isi-edu/chaise/src/components/display-value';
-import Dropdown from 'react-bootstrap/Dropdown';
 import Export from '@isrd-isi-edu/chaise/src/components/export';
 import Faceting from '@isrd-isi-edu/chaise/src/components/faceting/faceting';
 import FilterChiclet from '@isrd-isi-edu/chaise/src/components/recordset/filter-chiclet';
@@ -19,7 +18,6 @@ import SplitView from '@isrd-isi-edu/chaise/src/components/split-view';
 import TableHeader from '@isrd-isi-edu/chaise/src/components/recordset/table-header';
 import Title, { TitleProps } from '@isrd-isi-edu/chaise/src/components/title';
 import TitleVersion from '@isrd-isi-edu/chaise/src/components/title-version';
-import SnapshotForm from '@isrd-isi-edu/chaise/src/components/navbar/snapshot-form';
 
 // hooks
 import React, { useEffect, useRef, useState, type JSX } from 'react';

--- a/src/components/recordset/table-header.tsx
+++ b/src/components/recordset/table-header.tsx
@@ -38,7 +38,7 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
   const container = useRef<HTMLDivElement>(null);
 
   /**
- * as long as the table doesn't have any static update:false ACL, we should show the button.
+   * as long as the table doesn't have any static update:false ACL, we should show the button.
    * if user cannot edit any of the displayed rows, we should disable the button.
    */
   const canShowEditButton = config.displayMode === RecordsetDisplayMode.FULLSCREEN && config.editable && reference && reference.canUpdate;
@@ -51,7 +51,7 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
         There may be editable records in other pages or with different search criteria
       </>
     );
-  }
+  };
 
   const pageLimits = [10, 25, 50, 75, 100, 200];
   if (pageLimits.indexOf(pageLimit) === -1) {
@@ -148,13 +148,16 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
   /**
    * on click of create button generate referrer id, construct the link and open in new tab
    */
-  const addRecord = () => {
-    const referrer_id = 'recordset-' + generateRandomInteger(0, Number.MAX_SAFE_INTEGER);
-    const newRef = reference.table?.reference?.contextualize?.entryCreate;
+  const addRecord = (isBulkCopy = false) => {
+    // in copy, we want the filter/facets. but in create, we should start with an unfiltered reference
+    const currRef = isBulkCopy ? reference : reference.table.reference;
+    const newRef = currRef.contextualize.entryCreate;
     let appLink = newRef.appLink;
-
-    if (!!container.current) {
-      const eventDetails: { [key: string]: any } = { id: referrer_id };
+    
+    const referrer_id = 'recordset-' + generateRandomInteger(0, Number.MAX_SAFE_INTEGER);
+    
+    if (container.current) {
+      const eventDetails: { [key: string]: unknown } = { id: referrer_id };
 
       // currently containerDetails is not used for this code path,
       // but for completeness I added the following:
@@ -165,7 +168,12 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
 
     if (appLink) {
       appLink = appLink + (appLink.indexOf('?') === -1 ? '?' : '&') +
-        'invalidate=' + fixedEncodeURIComponent(referrer_id);
+        'invalidate=' + fixedEncodeURIComponent(referrer_id) + (isBulkCopy ? '&copy=true' : '');
+
+      // add page limit in copy mode
+      if (isBulkCopy && appLink.indexOf('?limit=') === -1 && appLink.indexOf('&limit=') === -1) {
+        appLink = `${appLink + '&limit=' + pageLimit}`;
+      }
 
       if (config.displayMode !== RecordsetDisplayMode.FULLSCREEN) {
         logRecordsetClientAction(LogActions.ADD_INTEND);
@@ -208,6 +216,8 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
     return isAddableDisplayMode && reference && reference.canCreate;
   }
 
+  const createButtonType = config.displayMode === RecordsetDisplayMode.FULLSCREEN ? 'chaise-btn-primary' : 'chaise-btn-secondary';
+
   return (
     <div className='chaise-table-header row' ref={container}>
       <div
@@ -220,50 +230,76 @@ const TableHeader = ({ config }: TableHeaderProps): JSX.Element => {
         {page && page.length > 0 && renderPageSizeDropdown()}
         <span className='total-count-text'>
           {appendLabel()}
-          {totalRowCountHasTimeoutError &&
+          {totalRowCountHasTimeoutError && (
             <ChaiseTooltip
               placement='bottom'
-              tooltip={'Request timeout: total count cannot be retrieved. Refresh the page later to try again.'}
+              tooltip={
+                'Request timeout: total count cannot be retrieved. Refresh the page later to try again.'
+              }
             >
               <span className='timeout-icon fa-solid fa-triangle-exclamation' />
             </ChaiseTooltip>
-          }
+          )}
         </span>
       </div>
       <div className='col-12 col-sm-6'>
-        <div
-          className='chaise-table-header-buttons'
-        >
+        <div className='chaise-table-header-buttons'>
           {shouldShowCreateButton() && (
-            <ChaiseTooltip
-              placement='bottom-end'
-              tooltip={<>Create new{' '}<DisplayValue value={reference.displayname} /></>}
-            >
-              <span className='chaise-table-header-buttons-span'>
+            <>
+              {/* create new button */}
+              <ChaiseTooltip
+                placement='bottom-end'
+                tooltip={
+                  <>
+                    Create new <DisplayValue value={reference.displayname} />
+                  </>
+                }
+              >
                 <button
-                  className={`chaise-btn  ${config.displayMode === RecordsetDisplayMode.FULLSCREEN ? 'chaise-btn-primary' : 'chaise-btn-secondary'} chaise-table-header-create-link`}
-                  onClick={addRecord}
+                  className={`chaise-btn  ${createButtonType} chaise-table-header-create-link`}
+                  onClick={() => addRecord(false)}
                 >
                   <span className='chaise-btn-icon fa-solid fa-plus' />
-                  <span>{config.displayMode === RecordsetDisplayMode.FULLSCREEN ? 'Create' : 'Create new'}</span>
+                  <span>
+                    {config.displayMode === RecordsetDisplayMode.FULLSCREEN
+                      ? 'Create'
+                      : 'Create new'}
+                  </span>
                 </button>
-              </span>
-            </ChaiseTooltip>
+              </ChaiseTooltip>
+
+              {/* bulk copy button */}
+              <ChaiseTooltip
+                placement='bottom-end'
+                tooltip={
+                  <>
+                    Create new records by copying this page of records. <br />
+                  </>
+                }
+              >
+                <button
+                  className={`chaise-btn  ${createButtonType} chaise-table-header-bulk-copy-link`}
+                  onClick={() => addRecord(true)}
+                  disabled={!page || page.tuples.length === 0}
+                >
+                  <span className='chaise-btn-icon fa fa-clipboard' />
+                  <span>Bulk Copy</span>
+                </button>
+              </ChaiseTooltip>
+            </>
           )}
 
           {/* Edit Button */}
           {canShowEditButton && (
-            <ChaiseTooltip placement='bottom-end' tooltip={editButtonTooltip} >
-              <span>
-                <button
-                  className='chaise-btn chaise-btn-primary chaise-table-header-edit-link'
-                  onClick={editRecord}
-                  disabled={disableEditButton}
-                >
-                  <span className='chaise-btn-icon fa-solid fa-pen' />
-                  <span>Bulk edit</span>
-                </button>
-              </span>
+            <ChaiseTooltip placement='bottom-end' tooltip={editButtonTooltip}>
+              <button
+                className='chaise-btn chaise-btn-primary chaise-table-header-edit-link'
+                onClick={editRecord}
+                disabled={disableEditButton}
+              >
+                <span className='chaise-btn-icon fa-solid fa-pen' />
+                <span>Bulk edit</span>
+              </button>
             </ChaiseTooltip>
           )}
         </div>

--- a/src/pages/recordedit.tsx
+++ b/src/pages/recordedit.tsx
@@ -66,9 +66,11 @@ const RecordeditApp = (): JSX.Element => {
       let reference = response;
       const location = reference.location;
 
-      if (location.filter || location.facets) {
-        appMode = res.queryParams.prefill ? appModes.CREATE : (res.queryParams.copy ? appModes.COPY : appModes.EDIT);
-      } else if (res.queryParams.limit) {
+      if (res.queryParams.prefill) {
+        appMode = appModes.CREATE;
+      } else if (res.queryParams.copy) {
+        appMode = appModes.COPY;
+      } else if (location.filter || location.facets || res.queryParams.limit) {
         appMode = appModes.EDIT;
       }
 

--- a/test/e2e/data_setup/data/product/bulk_copy_outbound1.json
+++ b/test/e2e/data_setup/data/product/bulk_copy_outbound1.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "name": "Type A" },
+  { "id": 2, "name": "Type B" },
+  { "id": 3, "name": "Type C" }
+]

--- a/test/e2e/data_setup/data/product/bulk_copy_table.json
+++ b/test/e2e/data_setup/data/product/bulk_copy_table.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "title": "Alpha", "outbound1": "Type A" },
+  { "id": 2, "title": "Beta", "outbound1": "Type B" },
+  { "id": 3, "title": "Gamma", "outbound1": "Type C" }
+]

--- a/test/e2e/data_setup/schema/recordset/product-add.json
+++ b/test/e2e/data_setup/schema/recordset/product-add.json
@@ -789,6 +789,65 @@
           "*": ["id", "term"]
         }
       }
+    },
+    "bulk_copy_outbound1": {
+      "comment": null,
+      "kind": "table",
+      "entityCount": 0,
+      "keys": [
+        { "comment": null, "annotations": {}, "unique_columns": ["id"] },
+        { "comment": null, "annotations": {}, "unique_columns": ["name"] }
+      ],
+      "table_name": "bulk_copy_outbound1",
+      "schema_name": "product-recordset-add",
+      "column_definitions": [
+        { "comment": null, "name": "id", "nullok": false, "type": { "typename": "int4" }, "annotations": {} },
+        { "comment": null, "name": "name", "nullok": false, "type": { "typename": "text" }, "annotations": {} }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns": {
+          "*": ["id", "name"]
+        },
+        "tag:isrd.isi.edu,2016:table-display": {
+          "row_name": { "row_markdown_pattern": "{{{name}}}" }
+        }
+      }
+    },
+    "bulk_copy_table": {
+      "comment": null,
+      "kind": "table",
+      "entityCount": 0,
+      "keys": [
+        { "comment": null, "annotations": {}, "unique_columns": ["id"] }
+      ],
+      "foreign_keys": [
+        {
+          "names": [["product-recordset-add", "bulk_copy_fk1"]],
+          "foreign_key_columns": [
+            { "table_name": "bulk_copy_table", "schema_name": "product-recordset-add", "column_name": "outbound1" }
+          ],
+          "annotations": {
+            "tag:isrd.isi.edu,2016:foreign-key": { "to_name": "Outbound 1" }
+          },
+          "referenced_columns": [
+            { "table_name": "bulk_copy_outbound1", "schema_name": "product-recordset-add", "column_name": "name" }
+          ]
+        }
+      ],
+      "table_name": "bulk_copy_table",
+      "schema_name": "product-recordset-add",
+      "column_definitions": [
+        { "comment": null, "name": "id", "nullok": false, "type": { "typename": "int4" }, "annotations": {} },
+        { "comment": null, "name": "title", "nullok": false, "type": { "typename": "text" }, "annotations": {} },
+        { "comment": null, "name": "outbound1", "nullok": true, "type": { "typename": "text" }, "annotations": {} }
+      ],
+      "annotations": {
+        "tag:isrd.isi.edu,2016:visible-columns": {
+          "compact": ["id", "title", ["product-recordset-add", "bulk_copy_fk1"]],
+          "entry/create": ["id", "title", ["product-recordset-add", "bulk_copy_fk1"]],
+          "entry/edit": ["id", "title", ["product-recordset-add", "bulk_copy_fk1"]]
+        }
+      }
     }
   },
   "table_names": [
@@ -796,7 +855,9 @@
     "file",
     "accommodation",
     "accommodation_image",
-    "booking"
+    "booking",
+    "bulk_copy_outbound1",
+    "bulk_copy_table"
   ],
   "comment": null,
   "annotations": {

--- a/test/e2e/locators/recordset.ts
+++ b/test/e2e/locators/recordset.ts
@@ -162,6 +162,10 @@ export default class RecordsetLocators {
     return container.locator('.chaise-table-header-edit-link');
   }
 
+  static getBulkCopyLink(container: Page | Locator): Locator {
+    return container.locator('.chaise-table-header-bulk-copy-link');
+  }
+
   static getRecordSetTable(container: Page | Locator): Locator {
     return container.locator('.recordset-table');
   }

--- a/test/e2e/specs/all-features/recordset/permissions-annotation.spec.ts
+++ b/test/e2e/specs/all-features/recordset/permissions-annotation.spec.ts
@@ -15,6 +15,10 @@ test.describe('Viewing Recordset app with permission related annotations', () =>
       await testButtonState(RecordsetLocators.getAddRecordsLink(page), true, false);
     });
 
+    await test.step('should not display the bulk copy button', async () => {
+      await testButtonState(RecordsetLocators.getBulkCopyLink(page), true, false);
+    });
+
     await test.step('should not display the edit button', async () => {
       await testButtonState(RecordsetLocators.getBulkEditLink(page), true, false);
     });
@@ -43,6 +47,10 @@ test.describe('Viewing Recordset app with permission related annotations', () =>
 
     await test.step('should display the create button', async () => {
       await testButtonState(RecordsetLocators.getAddRecordsLink(page), true, true);
+    });
+
+    await test.step('should display the bulk copy button', async () => {
+      await testButtonState(RecordsetLocators.getBulkCopyLink(page), true, true, false);
     });
 
     await test.step('should not display the edit button', async () => {
@@ -75,6 +83,10 @@ test.describe('Viewing Recordset app with permission related annotations', () =>
       await testButtonState(RecordsetLocators.getAddRecordsLink(page), true, true);
     });
 
+    await test.step('should display the bulk copy button', async () => {
+      await testButtonState(RecordsetLocators.getBulkCopyLink(page), true, true, false);
+    });
+
     await test.step('should display the edit button', async () => {
       await testButtonState(RecordsetLocators.getBulkEditLink(page), true, true);
     });
@@ -103,6 +115,10 @@ test.describe('Viewing Recordset app with permission related annotations', () =>
 
     await test.step('should not display the create button', async () => {
       await testButtonState(RecordsetLocators.getAddRecordsLink(page), true, false);
+    });
+
+    await test.step('should not display the bulk copy button', async () => {
+      await testButtonState(RecordsetLocators.getBulkCopyLink(page), true, false);
     });
 
     await test.step('should not display the edit button', async () => {

--- a/test/e2e/specs/default-config/recordset/add.spec.ts
+++ b/test/e2e/specs/default-config/recordset/add.spec.ts
@@ -9,7 +9,7 @@ import RecordsetLocators from '@isrd-isi-edu/chaise/test/e2e/locators/recordset'
 // utils
 import { getEntityRow } from '@isrd-isi-edu/chaise/test/e2e/utils/catalog-utils';
 import { clickNewTabLink, manuallyTriggerFocus } from '@isrd-isi-edu/chaise/test/e2e/utils/page-utils';
-import { setInputValue } from '@isrd-isi-edu/chaise/test/e2e/utils/recordedit-utils';
+import { setInputValue, testSubmission } from '@isrd-isi-edu/chaise/test/e2e/utils/recordedit-utils';
 import { APP_NAMES } from '@isrd-isi-edu/chaise/test/e2e/utils/constants';
 import { generateChaiseURL } from '@isrd-isi-edu/chaise/test/e2e/utils/page-utils';
 
@@ -21,6 +21,8 @@ const testParams = {
   rating: '3.50',
   summary: 'The BEST WESTERN PLUS Amedia Art Salzburg is located near the traditional old part of town, near the highway, near the train station and close to the exhibition center of Salzburg.\nBEST WESTERN PLUS Amedia Art Salzburg offers harmony of modern technique and convenient atmosphere to our national and international business guest and tourists.'
 };
+
+test.describe.configure({ mode: 'parallel' });
 
 test('Recordset add record', async ({ page, baseURL }, testInfo) => {
   const PAGE_URL = generateChaiseURL(APP_NAMES.RECORDSET, testParams.schema_name, testParams.table_name, testInfo, baseURL);
@@ -135,5 +137,54 @@ test('Recordset add record', async ({ page, baseURL }, testInfo) => {
     await manuallyTriggerFocus(page);
 
     await expect.soft(RecordsetLocators.getRows(page)).toHaveCount(testParams.num_rows+1);
+  });
+});
+
+test('bulk copy creates records from recordset', async ({ page, baseURL }, testInfo) => {
+  const PAGE_URL = generateChaiseURL(APP_NAMES.RECORDSET, testParams.schema_name, 'bulk_copy_table', testInfo, baseURL);
+  let newPage: Page;
+
+  await test.step('load recordset', async () => {
+    await page.goto(`${PAGE_URL}@sort(id)`);
+    await RecordsetLocators.waitForRecordsetPageReady(page);
+    await expect.soft(RecordsetLocators.getRows(page)).toHaveCount(3);
+  });
+
+  await test.step('bulk copy opens 3 pre-filled forms in a new tab', async () => {
+    // bulk copy opens recordedit in a new tab
+    newPage = await clickNewTabLink(RecordsetLocators.getBulkCopyLink(page));
+    await RecordeditLocators.waitForRecordeditPageReady(newPage);
+
+    await expect.soft(RecordeditLocators.getRecordeditForms(newPage)).toHaveCount(3);
+    // copy mode ("Create 3 ...") vs edit's "Edit 3 ..."
+    await expect.soft(RecordeditLocators.getPageTitle(newPage)).toContainText('Create 3');
+    await expect.soft(RecordeditLocators.getInputForAColumn(newPage, 'title', 1)).toHaveValue('Alpha');
+    await expect.soft(RecordeditLocators.getInputForAColumn(newPage, 'title', 2)).toHaveValue('Beta');
+    await expect.soft(RecordeditLocators.getForeignKeyInputDisplay(newPage, 'Outbound 1', 1)).toHaveText('Type A');
+  });
+
+  await test.step('edit keys and submit', async () => {
+    await RecordeditLocators.getInputForAColumn(newPage, 'id', 1).fill('101');
+    await RecordeditLocators.getInputForAColumn(newPage, 'id', 2).fill('102');
+    await RecordeditLocators.getInputForAColumn(newPage, 'id', 3).fill('103');
+    await RecordeditLocators.getInputForAColumn(newPage, 'title', 1).fill('Alpha edited');
+
+    await testSubmission(newPage, {
+      tableDisplayname: 'bulk_copy_table',
+      resultColumnNames: ['id', 'title', 'Outbound 1'],
+      resultRowValues: [
+        ['101', 'Alpha edited', 'Type A'],
+        ['102', 'Beta', 'Type B'],
+        ['103', 'Gamma', 'Type C'],
+      ],
+    });
+  });
+
+  await test.step('recordset auto-refreshes with the new rows', async () => {
+    await newPage.close();
+    // playwright keeps tabs focused, so manually fire focus on the recordset
+    await manuallyTriggerFocus(page);
+
+    await expect.soft(RecordsetLocators.getRows(page)).toHaveCount(6);
   });
 });

--- a/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.ts
+++ b/test/e2e/specs/delete-prohibited/recordset/misc-facet.spec.ts
@@ -10,7 +10,7 @@ import RecordsetLocators from '@isrd-isi-edu/chaise/test/e2e/locators/recordset'
 
 // utils
 import { APP_NAMES } from '@isrd-isi-edu/chaise/test/e2e/utils/constants';
-import { generateChaiseURL } from '@isrd-isi-edu/chaise/test/e2e/utils/page-utils';
+import { clickNewTabLink, generateChaiseURL } from '@isrd-isi-edu/chaise/test/e2e/utils/page-utils';
 import { testRecordMainSectionValues } from '@isrd-isi-edu/chaise/test/e2e/utils/record-utils';
 import {
   openFacet, openFacetAndTestFilterOptions, testColumnSort,
@@ -307,7 +307,7 @@ const testParams = {
 };
 
 test.describe('Other facet features', () => {
-  test.describe.configure({ mode: 'parallel', retries: 3 });
+  // test.describe.configure({ mode: 'parallel', retries: 3 });
 
   test('selecting entity facet that is not on the shortest key.', async ({ page, baseURL }, testInfo) => {
     const facet = RecordsetLocators.getFacetById(page, testParams.filter_secondary_key.facetIdx);
@@ -922,6 +922,27 @@ test.describe('Other facet features', () => {
         await RecordeditLocators.waitForRecordeditPageReady(page);
 
         await expect.soft(RecordeditLocators.getRecordeditForms(page)).toHaveCount(25);
+      });
+    });
+
+    test('bulk copy from recordset', async ({ page, baseURL }, testInfo) => {
+      await test.step('load recordset and clear filters', async () => {
+        await page.goto(generateChaiseURL(APP_NAMES.RECORDSET, testParams.schema_name, testParams.table_name, testInfo, baseURL));
+        await RecordsetLocators.waitForRecordsetPageReady(page);
+
+        await testClearAllFilters(page, 25);
+      });
+
+      await test.step('bulk copy opens copy mode in a new tab, one form per row', async () => {
+        // bulk copy opens recordedit in a new tab
+        const newPage = await clickNewTabLink(RecordsetLocators.getBulkCopyLink(page));
+        await RecordeditLocators.waitForRecordeditPageReady(newPage);
+
+        await expect.soft(RecordeditLocators.getRecordeditForms(newPage)).toHaveCount(25);
+        // copy mode shows "Create 25 ..." vs edit's "Edit 25 ..."; guards the no-filter copy fix
+        await expect.soft(RecordeditLocators.getPageTitle(newPage)).toContainText('Create 25');
+
+        await newPage.close();
       });
     });
 


### PR DESCRIPTION
This PR,

- Adds a Bulk Copy button to the recordset table header that opens recordedit in copy mode with one pre-filled form per row on the current page.
- Fixes recordedit `appMode` detection so `copy=true` is honored when the recordset has no filter/facet (previously fell through to edit mode).

Fixes #2776 