### PR TITLE
fix: apply small UI fixes to model app

### DIFF
--- a/src/assets/scss/_model.scss
+++ b/src/assets/scss/_model.scss
@@ -27,6 +27,10 @@ $model-js-colors: 'white', 'placeholder', 'primary', 'model-node-border', 'model
 
     padding-left: 0 !important;
     padding-right: 0 !important;
+
+    .footer-container {
+      margin-left: 0 !important;
+    }
   }
 
   .main-body {
@@ -150,9 +154,8 @@ $model-js-colors: 'white', 'placeholder', 'primary', 'model-node-border', 'model
     display: flex;
     flex-direction: column;
     gap: 10px;
-    // 140px = the bottom-left zoom controls plus panel margins, so the
-    // toolbar always stops above them
-    max-height: calc(100% - 130px);
+    // preserve enough space for the zoom controls
+    max-height: calc(100% - 85px);
     overflow-y: auto;
     @include scrollbar.chaise-scrollbar-style;
 
@@ -278,6 +281,17 @@ $model-js-colors: 'white', 'placeholder', 'primary', 'model-node-border', 'model
   // default to margin 15px; give it the same right inset as the minimap
   .react-flow__attribution {
     margin-right: 15px;
+
+    // tone the link down to grey (chaise's global link blue is too pronounced
+    // here); it stays a link, with underline on hover
+    a {
+      color: map.get(variables.$color-map, 'placeholder');
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
   }
 
   // keep the diagram readable under the minimap; it wakes up on hover

--- a/src/components/model/floating-edge.tsx
+++ b/src/components/model/floating-edge.tsx
@@ -38,12 +38,27 @@ const ModelFloatingEdge = ({ id, source, target, markerEnd, data }: EdgeProps<Mo
 
   const path = computeEdgePath(nodeRect(sourceNode), nodeRect(targetNode), data);
 
+  /*
+   * the edge id is the fk constraint id (`schema:constraint`); a <title> child
+   * of the edge's <g> wrapper shows it as a native tooltip on hover, same as
+   * the table-node headers do for their `schema:table`.
+   */
   if (displayMode === ModelDisplayMode.ERD) {
     const markers = erdMarkerUrls(data);
-    return <BaseEdge id={id} path={path} markerStart={markers.markerStart} markerEnd={markers.markerEnd} />;
+    return (
+      <>
+        <title>{id}</title>
+        <BaseEdge id={id} path={path} markerStart={markers.markerStart} markerEnd={markers.markerEnd} />
+      </>
+    );
   }
 
-  return <BaseEdge id={id} path={path} markerEnd={markerEnd} />;
+  return (
+    <>
+      <title>{id}</title>
+      <BaseEdge id={id} path={path} markerEnd={markerEnd} />
+    </>
+  );
 };
 
 export default ModelFloatingEdge;

--- a/src/components/model/model.tsx
+++ b/src/components/model/model.tsx
@@ -83,8 +83,8 @@ const nodeTypes = { modelTable: ModelTableNode };
 const edgeTypes = { modelFloating: ModelFloatingEdge };
 
 const DISPLAY_MODE_LABELS: Record<ModelDisplayMode, string> = {
-  [ModelDisplayMode.ERD]: 'ERD',
   [ModelDisplayMode.SIMPLIFIED]: 'Simplified',
+  [ModelDisplayMode.ERD]: 'ERD-like',
 };
 
 const DETAIL_LEVEL_LABELS: Record<ModelDetailLevel, string> = {
@@ -494,7 +494,7 @@ const ModelInner = (): JSX.Element => {
                     minZoom={0.05}
                   >
                     <Background />
-                    <Controls showInteractive={false} />
+                    <Controls showInteractive={false} orientation='horizontal' />
                     <Panel position='top-center' className='model-title'>
                       <h3>Catalog {catalogId} Data Model</h3>
                     </Panel>

--- a/test/e2e/locators/model-app.ts
+++ b/test/e2e/locators/model-app.ts
@@ -127,7 +127,7 @@ export default class ModelAppLocators {
   }
 
   static getDisplayModeDropdown(page: Page): Locator {
-    return ModelAppLocators.getToolbarRow(page, 'Display Mode').locator('.dropdown-toggle');
+    return ModelAppLocators.getToolbarRow(page, 'Mode').locator('.dropdown-toggle');
   }
 
   static getDetailDropdown(page: Page): Locator {

--- a/test/e2e/specs/model-app/model-app.spec.ts
+++ b/test/e2e/specs/model-app/model-app.spec.ts
@@ -53,6 +53,8 @@ test.describe('Model app', () => {
       // playwright reports rendered svg <g> edges as hidden, so assert attachment
       for (const id of [MAIN_FK1, MAIN_FK2, INBOUND_FK, SELF_FK]) {
         await expect.soft(ModelAppLocators.getEdge(page, id)).toBeAttached();
+        // the hover tooltip carries the fk constraint id
+        await expect.soft(ModelAppLocators.getEdge(page, id).locator('title')).toHaveText(id);
       }
     });
 
@@ -232,7 +234,7 @@ test.describe('Model app', () => {
 
     await test.step('erd display mode swaps edge markers', async () => {
       await ModelAppLocators.getDisplayModeDropdown(page).click();
-      await ModelAppLocators.getDropdownOption(page, 'ERD').click();
+      await ModelAppLocators.getDropdownOption(page, 'ERD-like').click();
       // mode change re-runs the layout (see the settings-change effect)
       await ModelAppLocators.waitForLayoutSettled(page);
 


### PR DESCRIPTION
In this PR includes small fixes for the model app:

- Show foreign key constraints as tooltips on the edges.
- Fix the footer padding issues.
- Change some labels and broken test cases because of that.
- Use a horizontal mode for "Controls" so settings toolbar can be longer.