### PR TITLE
fix: condition request dedup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,3 @@
-
 name: Chaise end-to-end tests
 
 on: [push]
@@ -10,10 +9,10 @@ jobs:
   install-and-test:
     runs-on: ubuntu-24.04
     strategy:
-       # allow all matrix jobs to complete
+      # allow all matrix jobs to complete
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x", "24.x"]
+        node-version: ['20.x', '22.x', '24.x']
     env:
       SHARDING: true
       HEADLESS: false
@@ -115,7 +114,6 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
-          git checkout condition-request-dedup
           sudo make root-install
       - name: Install chaise (build & deploy)
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           git clone https://github.com/informatics-isi-edu/ermrestjs.git
           cd ermrestjs
+          git checkout condition-request-dedup
           sudo make root-install
       - name: Install chaise (build & deploy)
         run: |

--- a/src/providers/record.tsx
+++ b/src/providers/record.tsx
@@ -772,8 +772,11 @@ export default function RecordProvider({
         // all-outbound, no async wait_for) the condition has no fetch and no
         // request model — that's expected; chaise just evaluates it against
         // the main tuple after the main entity is read.
+        // After the consolidation pass the source may instead live on a display
+        // request (inline/related) whose `entitysetSourceName` is the source
+        // hash — match that too, so the display read drives the condition.
         const condReqModel = flowControl.current.requestModels.find(
-          (m) => m.activeListModel.column?.name === condColName
+          (m) => m.activeListModel.column?.name === condColName || m.activeListModel.entitysetSourceName === condColName
         );
 
         // dependents inherit the condition source's priority when async, or get
@@ -1061,6 +1064,26 @@ export default function RecordProvider({
        * If the request errored out (timeout or other types of error) page will be undefined.
        */
       const hasMainData = res.success && res.page;
+
+      // If the consolidation pass folded data consumers (value / wait_for /
+      // citation / condition) onto this display request, this display read is the
+      // single read for the source. Store the page and dispatch those consumers
+      // the same way fetchSecondaryRequest does for an entityset. Done before the
+      // markdown block below so a self-referential markdown table sees its own
+      // page variables.
+      const activeListModel = reqModel.activeListModel;
+      if (hasMainData && activeListModel.entitysetSourceName && Array.isArray(activeListModel.objects) && activeListModel.objects.length > 0) {
+        const sourceName: string = activeListModel.entitysetSourceName;
+        flowControl.current.entitySetResults[sourceName] = res.page;
+        const sm = reference.table.sourceDefinitions.sourceMapping[sourceName];
+        if (Array.isArray(sm)) {
+          sm.forEach((k: string) => {
+            flowControl.current.templateVariables[k] = res.page.templateVariables;
+          });
+        }
+        attachPseudoColumnValue(activeListModel, isUpdate);
+      }
+
       const hasWaitForData = !rm.hasWaitFor || rm.waitForDataLoaded;
       if (hasMainData && hasWaitForData) {
         printDebugMessage('updating markdown content in afterUpdateRelatedEntity', m);

--- a/src/providers/record.tsx
+++ b/src/providers/record.tsx
@@ -776,13 +776,17 @@ export default function RecordProvider({
         // request (inline/related) whose `entitysetSourceName` is the source
         // hash — match that too, so the display read drives the condition.
         const condReqModel = flowControl.current.requestModels.find(
-          (m) => m.activeListModel.column?.name === condColName || m.activeListModel.entitysetSourceName === condColName
+          (m) =>
+            m.activeListModel.column?.name === condColName ||
+            m.activeListModel.entitysetSourceName === condColName
         );
 
         // dependents inherit the condition source's priority when async, or get
         // a synthetic late priority when sync (they're upserted at evaluation
         // time, so the priority only matters relative to other queued items).
-        const dependentPriority = condReqModel ? condReqModel.priority : flowControl.current.requestModels.length;
+        const dependentPriority = condReqModel
+          ? condReqModel.priority
+          : flowControl.current.requestModels.length;
 
         // create request models for dependent items but do NOT add to requestQueue
         const dependentModels: RecordRequestModel[] = [];
@@ -842,8 +846,8 @@ export default function RecordProvider({
 
     printDebugMessage(
       `initialized ${flowControl.current.conditionModels.length} condition models — ` +
-      `column-conditioned indices: [${Array.from(conditionedColumnIndices).join(',')}], ` +
-      `related-conditioned indices: [${Array.from(conditionedRelatedIndices).join(',')}]`
+        `column-conditioned indices: [${Array.from(conditionedColumnIndices).join(',')}], ` +
+        `related-conditioned indices: [${Array.from(conditionedRelatedIndices).join(',')}]`
     );
 
     // column models
@@ -1051,6 +1055,8 @@ export default function RecordProvider({
     isInline: boolean
   ) => {
     return function (res: { success: boolean; page: any }) {
+      const activeListModel = reqModel.activeListModel;
+
       reqModel.processed = !res.success;
 
       const rm = isInline
@@ -1065,14 +1071,18 @@ export default function RecordProvider({
        */
       const hasMainData = res.success && res.page;
 
-      // If the consolidation pass folded data consumers (value / wait_for /
-      // citation / condition) onto this display request, this display read is the
-      // single read for the source. Store the page and dispatch those consumers
-      // the same way fetchSecondaryRequest does for an entityset. Done before the
-      // markdown block below so a self-referential markdown table sees its own
-      // page variables.
-      const activeListModel = reqModel.activeListModel;
-      if (hasMainData && activeListModel.entitysetSourceName && Array.isArray(activeListModel.objects) && activeListModel.objects.length > 0) {
+      /**
+       * when consolidation folded data consumers (value / wait_for / citation / condition)
+       * onto this display, the display read is the single read for the source,
+       * so store its page and dispatch those consumers like fetchSecondaryRequest does.
+       * before the markdown block so a self-referential markdown table sees its own page variables.
+       */
+      if (
+        hasMainData &&
+        activeListModel.entitysetSourceName &&
+        Array.isArray(activeListModel.objects) &&
+        activeListModel.objects.length > 0
+      ) {
         const sourceName: string = activeListModel.entitysetSourceName;
         flowControl.current.entitySetResults[sourceName] = res.page;
         const sm = reference.table.sourceDefinitions.sourceMapping[sourceName];
@@ -1452,9 +1462,10 @@ export default function RecordProvider({
 
     // all data available -- get the condition value and evaluate
     const condColName = condModel.condition.column.name;
-    const conditionValue = flowControl.current.aggregateResults[condColName]
-      ?? flowControl.current.entitySetResults[condColName]
-      ?? null;
+    const conditionValue =
+      flowControl.current.aggregateResults[condColName] ??
+      flowControl.current.entitySetResults[condColName] ??
+      null;
 
     const result = condModel.condition.evaluateCondition(
       flowControl.current.templateVariables,
@@ -1467,7 +1478,7 @@ export default function RecordProvider({
 
     printDebugMessage(
       `condition evaluated, key=${condModel.condition.conditionKey || '<inline>'} ` +
-      `source=${condColName} shouldShow=${result.shouldShow}`
+        `source=${condColName} shouldShow=${result.shouldShow}`
     );
 
     if (result.shouldShow) {
@@ -1506,8 +1517,8 @@ export default function RecordProvider({
 
     printDebugMessage(
       `updateConditionedVisibility hide=${hide} key=${condModel.condition.conditionKey || '<inline>'} ` +
-      `colIdxs=[${Array.from(affectedColumnIndices).join(',')}] ` +
-      `relIdxs=[${Array.from(affectedRelatedIndices).join(',')}]`
+        `colIdxs=[${Array.from(affectedColumnIndices).join(',')}] ` +
+        `relIdxs=[${Array.from(affectedRelatedIndices).join(',')}]`
     );
     if (affectedColumnIndices.size > 0) {
       setColumnModels((prevModels: RecordColumnModel[]) =>
@@ -1519,7 +1530,11 @@ export default function RecordProvider({
             updated.relatedModel = {
               ...updated.relatedModel,
               tableMarkdownContentInitialized: true,
-              recordsetState: { ...updated.relatedModel.recordsetState, isInitialized: true, isLoading: false },
+              recordsetState: {
+                ...updated.relatedModel.recordsetState,
+                isInitialized: true,
+                isLoading: false,
+              },
             };
           }
           return updated;
@@ -1535,7 +1550,11 @@ export default function RecordProvider({
           // when hiding, mark as initialized so the related section spinner stops
           if (hide) {
             updated.tableMarkdownContentInitialized = true;
-            updated.recordsetState = { ...updated.recordsetState, isInitialized: true, isLoading: false };
+            updated.recordsetState = {
+              ...updated.recordsetState,
+              isInitialized: true,
+              isLoading: false,
+            };
           }
           return updated;
         })

--- a/test/e2e/data_setup/schema/record/condition.json
+++ b/test/e2e/data_setup/schema/record/condition.json
@@ -113,7 +113,9 @@
                         },
                         "cond_inbound1": {
                             "sourcekey": "cond_inbound1_src",
-                            "on_empty": "hide"
+                            "on_empty": "hide",
+                            "condition_pattern": "{{#if (gt $self.length 0)}}show{{/if}}",
+                            "template_engine": "handlebars"
                         },
                         "cond_inbound_count": {
                             "sourcekey": "cond_inbound_count_src",
@@ -125,7 +127,9 @@
                         },
                         "cond_path_multi": {
                             "sourcekey": "cond_path_multi_src",
-                            "on_empty": "hide"
+                            "on_empty": "hide",
+                            "condition_pattern": "{{#if (gt $self.length 0)}}show{{/if}}",
+                            "template_engine": "handlebars"
                         },
                         "cond_path_filter": {
                             "sourcekey": "cond_path_filter_src",

--- a/test/e2e/locators/record.ts
+++ b/test/e2e/locators/record.ts
@@ -107,8 +107,13 @@ export default class RecordLocators {
     return container.locator('tr:not(.forced-hidden) td.entity-value');
   }
 
-  static getColumnValue(container: Locator | Page, columnName: string): Locator {
-    return container.locator(`#row-${columnName} .entity-value span:not(.chaise-comment)`);
+  /**
+   * @param columnName either the column name or the column displayname (if isColumnDisplayname is true)
+   * @param isColumnDisplayname whether the second param is a column displayname (not the name/hash).
+   */
+  static getColumnValue(container: Locator | Page, columnName: string, isColumnDisplayname?: boolean): Locator {
+    const rowSelector = isColumnDisplayname ? `.entity-row-${makeSafeIdAttr(columnName)}` : `#row-${columnName}`;
+    return container.locator(`${rowSelector} .entity-value span:not(.chaise-comment)`);
   }
 
   static getColumnInlineComment(container: Locator | Page, columnDisplayName: string): Locator {

--- a/test/e2e/specs/default-config/record/condition.spec.ts
+++ b/test/e2e/specs/default-config/record/condition.spec.ts
@@ -55,7 +55,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
     await page.goto(url);
     await RecordLocators.waitForRecordPageReady(page);
 
-    await test.step('main-section visible columns are exactly the expected list, in order', async () => {
+    await test.step('main-section visible columns', async () => {
       // ns_inline_show / ns_key_show: no-source conditions that render non-empty -> kept.
       // ns_inline_hide: no-source condition that renders empty -> filtered out by the
       // no-source filter pass in ermrestjs (applyNoSourceConditions).
@@ -73,7 +73,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
       ]);
     });
 
-    await test.step('related-table accordions are exactly the expected list, in order', async () => {
+    await test.step('related-table accordions', async () => {
       // ns_related_show: no-source condition renders non-empty -> kept.
       // ns_related_hide: no-source condition renders empty -> filtered out.
       await expect.soft(RecordLocators.getDisplayedRelatedTableTitles(page)).toHaveText([
@@ -86,7 +86,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
       ]);
     });
 
-    await test.step('side-panel TOC lists every visible section', async () => {
+    await test.step('side-panel TOC', async () => {
       await expect.soft(RecordLocators.getSidePanelHeadings(page)).toHaveText([
         'Summary',
         'inbound1 (1)',
@@ -104,7 +104,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
     await page.goto(url);
     await RecordLocators.waitForRecordPageReady(page);
 
-    await test.step('title + outbound columns + no-source-show columns remain in main-section', async () => {
+    await test.step('main-section visible columns', async () => {
       // no-source conditions are deterministic (don't depend on row data), so ns_inline_show
       // and ns_key_show appear for id=2 just like for id=1.
       await expect.soft(RecordLocators.getAllColumnNames(page)).toHaveText([
@@ -116,7 +116,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
       ]);
     });
 
-    await test.step('inbound1 + always_shown_table + ns_related_show accordions are visible', async () => {
+    await test.step('related-table accordions', async () => {
       await expect.soft(RecordLocators.getDisplayedRelatedTableTitles(page)).toHaveText([
         'inbound1',
         'always_shown_table',
@@ -124,7 +124,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
       ]);
     });
 
-    await test.step('TOC lists Summary + visible related sections', async () => {
+    await test.step('side-panel TOC', async () => {
       await expect.soft(RecordLocators.getSidePanelHeadings(page)).toHaveText([
         'Summary',
         'inbound1 (0)',
@@ -135,11 +135,13 @@ test.describe('Condition on visible columns and foreign keys', () => {
   });
 
   test('id=1: a source used as display + condition + gated value is read once', async ({ page, baseURL }, testInfo) => {
-    // Two dedup paths, both should collapse to a single read:
-    //  - cond_inbound1_src (entity set) is BOTH the inbound1 vis-fk display AND the source of
-    //    cond_inbound1 -> the condition source folds onto the display (one entity-set read).
-    //  - cond_inbound_count_src (cnt aggregate) is BOTH inbound1_count_col's value AND its own
-    //    gate cond_inbound_count -> the gated value folds onto the condition source (one count read).
+    /*
+     * Two dedup paths, both should collapse to a single read:
+     *  - cond_inbound1_src (entity set) is BOTH the inbound1 vis-fk display AND the source of
+     *    cond_inbound1 -> the condition source folds onto the display (one entity-set read).
+     *  - cond_inbound_count_src (cnt aggregate) is BOTH inbound1_count_col's value AND its own
+     *    gate cond_inbound_count -> the gated value folds onto the condition source (one count read).
+     */
     const ermrestReads: string[] = [];
     page.on('request', (req) => {
       const u = req.url();
@@ -154,10 +156,12 @@ test.describe('Condition on visible columns and foreign keys', () => {
     await RecordLocators.waitForRecordPageReady(page);
     await page.waitForLoadState('networkidle');
 
-    // the inbound1 entity-set read (related reads aggregate rows via array_d). This is the
-    // query shared by the inbound1 vis-fk display and the cond_inbound1 source. The count
-    // aggregate (cnt), the kind=primary filtered read, and the multi-hop path read also touch
-    // inbound1 but are distinct queries, so the source-hash anchor + array_d excludes them.
+    /*
+     * the inbound1 entity-set read (related reads aggregate rows via array_d). This is the
+     * query shared by the inbound1 vis-fk display and the cond_inbound1 source. The count
+     * aggregate (cnt), the kind=primary filtered read, and the multi-hop path read also touch
+     * inbound1 but are distinct queries, so the source-hash anchor + array_d excludes them.
+     */
     const inbound1EntitySetReads = ermrestReads.filter((u) =>
       u.includes('M:=condition-test:inbound1/(main_id)') &&
       u.includes('array_d') &&
@@ -173,6 +177,12 @@ test.describe('Condition on visible columns and foreign keys', () => {
 
     await test.step('inbound1 count aggregate is read exactly once', async () => {
       expect(inbound1CountReads, 'inbound1 count reads:\n' + inbound1CountReads.join('\n')).toHaveLength(1);
+    });
+
+    await test.step('deduped reads still render their gated content', async () => {
+      await expect.soft(RecordLocators.getColumnValue(page, 'gated_col', true)).toBeVisible();
+      await expect.soft(RecordLocators.getColumnValue(page, 'inbound1_count_col', true)).toHaveText('1');
+      await expect.soft(RecordLocators.getDisplayedRelatedTableTitles(page)).toContainText(['inbound1']);
     });
   });
 
@@ -194,6 +204,19 @@ test.describe('Condition on visible columns and foreign keys', () => {
         'always_shown_table',
         'ns_related_show',
       ]);
+    });
+
+    /*
+     * always_shown_table stays visible across the update, so its accordion should never
+     * become forced-hidden while conditions re-evaluate.
+     */
+    await page.evaluate(() => {
+      (window as any).__alwaysShownFlashed = false;
+      const root = document.querySelector('.related-section-container') || document.body;
+      new MutationObserver(() => {
+        const acc = document.querySelector('.chaise-accordion:has(#rt-heading-always_shown_table)');
+        if (acc && acc.classList.contains('forced-hidden')) (window as any).__alwaysShownFlashed = true;
+      }).observe(root, { subtree: true, attributes: true, attributeFilter: ['class'], childList: true });
     });
 
     // Open the inbound1 vis-fk's "Add records" form, fill it, submit, return.
@@ -219,7 +242,7 @@ test.describe('Condition on visible columns and foreign keys', () => {
       }
     );
 
-    await test.step('after add: inbound1-keyed items become visible (re-evaluation worked)', async () => {
+    await test.step('after add: gated items become visible', async () => {
       await RecordLocators.waitForRecordPageReady(page);
 
       // gated_col (cond_inbound1) and inbound1_count_col (cond_inbound_count)
@@ -246,6 +269,10 @@ test.describe('Condition on visible columns and foreign keys', () => {
         'always_shown_table',
         'ns_related_show',
       ]);
+    });
+
+    await test.step('always_shown_table never flashes hidden', async () => {
+      expect(await page.evaluate(() => (window as any).__alwaysShownFlashed)).toBe(false);
     });
   });
 

--- a/test/e2e/specs/default-config/record/condition.spec.ts
+++ b/test/e2e/specs/default-config/record/condition.spec.ts
@@ -22,10 +22,13 @@ const tableName = 'main';
  *   - sync all-outbound scalar     -> cond_outbound_scalar  (vis-col outbound1_col)
  *   - sync all-outbound entity     -> inline cond on pattern_local_col
  *   - inline condition + wait_for  -> inline cond on pattern_with_waitfor_col
- *   - async inbound entityset      -> cond_inbound1  (shared by 3 items)
+ *   - async inbound entityset      -> cond_inbound1  (shared by 3 items; condition_pattern over
+ *                                     $self -> exercises single-inbound entityset $self end-to-end)
  *   - async aggregate cnt          -> cond_inbound_count (vis-col inbound1_count_col)
  *   - async pure-and-binary        -> cond_assoc  (vis-fk assoc_target)
- *   - async 3-hop with shared-prefix sourcekey -> cond_path_multi  (vis-fk path_target)
+ *   - async 3-hop with shared-prefix sourcekey -> cond_path_multi  (vis-fk path_target;
+ *                                     condition_pattern over $self -> exercises multi-hop entityset
+ *                                     $self end-to-end, proving chaise routes the page to $self)
  *   - async path with filter       -> cond_path_filter  (vis-fk filtered_inbound1)
  *   - on_empty:"show" inversion    -> cond_always_show  (vis-fk always_shown_table)
  *   - no-source (pattern-only)     -> inline + condition_key, on both vis-col
@@ -128,6 +131,48 @@ test.describe('Condition on visible columns and foreign keys', () => {
         'always_shown_table (0)',
         'ns_related_show (0)',
       ]);
+    });
+  });
+
+  test('id=1: a source used as display + condition + gated value is read once', async ({ page, baseURL }, testInfo) => {
+    // Two dedup paths, both should collapse to a single read:
+    //  - cond_inbound1_src (entity set) is BOTH the inbound1 vis-fk display AND the source of
+    //    cond_inbound1 -> the condition source folds onto the display (one entity-set read).
+    //  - cond_inbound_count_src (cnt aggregate) is BOTH inbound1_count_col's value AND its own
+    //    gate cond_inbound_count -> the gated value folds onto the condition source (one count read).
+    const ermrestReads: string[] = [];
+    page.on('request', (req) => {
+      const u = req.url();
+      if (req.method() === 'GET' && u.includes('/ermrest/catalog/') &&
+        (u.includes('/entity/') || u.includes('/attributegroup/') || u.includes('/aggregate/'))) {
+        ermrestReads.push(u);
+      }
+    });
+
+    const url = generateChaiseURL(APP_NAMES.RECORD, schemaName, tableName, testInfo, baseURL) + '/id=1';
+    await page.goto(url);
+    await RecordLocators.waitForRecordPageReady(page);
+    await page.waitForLoadState('networkidle');
+
+    // the inbound1 entity-set read (related reads aggregate rows via array_d). This is the
+    // query shared by the inbound1 vis-fk display and the cond_inbound1 source. The count
+    // aggregate (cnt), the kind=primary filtered read, and the multi-hop path read also touch
+    // inbound1 but are distinct queries, so the source-hash anchor + array_d excludes them.
+    const inbound1EntitySetReads = ermrestReads.filter((u) =>
+      u.includes('M:=condition-test:inbound1/(main_id)') &&
+      u.includes('array_d') &&
+      !u.includes('kind=primary')
+    );
+
+    // the inbound1 count aggregate, shared by inbound1_count_col's value and its gate.
+    const inbound1CountReads = ermrestReads.filter((u) => u.includes('cnt(T:RID)') && u.includes('inbound1:main_id'));
+
+    await test.step('inbound1 entity set is read exactly once', async () => {
+      expect(inbound1EntitySetReads, 'inbound1 entity-set reads:\n' + inbound1EntitySetReads.join('\n')).toHaveLength(1);
+    });
+
+    await test.step('inbound1 count aggregate is read exactly once', async () => {
+      expect(inbound1CountReads, 'inbound1 count reads:\n' + inbound1CountReads.join('\n')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
In [this PR in ermrestjs](https://github.com/informatics-isi-edu/ermrestjs/pull/1138) I added new APIs to the request object that active list returns for related and inline tables. This PR will use those APIs to ensure that the record provider reuses a single source read across a display and its data consumers.

Details:

- When a related or inline display read succeeds, I store the page and dispatch whatever consumers got folded onto it, reusing the same `attachPseudoColumnValue` path `fetchSecondaryRequest` already uses.
- The condition source lookup now also matches a display by `entitysetSourceName`.
