### PR TITLE
chore(deps): bump nanoid from 3.3.16 to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10248,9 +10248,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
- Resolves GHSA-2v37-7h3g-55p8 (high), nanoid custom generators can loop indefinitely when size is zero
- Lockfile only. postcss already declares nanoid@^3.3.16, so 3.3.18 satisfies the existing range and no manifest change is needed