### PR TITLE
Performance logging

### DIFF
--- a/docs/user-docs/chaise-config.md
+++ b/docs/user-docs/chaise-config.md
@@ -72,6 +72,8 @@ If a property appears in the same configuration twice, the property defined late
 - [Other Configuration:](#other-configuration)
   - [footerMarkdown](#footermarkdown)
   - [assetDownloadPolicyURL](#assetdownloadpolicyurl)
+  - [debug](#debug)
+  - [performanceLogging](#performancelogging)
 
 ## General Configuration:
  ### ermrestLocation
@@ -819,4 +821,24 @@ Use this property to modify the display settings for the "share and cite" button
    - Sample syntax:
      ```
      assetDownloadPolicyURL: "<your url>"
+     ```
+
+### debug
+
+Setting this property to `true` will enable the debug mode for chaise. In debug mode, chaise will log more information to the console.
+   - Type: Boolean
+   - Default behavior: debug mode is off
+   - Sample syntax:
+     ```
+     debug: true
+     ```
+
+### performanceLogging
+
+Setting this property to `true` will enable the performance logging for chaise. In performance logging mode, chaise captures the performance of record, recordset, and recordedit apps as they load and stores it in `window.__chaisePerf`. Please refer to [the type definitions](https://github.com/informatics-isi-edu/chaise/blob/master/src/utils/window-ref.ts) for more information about this object, and how to use it. This property is used by [deriva-load-testing](https://github.com/informatics-isi-edu/deriva-load-testing) to measure the performance of the apps.
+   - Type: Boolean
+   - Default behavior: performance logging is off
+   - Sample syntax:
+     ```
+     performanceLogging: true
      ```

--- a/src/components/app-wrapper.tsx
+++ b/src/components/app-wrapper.tsx
@@ -43,6 +43,7 @@ import { CLASS_NAMES, errorMessages } from '@isrd-isi-edu/chaise/src/utils/const
 import { clickHref } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { isSameOrigin } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type AppWrapperProps = {
   /**
@@ -261,9 +262,11 @@ const AppWrapperInner = ({
     sweepStalePrefillEntries();
 
     const onError = (event: any) => {
+      logPerformanceError('navbar', event.error);
       dispatchError({ error: event.error });
     };
     const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      logPerformanceError('navbar', event.reason);
       dispatchError({ error: event.reason });
     };
     const onHashChange = () => {

--- a/src/components/faceting/faceting.tsx
+++ b/src/components/faceting/faceting.tsx
@@ -53,7 +53,7 @@ import {
 // utils
 import { HELP_PAGES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { getHelpPageURL } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
-import { isPerformanceLoggingEnabled, logPerformanceMilestone, logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
+import { isPerformanceLoggingEnabled, logRecordsetDetail, logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type FacetingProps = {
   /**
@@ -346,7 +346,7 @@ const Faceting = ({
   useEffect(() => {
     if (!isPerformanceLoggingEnabled()) return;
     if (allFacetsRegistered && facetModels.every((fm) => !fm.isLoading)) {
-      logPerformanceMilestone('allFacetsLoaded');
+      logRecordsetDetail('allFacetsLoaded');
     }
   }, [facetModels, allFacetsRegistered]);
 

--- a/src/components/faceting/faceting.tsx
+++ b/src/components/faceting/faceting.tsx
@@ -53,6 +53,7 @@ import {
 // utils
 import { HELP_PAGES } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { getHelpPageURL } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
+import { isPerformanceLoggingEnabled, logPerformanceMilestone, logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type FacetingProps = {
   /**
@@ -342,6 +343,13 @@ const Faceting = ({
     setReadyToInitialize();
   }, [allFacetsRegistered]);
 
+  useEffect(() => {
+    if (!isPerformanceLoggingEnabled()) return;
+    if (allFacetsRegistered && facetModels.every((fm) => !fm.isLoading)) {
+      logPerformanceMilestone('allFacetsLoaded');
+    }
+  }, [facetModels, allFacetsRegistered]);
+
   /**
    * This will ensure the registered functions in flow-control
    * are updated based on the latest facet changes
@@ -456,6 +464,7 @@ const Faceting = ({
             if (err instanceof ConfigService.ERMrest.QueryTimeoutError) {
               setFacetModelByIndex(i, { facetHasTimeoutError: true });
             } else {
+              logPerformanceError('full', err);
               dispatchError({ error: err });
             }
           });
@@ -484,6 +493,7 @@ const Faceting = ({
               if (err instanceof ConfigService.ERMrest.QueryTimeoutError) {
                 setFacetModelByIndex(i, { facetHasTimeoutError: true });
               } else {
+                logPerformanceError('full', err);
                 dispatchError({ error: err });
               }
 

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -36,6 +36,7 @@ import {
 import { isObjectAndNotNull, isStringAndNotEmpty } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { debounce } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { APP_NAMES } from '@isrd-isi-edu/chaise/src/utils/constants';
+import { logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 const ChaiseNavbar = (): JSX.Element => {
   const catalogId: string = ConfigService.catalogID;
@@ -288,6 +289,7 @@ const ChaiseNavbar = (): JSX.Element => {
   };
 
   const renderRidSearch = () => {
+    logPerformanceMilestone('navbarLoad');
     if (cc.resolverImplicitCatalog === null || cc.hideGoToRID === true) return;
 
     return (

--- a/src/components/record/record-main-section.tsx
+++ b/src/components/record/record-main-section.tsx
@@ -11,6 +11,9 @@ import useError from '@isrd-isi-edu/chaise/src/hooks/error';
 // models
 import { RecordColumnModel } from '@isrd-isi-edu/chaise/src/models/record';
 
+// utilities
+import { logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
+
 import type { JSX } from 'react';
 
 /**
@@ -19,6 +22,8 @@ import type { JSX } from 'react';
 const RecordMainSection = (): JSX.Element => {
   const { errors } = useError();
   const { columnModels, showMainSectionSpinner } = useRecord();
+
+  logPerformanceMilestone('mainDataLoad');
 
   const hasSpinner = errors.length === 0 && showMainSectionSpinner;
   return (

--- a/src/components/record/record.tsx
+++ b/src/components/record/record.tsx
@@ -53,6 +53,7 @@ import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { isObjectAndNotNull } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { attachContainerHeightSensors, attachMainContainerPaddingSensor } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 export type RecordProps = {
   /**
@@ -276,6 +277,8 @@ const RecordInner = ({
   useEffect(() => {
     if (setupAfterPageLoadisDone.current || !relatedSectionInitialized || showMainSectionSpinner) return;
     setupAfterPageLoadisDone.current = true;
+
+    logPerformanceMilestone('fullPageLoad');
 
     // scroll to section based on query parameter
     if (scrollToDisplayname) {

--- a/src/components/recordedit/recordedit.tsx
+++ b/src/components/recordedit/recordedit.tsx
@@ -53,6 +53,7 @@ import {
 } from '@isrd-isi-edu/chaise/src/utils/recordedit-utils';
 import { attachContainerHeightSensors, attachMainContainerPaddingSensor } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { isPerformanceLoggingEnabled, logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 const Recordedit = ({
   appMode,
@@ -366,6 +367,16 @@ const RecordeditInner = ({
       resizeSensors?.forEach((rs) => !!rs && rs.detach());
     }
   }, [formProviderInitialized]);
+
+  /**
+   * record the canonical load milestones for the deriva-load-testing tool:
+   * mainDataLoad once the form is rendered, fullPageLoad once it is fully interactive
+   */
+  useEffect(() => {
+    if (!isPerformanceLoggingEnabled() || config.displayMode !== RecordeditDisplayMode.FULLSCREEN) return;
+    if (formProviderInitialized) logPerformanceMilestone('mainDataLoad');
+    if (allFormDataLoaded) logPerformanceMilestone('fullPageLoad');
+  }, [formProviderInitialized, allFormDataLoaded]);
 
   /**
    * This useEffect triggers when addFormsEffect is set to true when "clone" is clicked

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -26,6 +26,7 @@ import { CUSTOM_EVENTS } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { addTopHorizontalScroll, fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
+import { isPerformanceLoggingEnabled, logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type RecordsetTableProps = {
   config: RecordsetConfig,
@@ -268,6 +269,13 @@ const RecordsetTable = ({
       });
     }
   }, [isLoading]);
+
+  useEffect(() => {
+    if (!isPerformanceLoggingEnabled() || isLoading || config.displayMode !== RecordsetDisplayMode.FULLSCREEN) return;
+    if (columnModels.every((col: any) => !col.isLoading)) {
+      logPerformanceMilestone('allAggregatesLoaded');
+    }
+  }, [columnModels, isLoading, config.displayMode]);
 
   //------------------- react hook callbacks: --------------------//
   // Sync widths of the columns

--- a/src/components/recordset/recordset-table.tsx
+++ b/src/components/recordset/recordset-table.tsx
@@ -26,7 +26,7 @@ import { CUSTOM_EVENTS } from '@isrd-isi-edu/chaise/src/utils/constants';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 import { makeSafeIdAttr } from '@isrd-isi-edu/chaise/src/utils/string-utils';
 import { addTopHorizontalScroll, fireCustomEvent } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
-import { isPerformanceLoggingEnabled, logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
+import { isPerformanceLoggingEnabled, logRecordsetDetail } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type RecordsetTableProps = {
   config: RecordsetConfig,
@@ -273,7 +273,7 @@ const RecordsetTable = ({
   useEffect(() => {
     if (!isPerformanceLoggingEnabled() || isLoading || config.displayMode !== RecordsetDisplayMode.FULLSCREEN) return;
     if (columnModels.every((col: any) => !col.isLoading)) {
-      logPerformanceMilestone('allAggregatesLoaded');
+      logRecordsetDetail('allAggregatesLoaded');
     }
   }, [columnModels, isLoading, config.displayMode]);
 

--- a/src/components/recordset/recordset.tsx
+++ b/src/components/recordset/recordset.tsx
@@ -50,6 +50,7 @@ import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils
 import { attachContainerHeightSensors, attachMainContainerPaddingSensor, copyToClipboard } from '@isrd-isi-edu/chaise/src/utils/ui-utils';
 import { createRedirectLinkFromPath, getRecordsetLink, transformCustomFilter } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { isPerformanceLoggingEnabled, logPerformanceMilestone } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 const Recordset = ({
   initialReference,
@@ -837,6 +838,9 @@ const RecordsetInner = ({
 
   const renderMainContainer = () => {
     const hasSpinner = errors.length === 0 && (isLoading || forceShowSpinner);
+    if (isPerformanceLoggingEnabled() && !hasSpinner && config.displayMode === RecordsetDisplayMode.FULLSCREEN) {
+      logPerformanceMilestone('mainDataLoad');
+    }
     return (
       <div className='main-container dynamic-padding' ref={mainContainer}>
         {hasSpinner &&

--- a/src/providers/record.tsx
+++ b/src/providers/record.tsx
@@ -45,6 +45,7 @@ import {
 } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { createRedirectLinkFromPath } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { attachGoogleDatasetJsonLd } from '@isrd-isi-edu/chaise/src/utils/google-dataset';
+import { logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 import {
   canCreateRelated,
   generateRelatedRecordModel,
@@ -701,6 +702,7 @@ export default function RecordProvider({
               exception.errorData.redirectUrl = redirectLink.replace('record', 'recordset');
             }
           }
+          logPerformanceError('main', exception);
           reject(exception);
         });
 
@@ -1261,6 +1263,7 @@ export default function RecordProvider({
           resolve(true);
         } else {
           setColumnModelValues(errorIndexes, { isLoading: false });
+          logPerformanceError('full', err);
           reject(err);
         }
       });

--- a/src/providers/recordedit.tsx
+++ b/src/providers/recordedit.tsx
@@ -42,6 +42,7 @@ import {
 import { isObjectAndKeyDefined, isObjectAndNotNull } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { createRedirectLinkFromPath } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import { logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 
 type ResultsetProps = {
   pageTitle: string,
@@ -643,6 +644,8 @@ export default function RecordeditProvider({
         };
 
         const submitErrorCB = (exception: any) => {
+          logPerformanceError('submit', exception);
+
           if (onSubmitError) {
             const res = onSubmitError(exception);
             if (!res) return;

--- a/src/providers/recordset.tsx
+++ b/src/providers/recordset.tsx
@@ -35,6 +35,7 @@ import { RECORDSET_DEFAULT_PAGE_SIZE, URL_PATH_LENGTH_LIMIT } from '@isrd-isi-ed
 import { getColumnValuesFromPage } from '@isrd-isi-edu/chaise/src/utils/data-utils';
 import { isObjectAndKeyDefined } from '@isrd-isi-edu/chaise/src/utils/type-utils';
 import { createRedirectLinkFromPath } from '@isrd-isi-edu/chaise/src/utils/uri-utils';
+import { logPerformanceError } from '@isrd-isi-edu/chaise/src/utils/performance-logging-utils';
 import { MESSAGE_MAP } from '@isrd-isi-edu/chaise/src/utils/message-map';
 
 /**
@@ -854,6 +855,7 @@ export default function RecordsetProvider({
         if (isObjectAndKeyDefined(err.errorData, 'redirectPath')) {
           err.errorData.redirectUrl = createRedirectLinkFromPath(err.errorData.redirectPath);
         }
+        logPerformanceError('main', err);
         defer.reject(err);
       });
 
@@ -1110,6 +1112,7 @@ export default function RecordsetProvider({
         return true;
       } else {
         setColumnModelValues(errorIndexes, { isLoading: false });
+        logPerformanceError('full', err);
       }
 
       throw err;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -32,6 +32,7 @@ export const CHAISE_CONFIG_PROPERTY_NAMES = [
   'logClientActions', 'disableExternalLinkModal', 'internalHosts', 'hideGoToRID', 'hideGoToSnapshot', 'showWriterEmptyRelatedOnLoad',
   'showSavedQueryUI', 'savedQueryConfig', 'termsAndConditionsConfig', 'loggedInMenu', 'facetPanelDisplay', 'configRules',
   'debug', 'templating', 'hideRecordeditLeaveAlert', 'shareCite', 'exportConfigsSubmenu', 'asciiTextValidation',
+  'performanceLogging',
 ];
 
 /**
@@ -85,7 +86,8 @@ export const DEFAULT_CHAISE_CONFIG = {
       enable: []
     }
   },
-  asciiTextValidation: false
+  asciiTextValidation: false,
+  performanceLogging: false
 };
 
 export const dataFormats = {

--- a/src/utils/performance-logging-utils.ts
+++ b/src/utils/performance-logging-utils.ts
@@ -1,10 +1,15 @@
 import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
-import { windowRef, ChaisePerfError, ChaisePerfMarks } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+import {
+  windowRef,
+  ChaisePerfError,
+  ChaisePerfMarks,
+  ChaisePerfRecordsetDetail,
+} from '@isrd-isi-edu/chaise/src/utils/window-ref';
 
 /**
- * the milestone keys recorded on window.__chaisePerf (everything except the error object)
+ * the canonical page-load milestones every measured app records on window.__chaisePerf
  */
-type ChaisePerfMarkName = Exclude<keyof ChaisePerfMarks, 'error'>;
+type ChaisePerfMilestone = 'navbarLoad' | 'mainDataLoad' | 'fullPageLoad';
 
 /**
  * the loose shape of an ermrestjs error (the result of ErrorService.responseToError).
@@ -29,7 +34,7 @@ export function isPerformanceLoggingEnabled(): boolean {
  * Record the first time a page-load milestone is reached. No-op unless performance
  * logging is enabled. Read by the deriva-load-testing tool.
  */
-export function logPerformanceMilestone(name: ChaisePerfMarkName): void {
+export function logPerformanceMilestone(name: ChaisePerfMilestone): void {
   if (!isPerformanceLoggingEnabled()) return;
   const marks: ChaisePerfMarks = windowRef.__chaisePerf || (windowRef.__chaisePerf = {});
   if (marks[name] !== undefined) return;
@@ -37,9 +42,32 @@ export function logPerformanceMilestone(name: ChaisePerfMarkName): void {
 }
 
 /**
+ * Record a recordset-only detail mark (window.__chaisePerf.detail.recordset). Once both the
+ * facet and aggregate marks exist, derive the canonical fullPageLoad from them (first write
+ * wins). No-op unless performance logging is enabled.
+ */
+export function logRecordsetDetail(name: keyof ChaisePerfRecordsetDetail): void {
+  if (!isPerformanceLoggingEnabled()) return;
+  const marks: ChaisePerfMarks = windowRef.__chaisePerf || (windowRef.__chaisePerf = {});
+  const detail = marks.detail || (marks.detail = {});
+  const recordset = detail.recordset || (detail.recordset = {});
+  if (recordset[name] === undefined) recordset[name] = performance.now();
+  if (
+    marks.fullPageLoad === undefined &&
+    recordset.allFacetsLoaded !== undefined &&
+    recordset.allAggregatesLoaded !== undefined
+  ) {
+    marks.fullPageLoad = Math.max(recordset.allFacetsLoaded, recordset.allAggregatesLoaded);
+  }
+}
+
+/**
  * Record the first page-load error. No-op unless performance logging is enabled.
  */
-export function logPerformanceError(milestone: ChaisePerfError['milestone'], exception: PerfLoggableError): void {
+export function logPerformanceError(
+  milestone: ChaisePerfError['milestone'],
+  exception: PerfLoggableError
+): void {
   if (!isPerformanceLoggingEnabled()) return;
   const marks: ChaisePerfMarks = windowRef.__chaisePerf || (windowRef.__chaisePerf = {});
   if (marks.error) return;

--- a/src/utils/performance-logging-utils.ts
+++ b/src/utils/performance-logging-utils.ts
@@ -1,0 +1,52 @@
+import { ConfigService } from '@isrd-isi-edu/chaise/src/services/config';
+import { windowRef, ChaisePerfError, ChaisePerfMarks } from '@isrd-isi-edu/chaise/src/utils/window-ref';
+
+/**
+ * the milestone keys recorded on window.__chaisePerf (everything except the error object)
+ */
+type ChaisePerfMarkName = Exclude<keyof ChaisePerfMarks, 'error'>;
+
+/**
+ * the loose shape of an ermrestjs error (the result of ErrorService.responseToError).
+ * chaise treats these as `any`; we only read the fields we report.
+ */
+export interface PerfLoggableError {
+  status?: string;
+  code?: number;
+  message?: string;
+  subMessage?: string;
+}
+
+/**
+ * Whether performance logging is enabled (chaiseConfig.performanceLogging). Guard any
+ * extra work done only for logging with this, so production pays nothing when it is off.
+ */
+export function isPerformanceLoggingEnabled(): boolean {
+  return !!ConfigService.chaiseConfig?.performanceLogging;
+}
+
+/**
+ * Record the first time a page-load milestone is reached. No-op unless performance
+ * logging is enabled. Read by the deriva-load-testing tool.
+ */
+export function logPerformanceMilestone(name: ChaisePerfMarkName): void {
+  if (!isPerformanceLoggingEnabled()) return;
+  const marks: ChaisePerfMarks = windowRef.__chaisePerf || (windowRef.__chaisePerf = {});
+  if (marks[name] !== undefined) return;
+  marks[name] = performance.now();
+}
+
+/**
+ * Record the first page-load error. No-op unless performance logging is enabled.
+ */
+export function logPerformanceError(milestone: ChaisePerfError['milestone'], exception: PerfLoggableError): void {
+  if (!isPerformanceLoggingEnabled()) return;
+  const marks: ChaisePerfMarks = windowRef.__chaisePerf || (windowRef.__chaisePerf = {});
+  if (marks.error) return;
+  marks.error = {
+    milestone,
+    status: exception?.status,
+    code: exception?.code,
+    message: exception?.code === 500 ? exception?.subMessage : exception?.message,
+  };
+}

--- a/src/utils/window-ref.ts
+++ b/src/utils/window-ref.ts
@@ -4,23 +4,34 @@ import { ViewerConfig } from '@isrd-isi-edu/chaise/src/models/viewer';
  * load-error info recorded on window.__chaisePerf
  */
 export interface ChaisePerfError {
-  milestone: 'navbar' | 'main' | 'full';
+  milestone: 'navbar' | 'main' | 'full' | 'submit';
   status?: string;
   code?: number;
   message?: string;
 }
 
 /**
+ * recordset-only detail marks that back the canonical milestones
+ * (recordset fullPageLoad = max of the two below).
+ */
+export interface ChaisePerfRecordsetDetail {
+  allFacetsLoaded?: number;
+  allAggregatesLoaded?: number;
+}
+
+/**
  * page-load milestones in ms, recorded only when chaiseConfig.performanceLogging is on.
- * fullPageLoad is record-only; allFacetsLoaded and allAggregatesLoaded are recordset-only.
+ * navbarLoad, mainDataLoad, and fullPageLoad are the canonical milestones every measured app
+ * records (with app-specific meaning); detail holds app-specific extras.
  */
 export interface ChaisePerfMarks {
   navbarLoad?: number;
   mainDataLoad?: number;
   fullPageLoad?: number;
-  allFacetsLoaded?: number;
-  allAggregatesLoaded?: number;
   error?: ChaisePerfError;
+  detail?: {
+    recordset?: ChaisePerfRecordsetDetail;
+  };
 }
 
 // exporting so third-party apps can customize this
@@ -40,38 +51,38 @@ export interface ICustomWindow extends Window {
   dcctx: {
     // the object that will be logged with every request:
     contextHeaderParams: {
-      cid: string,
-      pid: string,
-      wid: string
-    },
+      cid: string;
+      pid: string;
+      wid: string;
+    };
     // TODO are these needed at all (we're not attaching them):
     // the settings that all chaise apps (including deriva webapps) honor
     settings?: {
-      hideNavbar: boolean,
-      appTitle: string,
-      overrideHeadTitle: boolean,
-      overrideImagePreviewBehavior: boolean,
-      overrideDownloadClickBehavior: boolean,
-      overrideExternalLinkBehavior: boolean,
-      openLinksInTab: boolean
-    }
-  },
+      hideNavbar: boolean;
+      appTitle: string;
+      overrideHeadTitle: boolean;
+      overrideImagePreviewBehavior: boolean;
+      overrideDownloadClickBehavior: boolean;
+      overrideExternalLinkBehavior: boolean;
+      openLinksInTab: boolean;
+    };
+  };
   // this is the callback that is used in recordedit to communicate with
   // the parent that the update request is done and therefore the caller
   // needs to be updated/refreshed
-  updated: any,
+  updated: any;
   /**
    * used in record page to help data-modelers with writing the annotation
    */
-  defaultExportTemplate: any,
+  defaultExportTemplate: any;
   /**
    * the config file of viewer app
    */
-  viewerConfigs: ViewerConfig,
+  viewerConfigs: ViewerConfig;
   /**
    * timing marks read by the deriva-load-testing tool
    */
-  __chaisePerf?: ChaisePerfMarks
+  __chaisePerf?: ChaisePerfMarks;
 }
 
 declare let window: ICustomWindow;

--- a/src/utils/window-ref.ts
+++ b/src/utils/window-ref.ts
@@ -1,5 +1,28 @@
 import { ViewerConfig } from '@isrd-isi-edu/chaise/src/models/viewer';
 
+/**
+ * load-error info recorded on window.__chaisePerf
+ */
+export interface ChaisePerfError {
+  milestone: 'navbar' | 'main' | 'full';
+  status?: string;
+  code?: number;
+  message?: string;
+}
+
+/**
+ * page-load milestones in ms, recorded only when chaiseConfig.performanceLogging is on.
+ * fullPageLoad is record-only; allFacetsLoaded and allAggregatesLoaded are recordset-only.
+ */
+export interface ChaisePerfMarks {
+  navbarLoad?: number;
+  mainDataLoad?: number;
+  fullPageLoad?: number;
+  allFacetsLoaded?: number;
+  allAggregatesLoaded?: number;
+  error?: ChaisePerfError;
+}
+
 // exporting so third-party apps can customize this
 export interface ICustomWindow extends Window {
   // WID
@@ -44,7 +67,11 @@ export interface ICustomWindow extends Window {
   /**
    * the config file of viewer app
    */
-  viewerConfigs: ViewerConfig
+  viewerConfigs: ViewerConfig,
+  /**
+   * timing marks read by the deriva-load-testing tool
+   */
+  __chaisePerf?: ChaisePerfMarks
 }
 
 declare let window: ICustomWindow;


### PR DESCRIPTION
This PR adds the performance instrumentation that [deriva-load-testing](https://github.com/informatics-isi-edu/deriva-load-testing/) uses.

By default, this measurement is disabled and it can be enabled by setting the `performanceLogging` chaise-config property.