### PR TITLE
fix(deps): bump ermrestjs to ^2.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/preset-typescript": "^7.26.0",
         "@fortawesome/fontawesome-free": "6.5.2",
         "@hello-pangea/dnd": "^18.0.1",
-        "@isrd-isi-edu/ermrestjs": "^2.11.1",
+        "@isrd-isi-edu/ermrestjs": "^2.12.0",
         "@types/bootstrap": "^5.2.10",
         "@types/papaparse": "^5.3.16",
         "@types/q": "^1.5.5",
@@ -2351,9 +2351,9 @@
       }
     },
     "node_modules/@isrd-isi-edu/ermrestjs": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrestjs/-/ermrestjs-2.11.1.tgz",
-      "integrity": "sha512-FD+Z9dBN945AxR3CBE9XebhIwL+YfcODjBeGiW0td5VWY8LjzsY8t0aoHP2F5fhAalXmHqz/DHSxYEc/29pJIg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@isrd-isi-edu/ermrestjs/-/ermrestjs-2.12.0.tgz",
+      "integrity": "sha512-eUBG9D937oOPOlns3Kk0FHMYIWnMfKmMaiScetTPnCaJHnYJzjviMTOTLUtqlPPQu6bpLWt9Bzx24pQUhVPodg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/lodash-es": "^4.17.12",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@fortawesome/fontawesome-free": "6.5.2",
     "@hello-pangea/dnd": "^18.0.1",
-    "@isrd-isi-edu/ermrestjs": "^2.11.1",
+    "@isrd-isi-edu/ermrestjs": "^2.12.0",
     "@types/bootstrap": "^5.2.10",
     "@types/papaparse": "^5.3.16",
     "@types/q": "^1.5.5",


### PR DESCRIPTION
This PR bumps ermrestjs to the just-released 2.12.0 ahead of the next chaise release.