### PR TITLE
fix(build): don't exclude @isrd-isi-edu packages from babel-loader

### DIFF
--- a/webpack/app.config.js
+++ b/webpack/app.config.js
@@ -169,7 +169,11 @@ const getWebPackConfig = (appConfigs, mode, env, options) => {
       rules: [
         {
           test: /\.(ts|js)x?$/,
-          exclude: /node_modules/,
+          /*
+           * skip transpiling prebuilt dependencies, except @isrd-isi-edu packages: downstream
+           * repos (deriva-webapps) compile chaise/ermrestjs source from node_modules
+           */
+          exclude: /node_modules[\\/](?!@isrd-isi-edu[\\/])/,
           use: ['babel-loader'],
         },
         {


### PR DESCRIPTION
The blanket node_modules exclude added in 2.7.1 broke downstream repos like deriva-webapps that compile chaise source from node_modules.