### PR TITLE
test: record one video per failing test, adopt 1.61 WebStorage API

### DIFF
--- a/test/e2e/setup/playwright.configuration.ts
+++ b/test/e2e/setup/playwright.configuration.ts
@@ -78,6 +78,12 @@ const getConfig = (options: TestOptions) => {
       // screenshots will be added to the playwright-report folder
       screenshot: 'only-on-failure',
 
+      /**
+       * Record one video per failing test: only the first attempt is captured, and kept
+       * only if it failed. A failure yields exactly one video, without duplicates from retries.
+       */
+      video: 'retain-on-first-failure',
+
       // set the timezone to Los Angeles
       timezoneId: 'America/Los_Angeles'
     },

--- a/test/e2e/utils/facet-utils.ts
+++ b/test/e2e/utils/facet-utils.ts
@@ -13,12 +13,7 @@ import { dragAndDropWithScroll } from '@isrd-isi-edu/chaise/test/e2e/utils/page-
 export const changeStoredOrder = async (page: Page, testInfo: TestInfo, schemaName: string, tableName: string, order: unknown) => {
   const keyName = `facet-order-${getCatalogID(testInfo.project.name)}_${schemaName}_${tableName}`;
   const orderStr = JSON.stringify(order);
-  await page.evaluate(
-    ({ keyName, orderStr }) => {
-      window.localStorage.setItem(keyName, orderStr);
-    },
-    { keyName, orderStr }
-  );
+  await page.localStorage.setItem(keyName, orderStr);
 
   await page.reload();
 };


### PR DESCRIPTION
This PR captures one video per failing e2e test (retain-on-first-failure) and switches the facet-order test helper to the new page.localStorage API from Playwright 1.61.