### PR TITLE
perf(build): scope vendor chunks per entry and lazy-load plotly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,21 +236,9 @@ RSYNC_FILE_LIST_W_CONFIG=$(RSYNC_FILE_LIST) \
 	@> .make-rsync-list-w-config
 	@$(call add_array_to_file,$(RSYNC_FILE_LIST_W_CONFIG),.make-rsync-list-w-config)
 
-# vendor files that will be treated externally in webpack
-WEBPACK_EXTERNAL_VENDOR_FILES= \
-	$(MODULES)/plotly.js-basic-dist-min/plotly-basic.min.js
-
 define add_array_to_file
 	for folder in $(1); do \
 		echo "$$folder" >> $(2); \
-	done
-endef
-
-define copy_webpack_external_vendor_files
-	$(info - copying webpack external files into location)
-	mkdir -p $(REACT_BUNDLES)
-	for f in $(WEBPACK_EXTERNAL_VENDOR_FILES); do \
-		eval "rsync -a $$f $(REACT_BUNDLES)" ; \
 	done
 endef
 
@@ -312,12 +300,10 @@ dist-wo-deps: print-variables run-webpack gitversion
 # Rule to install the dependencies and create the pacakge
 $(DIST): deps dist-wo-deps
 
-# run webpack to build the react folder and bundles in it, and
-# copy the external vendor files that webpack expects into react folder
+# run webpack to build the react folder and bundles in it
 run-webpack: $(SOURCE) $(BUILD_VERSION)
 	$(info - creating webpack bundles)
 	@npx webpack --config ./webpack/main.config.js --env BUILD_VARIABLES.BUILD_VERSION=$(BUILD_VERSION) --env BUILD_VARIABLES.CHAISE_BASE_PATH=$(CHAISE_BASE_PATH) --env BUILD_VARIABLES.ERMRESTJS_BASE_PATH=$(ERMRESTJS_BASE_PATH) --env BUILD_VARIABLES.OSD_VIEWER_BASE_PATH=$(OSD_VIEWER_BASE_PATH)
-	@$(call copy_webpack_external_vendor_files)
 
 # deploy chaise to the location
 # this is separated into three seaprate rsyncs:

--- a/docs/dev-docs/dev-guide.md
+++ b/docs/dev-docs/dev-guide.md
@@ -1363,6 +1363,8 @@ Guidelines:
 - Mount the lazy component as soon as the feature is visible, even if its data hasn't arrived yet (return `null` from the component until it has). This lets the chunk download run in parallel with data requests instead of after them.
 - Give the `Suspense` `fallback` a spinner so users see progress while the chunk downloads.
 
+## Documentation
+
 The Markdown files under [`docs/user-docs`](../user-docs) that are listed in [`docs/index.rst`](../index.rst) are published on [docs.derivacloud.org](https://docs.derivacloud.org/chaise/index.html) by deriva-docs. If you add a new user-docs file, add it to `index.rst` as well.
 
 GitHub and the docs site (Sphinx) generate heading anchors differently. GitHub keeps `_` and a leading `1.` number and drops other punctuation without a separator, while Sphinx turns `_` and punctuation runs into `-` and strips leading digits. So a heading like `### 1. Install Chaise` is `#1-install-chaise` on GitHub but `#install-chaise` on the site, and an in-page link can only target one of them. To support both, an explicit `<a name="<github-slug>"></a>` anchor is added right before any heading whose two slugs differ: GitHub resolves the link through the heading's own id, and the explicit anchor gives Sphinx a matching `id`.

--- a/docs/dev-docs/dev-guide.md
+++ b/docs/dev-docs/dev-guide.md
@@ -68,6 +68,7 @@ This is a guide for people who develop Chaise.
 - [Performance](#performance)
   - [Debugging](#debugging)
   - [Memoization](#memoization)
+  - [Lazy loading heavy dependencies](#lazy-loading-heavy-dependencies)
 - [Documentation](#documentation)
 
 ## Commit message conventions
@@ -1351,7 +1352,16 @@ Useful links:
 - https://react.dev/reference/react/memo
 - https://dmitripavlutin.com/use-react-memo-wisely/
 
-## Documentation
+### Lazy loading heavy dependencies
+
+When a large dependency is only needed on some code paths, don't import it eagerly. Isolate it in its own module and load it with [`React.lazy`](https://react.dev/reference/react/lazy) + `Suspense` so webpack puts it in a separate chunk that's only fetched when that path actually renders. For example, `plotly.js-basic-dist-min` (~1MB) is only needed when a range facet shows a histogram, so it's isolated in `facet-range-plot.tsx` and lazy-loaded from `facet-range-picker.tsx`.
+
+Guidelines:
+
+- Place the `lazy()` boundary at the call site with an existing conditional (the place that decides whether the feature shows), not inside the heavy component itself. A module cannot defer its own load; whoever imports it decides eager vs lazy.
+- `import()` splits at module granularity. If only part of a component needs the heavy dependency, extract that part into its own file first (like `facet-range-plot.tsx`) and keep the rest eagerly loaded.
+- Mount the lazy component as soon as the feature is visible, even if its data hasn't arrived yet (return `null` from the component until it has). This lets the chunk download run in parallel with data requests instead of after them.
+- Give the `Suspense` `fallback` a spinner so users see progress while the chunk downloads.
 
 The Markdown files under [`docs/user-docs`](../user-docs) that are listed in [`docs/index.rst`](../index.rst) are published on [docs.derivacloud.org](https://docs.derivacloud.org/chaise/index.html) by deriva-docs. If you add a new user-docs file, add it to `index.rst` as well.
 

--- a/src/assets/scss/_range-picker.scss
+++ b/src/assets/scss/_range-picker.scss
@@ -13,6 +13,12 @@
     margin-left: -5px;
   }
 
+  // shown while the lazy-loaded histogram module is being fetched
+  .plotly-loading {
+    padding-top: 15px;
+    text-align: center;
+  }
+
   .plotly-actions {
     padding-top: 15px;
     text-align: right;

--- a/src/components/faceting/facet-range-picker.tsx
+++ b/src/components/faceting/facet-range-picker.tsx
@@ -6,15 +6,10 @@ import React from 'react';
 import ChaiseTooltip from '@isrd-isi-edu/chaise/src/components/tooltip';
 import FacetCheckList from '@isrd-isi-edu/chaise/src/components/faceting/facet-check-list';
 import RangeInputs from '@isrd-isi-edu/chaise/src/components/range-inputs';
-
-
-// customizable method: use your own `Plotly` object to use minified basic distribution of plotlyjs
-import Plotly from 'plotly.js-basic-dist-min';
-import createPlotlyComponent from 'react-plotly.js/factory';
-const Plot = createPlotlyComponent(Plotly);
+import Spinner from 'react-bootstrap/Spinner';
 
 // hooks
-import { useEffect, useLayoutEffect, useRef, useState, type JSX } from 'react';
+import { lazy, Suspense, useEffect, useLayoutEffect, useRef, useState, type JSX } from 'react';
 import useStateRef from '@isrd-isi-edu/chaise/src/hooks/state-ref';
 import useVarRef from '@isrd-isi-edu/chaise/src/hooks/var-ref';
 
@@ -42,6 +37,12 @@ import { getNotNullFacetCheckBoxRow, getNullFacetCheckBoxRow } from '@isrd-isi-e
 import { windowRef } from '@isrd-isi-edu/chaise/src/utils/window-ref';
 import { ResizeSensor } from 'css-element-queries';
 import { getInputType } from '@isrd-isi-edu/chaise/src/utils/input-utils';
+
+/*
+ * plotly.js-basic-dist-min is ~1MB, so it's lazy-loaded (not every range facet shows a
+ * histogram, see `showHistogram`)
+ */
+const FacetRangePlot = lazy(() => import('@isrd-isi-edu/chaise/src/components/faceting/facet-range-plot'));
 
 const FacetRangePicker = ({
   dispatchFacetUpdate,
@@ -154,6 +155,11 @@ const FacetRangePicker = ({
   const plotlyRef = useRef<HTMLPlotElement>(null);
 
   const numBuckets = facetColumn.histogramBucketCount;
+
+  const showHistogram = (): boolean => {
+    return facetModel.initialized && facetModel.isOpen && facetPanelOpen &&
+      facetColumn.barPlot && (compState.rangeOptions.absMin !== null && compState.rangeOptions.absMax !== null)
+  }
 
   // set the resize sensor to call the plot resize fucntion
   useLayoutEffect(() => {
@@ -532,10 +538,6 @@ const FacetRangePicker = ({
     const res = facetColumnRef.current.sourceReference.defaultLogInfo;
     res.stack = getFacetLogStack(facetIndex);
     return res;
-  }
-
-  const showHistogram = (): boolean => {
-    return facetColumn.barPlot && (compState.rangeOptions.absMin !== null && compState.rangeOptions.absMax !== null)
   }
 
   // floats should truncate to 4 digits always
@@ -922,21 +924,6 @@ const FacetRangePicker = ({
     )
   };
 
-  const renderPlot = () => {
-    const plotData = compState.plot.data as PlotData[];
-    if (plotData[0].x.length < 1 || plotData[0].y.length < 1) return;
-    return (<Plot
-      config={compState.plot.config}
-      data={compState.plot.data}
-      layout={compState.plot.layout ? compState.plot.layout : {}}
-      labels={compState.plot.labels}
-      onRelayout={(event: any) => plotlyRelayout(event)}
-      ref={plotlyRef}
-      style={{ 'width': '100%' }}
-      useResizeHandler
-    />)
-  }
-
   const renderHistogramHelpTooltip = () => {
     // to avoid max line length eslint error
     const splitLine1 = 'Clicking and holding anywhere in the graph display will allow you to zoom into a smaller subset of data. ' +
@@ -987,8 +974,14 @@ const FacetRangePicker = ({
   }
 
   const renderHistogram = () => {
-    if (facetModel.initialized && facetModel.isOpen && facetPanelOpen && showHistogram()) {
-      return (<>
+    if (!showHistogram()) return;
+
+    /*
+     * the toolbar is only useful alongside the plot, so both wait behind one Suspense.
+     * FacetRangePlot mounts before data arrives so the module and data fetches run in parallel.
+     */
+    return (
+      <Suspense fallback={<div className='plotly-loading'><Spinner animation='border' size='sm' /></div>}>
         <div className='plotly-actions'>
           <div className='chaise-btn-group' style={{ 'zIndex': 1 }}>
             <ChaiseTooltip
@@ -1008,11 +1001,13 @@ const FacetRangePicker = ({
             </ChaiseTooltip>
           </div>
         </div>
-        {renderPlot()}
-      </>)
-    }
-
-    return;
+        <FacetRangePlot
+          plot={compState.plot}
+          onRelayout={(event: any) => plotlyRelayout(event)}
+          plotlyRef={plotlyRef}
+        />
+      </Suspense>
+    )
   }
 
   return (

--- a/src/components/faceting/facet-range-plot.tsx
+++ b/src/components/faceting/facet-range-plot.tsx
@@ -1,0 +1,50 @@
+// customizable method: use your own `Plotly` object to use minified basic distribution of plotlyjs
+import Plotly from 'plotly.js-basic-dist-min';
+import createPlotlyComponent from 'react-plotly.js/factory';
+const Plot = createPlotlyComponent(Plotly);
+
+// hooks
+import { type JSX, type RefObject } from 'react';
+
+// models
+import { HTMLPlotElement, PlotData, PlotlyDataLayoutConfig } from '@isrd-isi-edu/chaise/src/models/range-picker';
+
+type FacetRangePlotProps = {
+  /**
+   * the plotly data/layout/config/labels for the histogram
+   */
+  plot: PlotlyDataLayoutConfig,
+  /**
+   * called when the plot is zoomed/panned/resized
+   */
+  onRelayout: (event: any) => void,
+  /**
+   * ref to the underlying plotly instance, used by the parent for imperative resize calls
+   */
+  plotlyRef: RefObject<HTMLPlotElement | null>,
+}
+
+/**
+ * isolates the plotly.js-basic-dist-min dependency (~1MB) so it's only fetched when a
+ * facet-range-picker histogram actually renders, instead of on every page that has faceting
+ */
+const FacetRangePlot = ({ plot, onRelayout, plotlyRef }: FacetRangePlotProps): JSX.Element | null => {
+  // this component mounts before the histogram data arrives, so render nothing until it does
+  const plotData = plot.data as PlotData[];
+  if (plotData[0].x.length < 1 || plotData[0].y.length < 1) return null;
+
+  return (
+    <Plot
+      config={plot.config}
+      data={plot.data}
+      layout={plot.layout ? plot.layout : {}}
+      labels={plot.labels}
+      onRelayout={onRelayout}
+      ref={plotlyRef}
+      style={{ 'width': '100%' }}
+      useResizeHandler
+    />
+  );
+};
+
+export default FacetRangePlot;

--- a/src/models/range-picker.ts
+++ b/src/models/range-picker.ts
@@ -6,7 +6,7 @@ import { LogActions } from '@isrd-isi-edu/chaise/src/models/log';
 // TODO why are we doing this?
 // export plotly types by getting the typeof the interfaces
 export type PlotData = typeof PlotData;
-type PlotlyDataLayoutConfig = typeof PlotlyDataLayoutConfig;
+export type PlotlyDataLayoutConfig = typeof PlotlyDataLayoutConfig;
 export type PlotlyLayout = typeof PlotlyLayout;
 export type HTMLPlotElement = typeof HTMLPlotElement;
 

--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -169,6 +169,7 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
       rules: [
         {
           test: /\.(ts|js)x?$/,
+          exclude: /node_modules/,
           use: ['babel-loader'],
         },
         {
@@ -226,7 +227,6 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
         minSize: 50000,
         maxSize: 500000,
         hidePathInfo: true,
-        name: 'common',
         /**
          * the noted priority is also changing the order of include statements in the output html.
          * we want to make sure chaise is the last css file that is added, that's why it has the lowest priority.
@@ -258,9 +258,18 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
           },
           vendor: {
             test: /[\\/]node_modules[\\/](?!(\@isrd-isi-edu[\\/]chaise|bootstrap|react|react-dom|react-bootstrap)[\\/])/,
-            name: 'vendor-rest',
             chunks: 'all',
-            priority: 4
+            priority: 4,
+            /**
+             * a static name here would merge every matched dependency into one chunk shared by
+             * all entries (e.g. an erd-only dep shipping to every app); naming per-module keeps
+             * each entry scoped to only the vendor code it actually imports.
+             */
+            name(module) {
+              const match = module.context && module.context.match(/[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+|[^\\/]+)/);
+              const pkg = match ? match[1].replace('@', '').replace(/[\\/]/g, '-') : 'misc';
+              return `vendor-${pkg}`;
+            }
           }
         },
       },

--- a/webpack/main.config.js
+++ b/webpack/main.config.js
@@ -12,26 +12,20 @@ if (nodeDevs.indexOf(mode) === -1) {
 module.exports = (env) => {
   const chaisePath = env.BUILD_VARIABLES.CHAISE_BASE_PATH;
 
-  const recordsetExtFiles = [`${chaisePath}bundles/plotly-basic.min.js`];
-
   return getWebPackConfig(
     [
       {
         appName: 'login',
         appTitle: 'Login',
-        // app-wrapper uses navbar
-        externalFiles: [...recordsetExtFiles]
       },
       {
         appName: 'recordset',
         appTitle: 'Recordset',
-        externalFiles: [...recordsetExtFiles]
       },
       {
         appName: 'record',
         appTitle: 'Record',
         externalFiles: [
-          ...recordsetExtFiles,
           `${chaisePath}google-dataset-config.js`,
           `${chaisePath}config/google-dataset-config.js`
         ]
@@ -39,13 +33,11 @@ module.exports = (env) => {
       {
         appName: 'recordedit',
         appTitle: 'Recordedit',
-        externalFiles: [...recordsetExtFiles]
       },
       {
         appName: 'viewer',
         appTitle: 'Image Viewer',
         externalFiles: [
-          ...recordsetExtFiles,
           `${chaisePath}viewer/viewer-config.js`,
           `${chaisePath}config/viewer-config.js`
         ]
@@ -53,37 +45,21 @@ module.exports = (env) => {
       {
         appName: 'help',
         appTitle: 'Wiki Pages',
-        // app-wrapper uses navbar
-        externalFiles: [...recordsetExtFiles],
       },
       {
         appName: 'navbar',
         bundleName: 'navbar-lib',
         appTitle: 'Navbar standalone library',
         isLib: true,
-        /**
-         * navbar -> snapshot-dropdown -> input-switch -> recordset (fk) -> plotly
-         */
-        externalFiles: [...recordsetExtFiles],
       },
       {
         appName: 'login',
         bundleName: 'login-lib',
         appTitle: 'Login standalone library',
         isLib: true,
-        // app-wrapper uses navbar
-        externalFiles: [...recordsetExtFiles]
       }
     ],
     mode,
     env,
-    {
-      extraWebpackProps: {
-        externals: {
-          // treat plotly as an external dependency and don't compute it
-          'plotly.js-basic-dist-min': 'Plotly'
-        }
-      }
-    }
   );
 }


### PR DESCRIPTION
When we added ploly.js to this repo, it made all bundles very large and slowed down the build step. So I made sure webpack is treating it as an external file and I manually copied it over during the build.

This RP will remove all those manual improvements and instead uses `React.lazy` to dynamically import facet range picker plot. This means that pages that are not using this feature, will not even include plotly.

Summary of changes:
- remove the fixed splitChunks name that merged every vendor dependency into chunks shared by all apps regardless of 
use. The catch-all vendor group now produces one readable chunk per package, so each app only loads the vendor code it imports (I aded these names to make managing bundle easier, but it had the side effect of including vendor files on all apps)
- exclude `node_modules` from babel-loader (faster builds, removes the "deoptimised styling" warnings)
- drop the plotly externals workaround (webpack externals, script-tag injection, Makefile rsync). plotly is now a normally bundled chunk
- lazy-load the facet range picker histogram: plotly (~1MB) is isolated in facet-range-plot.tsx behind React.lazy and only fetched when a histogram actually shows
- document the lazy-loading pattern in dev-guide